### PR TITLE
Datasource context

### DIFF
--- a/src/types/connection/mod.rs
+++ b/src/types/connection/mod.rs
@@ -130,7 +130,7 @@ struct Pagination {
 ///     type Element = i32;
 ///     type EdgeFieldsObj = DiffFields;
 ///
-///     async fn query_operation(&self, operation: &QueryOperation) -> FieldResult<Connection<Self::Element, Self::EdgeFieldsObj>> {
+///     async fn query_operation(&self, ctx: &Context<'_>, operation: &QueryOperation) -> FieldResult<Connection<Self::Element, Self::EdgeFieldsObj>> {
 ///         let (start, end) = match operation {
 ///             QueryOperation::First {limit} => {
 ///                 let start = 0;
@@ -216,7 +216,7 @@ pub trait DataSource: Sync + Send {
     /// Execute the query.
     async fn query(
         &self,
-        _ctx: &Context<'_>,
+        ctx: &Context<'_>,
         after: Option<Cursor>,
         before: Option<Cursor>,
         first: Option<i32>,
@@ -335,12 +335,13 @@ pub trait DataSource: Sync + Send {
             },
         };
 
-        self.query_operation(&operation).await
+        self.query_operation(ctx, &operation).await
     }
 
     /// Parses the parameters and executes the query，Usually you just need to implement this method.
     async fn query_operation(
         &self,
+        ctx: &Context<'_>,
         operation: &QueryOperation,
     ) -> FieldResult<Connection<Self::Element, Self::EdgeFieldsObj>>;
 }

--- a/src/types/connection/slice.rs
+++ b/src/types/connection/slice.rs
@@ -1,5 +1,5 @@
 use crate::types::connection::{EmptyEdgeFields, QueryOperation};
-use crate::{Connection, DataSource, FieldResult};
+use crate::{Connection, Context, DataSource, FieldResult};
 use byteorder::{ReadBytesExt, BE};
 
 #[async_trait::async_trait]
@@ -9,6 +9,7 @@ impl<'a, T: Sync> DataSource for &'a [T] {
 
     async fn query_operation(
         &self,
+        _ctx: &Context<'_>,
         operation: &QueryOperation,
     ) -> FieldResult<Connection<Self::Element, Self::EdgeFieldsObj>> {
         let (start, end) = match operation {


### PR DESCRIPTION
I'd like to implement datasource for my structs, but my database connection pool is attached to the context. If we pass the context to `query_operation`, I should be able to implement this.

I also updated the book for Datasource based on my newer changes.