### PR TITLE
Update date time parsing to support more formats

### DIFF
--- a/src/scalars/datetime.rs
+++ b/src/scalars/datetime.rs
@@ -1,6 +1,6 @@
 use crate::{InputValueError, InputValueResult, ScalarType, Value};
 use async_graphql_derive::Scalar;
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 
 /// Implement the DateTime<Utc> scalar
 ///
@@ -8,8 +8,10 @@ use chrono::{DateTime, TimeZone, Utc};
 #[Scalar(internal, name = "DateTimeUtc")]
 impl ScalarType for DateTime<Utc> {
     fn parse(value: Value) -> InputValueResult<Self> {
-        match value {
-            Value::String(s) => Ok(Utc.datetime_from_str(&s, "%+")?),
+        match &value {
+            Value::String(s) => s
+                .parse::<DateTime<Utc>>()
+                .map_err(|_| InputValueError::ExpectedType(value)),
             _ => Err(InputValueError::ExpectedType(value)),
         }
     }


### PR DESCRIPTION
This includes the JS standard format that is not compatible with the `%+` time format.

`%+` is fairly strict in its parsing, however `DateTime<Utc>` is capable of parsing more standard formats by default. 

This allows for JSON standard formats such as:
`2020-06-23T10:00:00-09:00`