### PR TITLE
add feature attribute to field attribute inside Object

### DIFF
--- a/async-graphql-derive/src/args.rs
+++ b/async-graphql-derive/src/args.rs
@@ -200,6 +200,7 @@ pub struct Field {
     pub is_ref: bool,
     pub guard: Option<TokenStream>,
     pub post_guard: Option<TokenStream>,
+    pub features: Vec<String>,
 }
 
 impl Field {
@@ -211,6 +212,7 @@ impl Field {
         let mut external = false;
         let mut provides = None;
         let mut requires = None;
+        let mut features = Vec::new();
         let mut is_ref = false;
         let mut guard = None;
         let mut post_guard = None;
@@ -277,6 +279,21 @@ impl Field {
                                             "Attribute 'requires' should be a string.",
                                         ));
                                     }
+                                } else if nv.path.is_ident("feature") {
+                                    if let syn::Lit::Str(lit) = &nv.lit {
+                                        features = lit
+                                            .value()
+                                            .to_string()
+                                            .split(',')
+                                            .into_iter()
+                                            .map(|s| s.trim().to_string())
+                                            .collect();
+                                    } else {
+                                        return Err(Error::new_spanned(
+                                            &nv.lit,
+                                            "Attribute 'feature' should be a string.",
+                                        ));
+                                    }
                                 }
                             }
                             NestedMeta::Meta(Meta::List(ls)) => {
@@ -307,6 +324,7 @@ impl Field {
             is_ref,
             guard,
             post_guard,
+            features,
         }))
     }
 }

--- a/async-graphql-derive/src/object.rs
+++ b/async-graphql-derive/src/object.rs
@@ -376,9 +376,7 @@ pub fn generate(object_args: &args::Object, item_impl: &mut ItemImpl) -> Result<
                     let new_block = quote!({
                         #[cfg(not(all(#(feature = #features),*)))]
                         {
-                            return Err(anyhow!(
-                            #error_message
-                            )).map_err(std::convert::Into::into);
+                            return Err(#crate_name::FieldError::from(#error_message)).map_err(std::convert::Into::into);
                         }
                         #[cfg(all(#(feature = #features),*))]
                         {

--- a/async-graphql-derive/src/object.rs
+++ b/async-graphql-derive/src/object.rs
@@ -200,6 +200,7 @@ pub fn generate(object_args: &args::Object, item_impl: &mut ItemImpl) -> Result<
                     .map(|s| quote! {Some(#s)})
                     .unwrap_or_else(|| quote! {None});
                 let external = field.external;
+                let features = field.features;
                 let requires = match &field.requires {
                     Some(requires) => quote! { Some(#requires) },
                     None => quote! { None },
@@ -364,6 +365,28 @@ pub fn generate(object_args: &args::Object, item_impl: &mut ItemImpl) -> Result<
                         quote! { -> #crate_name::FieldResult<#inner_ty> },
                     )
                     .expect("invalid result type");
+                }
+                if !features.is_empty() {
+                    let block = &method.block;
+                    let error_message = format!(
+                        "`{}` is only available if the features `{}` are enabled",
+                        field_name,
+                        features.join(",")
+                    );
+                    let new_block = quote!({
+                        #[cfg(not(all(#(feature = #features),*)))]
+                        {
+                            return Err(anyhow!(
+                            #error_message
+                            )).map_err(std::convert::Into::into);
+                        }
+                        #[cfg(all(#(feature = #features),*))]
+                        {
+                            #block
+                        }
+                    });
+
+                    method.block = syn::parse2::<Block>(new_block).expect("invalid block");
                 }
                 let resolve_obj = quote! {
                     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,6 +656,7 @@ pub use async_graphql_derive::Union;
 /// | desc        | Field description         | string   | Y        |
 /// | deprecation | Field deprecation reason  | string   | Y        |
 /// | guard         | Field of guard            | [`Guard`](guard/trait.Guard.html) | Y        |
+/// | feature       | It's like a `#[cfg(feature = "foo")]` attribute but instead of not compiling this field it will just return a proper `FieldError` to tell you this feature is not enabled | string ("feature1,feature2") | Y |
 ///
 /// # Field argument parameters
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,7 @@ pub use types::{EnumItem, EnumType};
 /// | provides      | Annotate the expected returned fieldset from a field on a base type that is guaranteed to be selectable by the gateway. | string | Y |
 /// | requires      | Annotate the required input fieldset from a base type for a resolver. It is used to develop a query plan where the required fields may not be needed by the client, but the service may need additional information from other services. | string | Y |
 /// | guard         | Field of guard            | [`Guard`](guard/trait.Guard.html) | Y        |
+/// | feature       | It's like a `#[cfg(feature = "foo")]` attribute but instead of not compiling this field it will just return a proper `FieldError` to tell you this feature is not enabled | string ("feature1,feature2") | Y |
 ///
 /// # Field argument parameters
 ///


### PR DESCRIPTION
Code example:
```rust
#[field(feature = "users")]
pub async fn all_users(
    &self,
    context: &Context<'_>,
    after: Option<String>,
    before: Option<String>,
    first: Option<i32>,
    last: Option<i32>,
) -> FieldResult<Connection<usize, UserPosition, EmptyFields, EmptyFields>> {
    Users::fetch()
}
```

Response if you don't have feature `users` enabled:
```
{
  "errors": [
    {
      "message": "`allUsers` is only available if the features `users` are enabled",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "allUsers"
      ]
    }
  ]
}
```