### PR TITLE
Allow for crate renaming in Cargo.toml

### DIFF
--- a/async-graphql-derive/Cargo.toml
+++ b/async-graphql-derive/Cargo.toml
@@ -21,3 +21,4 @@ proc-macro2 = "1.0.6"
 syn = { version = "1.0.13", features = ["full"] }
 quote = "1.0.3"
 Inflector = "0.11.4"
+proc-macro-crate = "0.1.4"

--- a/async-graphql-derive/src/utils.rs
+++ b/async-graphql-derive/src/utils.rs
@@ -1,5 +1,6 @@
 use async_graphql_parser::Value;
 use proc_macro2::{Span, TokenStream};
+use proc_macro_crate::crate_name;
 use quote::quote;
 use syn::{Attribute, Error, Expr, Ident, Lit, Meta, MetaList, NestedMeta, Result};
 
@@ -7,7 +8,8 @@ pub fn get_crate_name(internal: bool) -> TokenStream {
     if internal {
         quote! { crate }
     } else {
-        let id = Ident::new("async_graphql", Span::call_site());
+        let name = crate_name("async-graphql").expect("async-graphql is not present in `Cargo.toml`");
+        let id = Ident::new(&name, Span::call_site());
         quote! { #id }
     }
 }


### PR DESCRIPTION
Macros will now correctly expands when users rename the crate in cargo.toml