### PR TITLE
Remove check_reserved_name

### DIFF
--- a/async-graphql-derive/src/enum.rs
+++ b/async-graphql-derive/src/enum.rs
@@ -1,5 +1,5 @@
 use crate::args;
-use crate::utils::{check_reserved_name, get_crate_name, get_rustdoc};
+use crate::utils::{get_crate_name, get_rustdoc};
 use inflector::Inflector;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
@@ -62,7 +62,6 @@ pub fn generate(enum_args: &args::Enum, input: &DeriveInput) -> Result<TokenStre
     }
 
     let gql_typename = enum_args.name.clone().unwrap_or_else(|| ident.to_string());
-    check_reserved_name(&gql_typename, enum_args.internal)?;
 
     let desc = enum_args
         .desc

--- a/async-graphql-derive/src/input_object.rs
+++ b/async-graphql-derive/src/input_object.rs
@@ -1,5 +1,5 @@
 use crate::args;
-use crate::utils::{check_reserved_name, get_crate_name, get_rustdoc};
+use crate::utils::{get_crate_name, get_rustdoc};
 use inflector::Inflector;
 use proc_macro::TokenStream;
 use quote::quote;
@@ -41,7 +41,6 @@ pub fn generate(object_args: &args::InputObject, input: &DeriveInput) -> Result<
         .name
         .clone()
         .unwrap_or_else(|| ident.to_string());
-    check_reserved_name(&gql_typename, object_args.internal)?;
 
     let desc = object_args
         .desc

--- a/async-graphql-derive/src/interface.rs
+++ b/async-graphql-derive/src/interface.rs
@@ -1,7 +1,7 @@
 use crate::args;
 use crate::args::{InterfaceField, InterfaceFieldArgument};
 use crate::output_type::OutputType;
-use crate::utils::{check_reserved_name, get_crate_name, get_rustdoc};
+use crate::utils::{get_crate_name, get_rustdoc};
 use inflector::Inflector;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
@@ -30,7 +30,6 @@ pub fn generate(interface_args: &args::Interface, input: &DeriveInput) -> Result
         .name
         .clone()
         .unwrap_or_else(|| ident.to_string());
-    check_reserved_name(&gql_typename, interface_args.internal)?;
 
     let desc = interface_args
         .desc

--- a/async-graphql-derive/src/object.rs
+++ b/async-graphql-derive/src/object.rs
@@ -1,8 +1,6 @@
 use crate::args;
 use crate::output_type::OutputType;
-use crate::utils::{
-    check_reserved_name, feature_block, get_crate_name, get_param_getter_ident, get_rustdoc,
-};
+use crate::utils::{feature_block, get_crate_name, get_param_getter_ident, get_rustdoc};
 use inflector::Inflector;
 use proc_macro::TokenStream;
 use quote::quote;
@@ -29,7 +27,6 @@ pub fn generate(object_args: &args::Object, item_impl: &mut ItemImpl) -> Result<
         .name
         .clone()
         .unwrap_or_else(|| self_name.clone());
-    check_reserved_name(&gql_typename, object_args.internal)?;
 
     let desc = object_args
         .desc

--- a/async-graphql-derive/src/scalar.rs
+++ b/async-graphql-derive/src/scalar.rs
@@ -1,5 +1,5 @@
 use crate::args;
-use crate::utils::{check_reserved_name, get_crate_name, get_rustdoc};
+use crate::utils::{get_crate_name, get_rustdoc};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Error, ItemImpl, Result, Type};
@@ -18,7 +18,6 @@ pub fn generate(scalar_args: &args::Scalar, item_impl: &mut ItemImpl) -> Result<
         .name
         .clone()
         .unwrap_or_else(|| self_name.clone());
-    check_reserved_name(&gql_typename, scalar_args.internal)?;
     let desc = scalar_args
         .desc
         .clone()

--- a/async-graphql-derive/src/simple_object.rs
+++ b/async-graphql-derive/src/simple_object.rs
@@ -1,5 +1,5 @@
 use crate::args;
-use crate::utils::{check_reserved_name, feature_block, get_crate_name, get_rustdoc};
+use crate::utils::{feature_block, get_crate_name, get_rustdoc};
 use inflector::Inflector;
 use proc_macro::TokenStream;
 use quote::quote;
@@ -15,7 +15,6 @@ pub fn generate(object_args: &args::Object, input: &mut DeriveInput) -> Result<T
         .name
         .clone()
         .unwrap_or_else(|| ident.to_string());
-    check_reserved_name(&gql_typename, object_args.internal)?;
 
     let desc = object_args
         .desc

--- a/async-graphql-derive/src/subscription.rs
+++ b/async-graphql-derive/src/subscription.rs
@@ -1,8 +1,6 @@
 use crate::args;
 use crate::output_type::OutputType;
-use crate::utils::{
-    check_reserved_name, feature_block, get_crate_name, get_param_getter_ident, get_rustdoc,
-};
+use crate::utils::{feature_block, get_crate_name, get_param_getter_ident, get_rustdoc};
 use inflector::Inflector;
 use proc_macro::TokenStream;
 use quote::quote;
@@ -31,7 +29,6 @@ pub fn generate(object_args: &args::Object, item_impl: &mut ItemImpl) -> Result<
         .name
         .clone()
         .unwrap_or_else(|| self_name.clone());
-    check_reserved_name(&gql_typename, object_args.internal)?;
 
     let desc = object_args
         .desc

--- a/async-graphql-derive/src/union.rs
+++ b/async-graphql-derive/src/union.rs
@@ -1,5 +1,5 @@
 use crate::args;
-use crate::utils::{check_reserved_name, get_crate_name, get_rustdoc};
+use crate::utils::{get_crate_name, get_rustdoc};
 use proc_macro::TokenStream;
 use quote::quote;
 use std::collections::HashSet;
@@ -22,7 +22,6 @@ pub fn generate(union_args: &args::Interface, input: &DeriveInput) -> Result<Tok
     let mut enum_items = HashSet::new();
     let mut type_into_impls = Vec::new();
     let gql_typename = union_args.name.clone().unwrap_or_else(|| ident.to_string());
-    check_reserved_name(&gql_typename, union_args.internal)?;
 
     let desc = union_args
         .desc

--- a/async-graphql-derive/src/utils.rs
+++ b/async-graphql-derive/src/utils.rs
@@ -11,24 +11,6 @@ pub fn get_crate_name(internal: bool) -> TokenStream {
         quote! { #id }
     }
 }
-pub fn check_reserved_name(name: &str, internal: bool) -> Result<()> {
-    if internal {
-        return Ok(());
-    }
-    if name.ends_with("Connection") {
-        Err(Error::new(
-            Span::call_site(),
-            "The name ending with 'Connection' is reserved",
-        ))
-    } else if name == "PageInfo" {
-        Err(Error::new(
-            Span::call_site(),
-            "The name 'PageInfo' is reserved",
-        ))
-    } else {
-        Ok(())
-    }
-}
 fn parse_nested_validator(
     crate_name: &TokenStream,
     nested_meta: &NestedMeta,


### PR DESCRIPTION
This allows types to end in `Connection` or be named `PageInfo`.

Addresses #126