### PR TITLE
Update name of scalar DateTime to DateTimeUtc

### DIFF
--- a/src/scalars/datetime.rs
+++ b/src/scalars/datetime.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, TimeZone, Utc};
 /// Implement the DateTime<Utc> scalar
 ///
 /// The input/output is a string in RFC3339 format.
-#[Scalar(internal, name = "DateTime")]
+#[Scalar(internal, name = "DateTimeUtc")]
 impl ScalarType for DateTime<Utc> {
     fn parse(value: Value) -> InputValueResult<Self> {
         match value {

--- a/src/scalars/mod.rs
+++ b/src/scalars/mod.rs
@@ -55,10 +55,10 @@ mod tests {
         assert_eq!(<NaiveTime as Type>::type_name(), "NaiveTime");
         assert_eq!(<NaiveTime as Type>::qualified_type_name(), "NaiveTime!");
 
-        assert_eq!(<DateTime::<Utc> as Type>::type_name(), "DateTime");
+        assert_eq!(<DateTime::<Utc> as Type>::type_name(), "DateTimeUtc");
         assert_eq!(
             <DateTime::<Utc> as Type>::qualified_type_name(),
-            "DateTime!"
+            "DateTimeUtc!"
         );
 
         assert_eq!(<Uuid as Type>::type_name(), "UUID");


### PR DESCRIPTION
I'm currently migrating from Juniper and I use a tool to check if there isn't any breaking change in my schema. Do you mind if we use the same name as Juniper here https://github.com/graphql-rust/juniper/blob/2cb96d0fc4386b1ec5de8912cb0df0f271fa7cf8/juniper/src/integrations/chrono.rs#L53 for this scalar ? 