### PR TITLE
Add allow(unused_braces, unused_parens) attribute

### DIFF
--- a/async-graphql-derive/src/object.rs
+++ b/async-graphql-derive/src/object.rs
@@ -465,6 +465,7 @@ pub fn generate(object_args: &args::Object, item_impl: &mut ItemImpl) -> Result<
             }
         }
 
+        #[allow(unused_braces, unused_parens)]
         #[#crate_name::async_trait::async_trait]
         impl#generics #crate_name::ObjectType for #self_ty #where_clause {
             async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::Result<#crate_name::serde_json::Value> {


### PR DESCRIPTION
This fixes false positive warnings for the stable compiler.

This can probably be removed once https://github.com/rust-lang/rust/pull/70789 lands on stable?