### PR TITLE
Change interfaces & unions to require enums

### DIFF
--- a/docs/en/src/define_interface.md
+++ b/docs/en/src/define_interface.md
@@ -1,8 +1,8 @@
 # Interface
 
-`Interface` is used to abstract `Object`s with common fields. 
-`Async-graphql` implemented it as a wrapper. 
-The wrapper will forward Resolve to the `Object` that implemented this `Interface`. 
+`Interface` is used to abstract `Object`s with common fields.
+`Async-graphql` implemented it as a wrapper.
+The wrapper will forward Resolve to the `Object` that implemented this `Interface`.
 Therefore, the `Object`'s fields' type, arguments must match with the `Interface`'s.
 
 `Async-graphql` implemented auto conversion from `Object` to `Interface`, you only need to call `Into::into`.
@@ -44,5 +44,8 @@ impl Square {
     field(name = "area", type = "f32"),
     field(name = "scale", type = "Shape", arg(name = "s", type = "f32"))
 )]
-struct Shape(Circle, Square);
+enum Shape {
+    Circle(Circle),
+    Square(Square),
+}
 ```

--- a/docs/en/src/define_union.md
+++ b/docs/en/src/define_union.md
@@ -1,7 +1,7 @@
 # Union
 
 The definition of `Union` is similar to `Interface`'s, **but no field allowed.**.
-The implemention is quite similar for `Async-graphql`. 
+The implemention is quite similar for `Async-graphql`.
 From `Async-graphql`'s perspective, `Union` is a subset of `Interface`.
 
 The following example modified the definition of `Interface` a little bit and removed fields.
@@ -40,5 +40,8 @@ impl Square {
 }
 
 #[Union]
-struct Shape(Circle, Square);
+enum Shape {
+    Circle(Circle),
+    Square(Square),
+}
 ```

--- a/docs/zh-CN/src/define_interface.md
+++ b/docs/zh-CN/src/define_interface.md
@@ -41,5 +41,8 @@ impl Square {
     field(name = "area", type = "f32"),
     field(name = "scale", type = "Shape", arg(name = "s", type = "f32"))
 )]
-struct Shape(Circle, Square);
+enum Shape {
+    Circle(Circle),
+    Square(Square),
+}
 ```

--- a/docs/zh-CN/src/define_union.md
+++ b/docs/zh-CN/src/define_union.md
@@ -38,5 +38,8 @@ impl Square {
 }
 
 #[Union]
-struct Shape(Circle, Square);
+enum Shape {
+    Circle(Circle),
+    Square(Square),
+}
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,7 +447,12 @@ pub use async_graphql_derive::InputObject;
 ///
 /// ```ignore
 /// #[Interface]
-/// struct MyInterface(TypeA, TypeB, TypeC, ...);
+/// enum MyInterface {
+///     TypeA(TypeA),
+///     TypeB(TypeB),
+///     TypeC(TypeC),
+///     ...
+/// }
 /// ```
 ///
 /// # Fields
@@ -487,7 +492,9 @@ pub use async_graphql_derive::InputObject;
 ///         arg(name = "a", type = "i32"),
 ///         arg(name = "b", type = "i32")),
 /// )]
-/// struct MyInterface(TypeA);
+/// enum MyInterface {
+///     TypeA(TypeA)
+/// }
 ///
 /// struct QueryRoot;
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,7 +529,68 @@ pub use async_graphql_derive::Interface;
 
 /// Define a GraphQL union
 ///
-/// It's similar to Interface, but it doesn't have fields.
+///
+/// # Macro parameters
+///
+/// | Attribute   | description               | Type     | Optional |
+/// |-------------|---------------------------|----------|----------|
+/// | name        | Object name               | string   | Y        |
+/// | desc        | Object description        | string   | Y        |
+///
+/// # Define a union
+///
+/// Define TypeA, TypeB, ... as MyUnion
+///
+/// ```rust
+/// use async_graphql::*;
+///
+/// #[SimpleObject]
+/// struct TypeA {
+///     value_a: i32,
+/// }
+///
+/// #[SimpleObject]
+/// struct TypeB {
+///     value_b: i32
+/// }
+///
+/// #[Union]
+/// enum MyUnion {
+///     TypeA(TypeA),
+///     TypeB(TypeB),
+/// }
+///
+/// struct QueryRoot;
+///
+/// #[Object]
+/// impl QueryRoot {
+///     async fn all_data(&self) -> Vec<MyUnion> {
+///         vec![TypeA { value_a: 10 }.into(), TypeB { value_b: 20 }.into()]
+///     }
+/// }
+///
+/// #[async_std::main]
+/// async fn main() {
+///     let schema = Schema::build(QueryRoot, EmptyMutation, EmptySubscription).data("hello".to_string()).finish();
+///     let res = schema.execute(r#"
+///     {
+///         allData {
+///             ... on TypeA {
+///                 valueA
+///             }
+///             ... on TypeB {
+///                 valueB
+///             }
+///         }
+///     }"#).await.unwrap().data;
+///     assert_eq!(res, serde_json::json!({
+///         "allData": [
+///             { "valueA": 10 },
+///             { "valueB": 20 },
+///         ]
+///     }));
+/// }
+/// ```
 pub use async_graphql_derive::Union;
 
 /// Define a GraphQL subscription

--- a/src/validation/test_harness.rs
+++ b/src/validation/test_harness.rs
@@ -86,7 +86,10 @@ impl Cat {
 }
 
 #[Union(internal)]
-struct CatOrDog(Cat, Dog);
+enum CatOrDog {
+    Cat(Cat),
+    Dog(Dog),
+}
 
 struct Human;
 
@@ -127,10 +130,16 @@ impl Alien {
 }
 
 #[Union(internal)]
-struct DogOrHuman(Dog, Human);
+enum DogOrHuman {
+    Dog(Dog),
+    Human(Human),
+}
 
 #[Union(internal)]
-struct HumanOrAlien(Human, Alien);
+enum HumanOrAlien {
+    Human(Human),
+    Alien(Alien),
+}
 
 #[Interface(
     internal,

--- a/src/validation/test_harness.rs
+++ b/src/validation/test_harness.rs
@@ -140,7 +140,12 @@ struct HumanOrAlien(Human, Alien);
         arg(name = "surname", type = "Option<bool>")
     )
 )]
-struct Being(Dog, Cat, Human, Alien);
+enum Being {
+    Dog(Dog),
+    Cat(Cat),
+    Human(Human),
+    Alien(Alien),
+}
 
 #[Interface(
     internal,
@@ -150,7 +155,10 @@ struct Being(Dog, Cat, Human, Alien);
         arg(name = "surname", type = "Option<bool>")
     )
 )]
-struct Pet(Dog, Cat);
+enum Pet {
+    Dog(Dog),
+    Cat(Cat),
+}
 
 #[Interface(
     internal,
@@ -160,10 +168,15 @@ struct Pet(Dog, Cat);
         arg(name = "surname", type = "Option<bool>")
     )
 )]
-struct Canine(Dog);
+enum Canine {
+    Dog(Dog),
+}
 
 #[Interface(internal, field(name = "iq", type = "Option<i32>"))]
-struct Intelligent(Human, Alien);
+enum Intelligent {
+    Human(Human),
+    Alien(Alien),
+}
 
 #[InputObject(internal)]
 struct ComplexInput {

--- a/tests/interface.rs
+++ b/tests/interface.rs
@@ -9,7 +9,9 @@ pub async fn test_interface_simple_object() {
     }
 
     #[async_graphql::Interface(field(name = "id", type = "i32"))]
-    struct Node(MyObj);
+    enum Node {
+        MyObj(MyObj),
+    }
 
     struct Query;
 
@@ -52,7 +54,9 @@ pub async fn test_interface_simple_object2() {
     }
 
     #[async_graphql::Interface(field(name = "id", type = "&i32"))]
-    struct Node(MyObj);
+    enum Node {
+        MyObj(MyObj),
+    }
 
     struct Query;
 
@@ -105,10 +109,14 @@ pub async fn test_multiple_interfaces() {
     }
 
     #[async_graphql::Interface(field(name = "value_a", type = "i32"))]
-    struct InterfaceA(MyObj);
+    enum InterfaceA {
+        MyObj(MyObj),
+    }
 
     #[async_graphql::Interface(field(name = "value_b", type = "i32"))]
-    struct InterfaceB(MyObj);
+    enum InterfaceB {
+        MyObj(MyObj),
+    }
 
     struct Query;
 
@@ -176,10 +184,15 @@ pub async fn test_multiple_objects_in_multiple_interfaces() {
     }
 
     #[async_graphql::Interface(field(name = "value_a", type = "i32"))]
-    struct InterfaceA(MyObjOne, MyObjTwo);
+    enum InterfaceA {
+        MyObjOne(MyObjOne),
+        MyObjTwo(MyObjTwo),
+    }
 
     #[async_graphql::Interface(field(name = "value_b", type = "i32"))]
-    struct InterfaceB(MyObjOne);
+    enum InterfaceB {
+        MyObjOne(MyObjOne),
+    }
 
     struct Query;
 
@@ -232,7 +245,9 @@ pub async fn test_interface_field_result() {
     }
 
     #[async_graphql::Interface(field(name = "value", type = "FieldResult<i32>"))]
-    struct Node(MyObj);
+    enum Node {
+        MyObj(MyObj),
+    }
 
     struct Query;
 

--- a/tests/subscription.rs
+++ b/tests/subscription.rs
@@ -325,7 +325,9 @@ pub async fn test_subscription_fragment() {
     }
 
     #[Interface(field(name = "a", type = "i32"))]
-    struct MyInterface(Event);
+    enum MyInterface {
+        Event(Event),
+    }
 
     #[Object]
     impl QueryRoot {}
@@ -380,7 +382,9 @@ pub async fn test_subscription_fragment2() {
     }
 
     #[Interface(field(name = "a", type = "i32"))]
-    struct MyInterface(Event);
+    enum MyInterface {
+        Event(Event),
+    }
 
     #[Object]
     impl QueryRoot {}

--- a/tests/union.rs
+++ b/tests/union.rs
@@ -1,0 +1,287 @@
+use async_graphql::*;
+
+#[async_std::test]
+pub async fn test_union_simple_object() {
+    #[async_graphql::SimpleObject]
+    struct MyObj {
+        id: i32,
+        title: String,
+    }
+
+    #[async_graphql::Union]
+    enum Node {
+        MyObj(MyObj),
+    }
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn node(&self) -> Node {
+            MyObj {
+                id: 33,
+                title: "haha".to_string(),
+            }
+            .into()
+        }
+    }
+
+    let query = r#"{
+            node {
+                ... on MyObj {
+                    id
+                }
+            }
+        }"#;
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+    assert_eq!(
+        schema.execute(&query).await.unwrap().data,
+        serde_json::json!({
+            "node": {
+                "id": 33,
+            }
+        })
+    );
+}
+
+#[async_std::test]
+pub async fn test_union_simple_object2() {
+    #[async_graphql::SimpleObject]
+    struct MyObj {
+        #[field(ref)]
+        id: i32,
+        title: String,
+    }
+
+    #[async_graphql::Union]
+    enum Node {
+        MyObj(MyObj),
+    }
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn node(&self) -> Node {
+            MyObj {
+                id: 33,
+                title: "haha".to_string(),
+            }
+            .into()
+        }
+    }
+
+    let query = r#"{
+            node {
+                ... on MyObj {
+                    id
+                }
+            }
+        }"#;
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+    assert_eq!(
+        schema.execute(&query).await.unwrap().data,
+        serde_json::json!({
+            "node": {
+                "id": 33,
+            }
+        })
+    );
+}
+
+#[async_std::test]
+pub async fn test_multiple_unions() {
+    struct MyObj;
+
+    #[async_graphql::Object]
+    impl MyObj {
+        async fn value_a(&self) -> i32 {
+            1
+        }
+
+        async fn value_b(&self) -> i32 {
+            2
+        }
+
+        async fn value_c(&self) -> i32 {
+            3
+        }
+    }
+
+    #[async_graphql::Union]
+    enum UnionA {
+        MyObj(MyObj),
+    }
+
+    #[async_graphql::Union]
+    enum UnionB {
+        MyObj(MyObj),
+    }
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn union_a(&self) -> UnionA {
+            MyObj.into()
+        }
+        async fn union_b(&self) -> UnionB {
+            MyObj.into()
+        }
+    }
+
+    let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
+        .register_type::<UnionA>() // `UnionA` is not directly referenced, so manual registration is required.
+        .finish();
+    let query = r#"{
+            unionA {
+               ... on MyObj {
+                valueA
+                valueB
+                valueC
+              }
+            }
+            unionB {
+                ... on MyObj {
+                 valueA
+                 valueB
+                 valueC
+               }
+             }
+        }"#;
+    assert_eq!(
+        schema.execute(&query).await.unwrap().data,
+        serde_json::json!({
+            "unionA": {
+                "valueA": 1,
+                "valueB": 2,
+                "valueC": 3,
+            },
+            "unionB": {
+                "valueA": 1,
+                "valueB": 2,
+                "valueC": 3,
+            }
+        })
+    );
+}
+
+#[async_std::test]
+pub async fn test_multiple_objects_in_multiple_unions() {
+    struct MyObjOne;
+
+    #[async_graphql::Object]
+    impl MyObjOne {
+        async fn value_a(&self) -> i32 {
+            1
+        }
+
+        async fn value_b(&self) -> i32 {
+            2
+        }
+
+        async fn value_c(&self) -> i32 {
+            3
+        }
+    }
+
+    struct MyObjTwo;
+
+    #[async_graphql::Object]
+    impl MyObjTwo {
+        async fn value_a(&self) -> i32 {
+            1
+        }
+    }
+
+    #[async_graphql::Union]
+    enum UnionA {
+        MyObjOne(MyObjOne),
+        MyObjTwo(MyObjTwo),
+    }
+
+    #[async_graphql::Union]
+    enum UnionB {
+        MyObjOne(MyObjOne),
+    }
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn my_obj(&self) -> Vec<UnionA> {
+            vec![MyObjOne.into(), MyObjTwo.into()]
+        }
+    }
+
+    let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
+        .register_type::<UnionB>() // `UnionB` is not directly referenced, so manual registration is required.
+        .finish();
+    let query = r#"{
+            myObj {
+                ... on MyObjTwo {
+                    valueA
+                }
+                ... on MyObjOne {
+                    valueA
+                    valueB
+                    valueC
+                }
+            }
+         }"#;
+    assert_eq!(
+        schema.execute(&query).await.unwrap().data,
+        serde_json::json!({
+            "myObj": [{
+                "valueA": 1,
+                "valueB": 2,
+                "valueC": 3,
+            }, {
+                "valueA": 1
+            }]
+        })
+    );
+}
+
+#[async_std::test]
+pub async fn test_union_field_result() {
+    struct MyObj;
+
+    #[async_graphql::Object]
+    impl MyObj {
+        async fn value(&self) -> FieldResult<i32> {
+            Ok(10)
+        }
+    }
+
+    #[async_graphql::Union]
+    enum Node {
+        MyObj(MyObj),
+    }
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn node(&self) -> Node {
+            MyObj.into()
+        }
+    }
+
+    let query = r#"{
+            node {
+                ... on MyObj {
+                    value
+                }
+            }
+        }"#;
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+    assert_eq!(
+        schema.execute(&query).await.unwrap().data,
+        serde_json::json!({
+            "node": {
+                "value": 10,
+            }
+        })
+    );
+}


### PR DESCRIPTION
@sunli829 this is my first time working on a macro, so it might be bad.

I have found it weird that the `#[async_graphql::Interface]` macro replaces a `struct` definition with a `enum` definition. You can see me trying to extend an interface with diesel traits in https://github.com/phated/twentyfive-stars/blob/master/server/src/data/character_mode.rs - and you can see the "weird" behavior at https://github.com/phated/twentyfive-stars/blob/master/server/src/data/character_mode.rs#L116

By making this macro only usable on enums, we have a more natural usage pattern when extending it.