### PR TITLE
Prefer TryFrom to TryInto for ID

### DIFF
--- a/src/scalars/id.rs
+++ b/src/scalars/id.rs
@@ -1,7 +1,7 @@
 use crate::{InputValueError, InputValueResult, Result, ScalarType, Value};
 use async_graphql_derive::Scalar;
 use bson::oid::{self, ObjectId};
-use std::convert::TryInto;
+use std::convert::TryFrom;
 use std::num::ParseIntError;
 use std::ops::{Deref, DerefMut};
 use uuid::Uuid;
@@ -41,27 +41,27 @@ impl Into<String> for ID {
     }
 }
 
-impl TryInto<usize> for ID {
+impl TryFrom<ID> for usize {
     type Error = ParseIntError;
 
-    fn try_into(self) -> std::result::Result<usize, Self::Error> {
-        self.0.parse()
+    fn try_from(id: ID) -> std::result::Result<Self, Self::Error> {
+        id.0.parse()
     }
 }
 
-impl TryInto<Uuid> for ID {
+impl TryFrom<ID> for Uuid {
     type Error = uuid::Error;
 
-    fn try_into(self) -> std::result::Result<Uuid, Self::Error> {
-        Uuid::parse_str(&self.0)
+    fn try_from(id: ID) -> std::result::Result<Self, Self::Error> {
+        Uuid::parse_str(&id.0)
     }
 }
 
-impl TryInto<ObjectId> for ID {
+impl TryFrom<ID> for ObjectId {
     type Error = oid::Error;
 
-    fn try_into(self) -> std::result::Result<ObjectId, oid::Error> {
-        ObjectId::with_string(&self.0)
+    fn try_from(id: ID) -> std::result::Result<Self, oid::Error> {
+        ObjectId::with_string(&id.0)
     }
 }
 

--- a/src/types/connection/cursor.rs
+++ b/src/types/connection/cursor.rs
@@ -1,4 +1,4 @@
-use crate::{InputValueError, InputValueResult, Result, ScalarType, Value};
+use crate::{InputValueError, InputValueResult, Result, ScalarType, Value, ID};
 use async_graphql_derive::Scalar;
 use std::ops::{Deref, DerefMut};
 
@@ -29,6 +29,12 @@ where
 {
     fn from(value: T) -> Self {
         Cursor(value.to_string())
+    }
+}
+
+impl From<ID> for Cursor {
+    fn from(id: ID) -> Self {
+        Cursor(id.into())
     }
 }
 


### PR DESCRIPTION
#71 was merged a bit fast :D
Generally speaking `TryFrom` is more general than `TryInto` (cause `TryFrom` implies `TryInto`), so this should gives a bit more flexibility, like using the try_from as a closure
```rust
vec![ /* ... */ ]
    .iter()
    .map(ID::try_trom)
    .collect::<Result<usize, _>>()
```