### PR TITLE
Increase Tide to v0.11.0

### DIFF
--- a/async-graphql-tide/Cargo.toml
+++ b/async-graphql-tide/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["futures", "async", "graphql"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-graphql = { path = "..", version = "1.14.0" }
-tide = "0.10.0"
+async-graphql = { path = "..", version = "1.15.0" }
+tide = "0.11.0"
 async-trait = "0.1.30"
 serde_json = "1.0.51"
 futures = "0.3.4"
-async-std = "1.5.0"
+async-std = "1.6.0"
 
 [dev-dependencies]
 smol = { version = "0.1.10", features = ["tokio02"] }


### PR DESCRIPTION
Tide released v0.11.0 a few days ago. It doesn't seem like any changes affect our integration.