### PR TITLE
Fix issue with unwrapping derive attributes

### DIFF
--- a/async-graphql-derive/src/utils.rs
+++ b/async-graphql-derive/src/utils.rs
@@ -41,14 +41,17 @@ pub fn add_container_attrs(
 pub fn parse_derive(input: TokenStream) -> Result<(proc_macro::TokenStream, DeriveInput)> {
     let mut input: DeriveInput = syn::parse2(input)?;
     let attrs = &mut input.attrs;
-    let pos = attrs
+    let graphql_attr = attrs
         .iter()
-        .find_position(|attr| attr.path.is_ident("graphql"))
-        .unwrap()
-        .0;
-    let attribute = attrs.remove(pos);
-    let args = attribute.parse_args::<TokenStream>()?;
-    Ok((args.into(), input))
+        .find_position(|attr| attr.path.is_ident("graphql"));
+
+    if let Some((pos, _attr)) = graphql_attr {
+        let attribute = attrs.remove(pos);
+        let args = attribute.parse_args::<TokenStream>()?;
+        Ok((args.into(), input))
+    } else {
+        Ok((TokenStream::new().into(), input))
+    }
 }
 
 fn parse_nested_validator(

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -8,9 +8,17 @@ pub async fn test_derive() {
         A,
     }
 
+    // Infers the name based on Rust name
     #[derive(GQLEnum, Eq, Copy, PartialEq, Clone)]
-    #[graphql(name = "MyEnumDerive1")]
     enum MyEnumDerive {
+        #[cfg_attr(feature = "bson", item(name = "A1"))]
+        A,
+    }
+
+    // Can be renamed with graphql(name = ..) attribute
+    #[derive(GQLEnum, Eq, Copy, PartialEq, Clone)]
+    #[graphql(name = "MyEnumDerive")]
+    enum MyEnumDeriveRenamed {
         #[cfg_attr(feature = "bson", item(name = "A1"))]
         A,
     }
@@ -21,9 +29,17 @@ pub async fn test_derive() {
         value: i32,
     }
 
+    // Infers the name based on Rust name
     #[derive(GQLInputObject)]
-    #[graphql(name = "MyInputObjDerive1")]
     struct MyInputObjDerive {
+        #[cfg_attr(feature = "bson", field(default))]
+        value: i32,
+    }
+
+    // Can be renamed with graphql(name = ..) attribute
+    #[derive(GQLInputObject)]
+    #[graphql(name = "MyInputObjDerive")]
+    struct MyInputObjDeriveRenamed {
         #[cfg_attr(feature = "bson", field(default))]
         value: i32,
     }
@@ -34,9 +50,17 @@ pub async fn test_derive() {
         value: i32,
     }
 
+    // Infers the name based on Rust name
     #[derive(GQLInputObject)]
-    #[graphql(name = "MySimpleObjDerive1")]
     struct MySimpleObjDerive {
+        #[cfg_attr(feature = "bson", field(name = "value1"))]
+        value: i32,
+    }
+
+    // Can be renamed with graphql(name = ..) attribute
+    #[derive(GQLInputObject)]
+    #[graphql(name = "MySimpleObjDerive")]
+    struct MySimpleObjDeriveRenamed {
         #[cfg_attr(feature = "bson", field(name = "value1"))]
         value: i32,
     }


### PR DESCRIPTION
When I upgraded to the new Derive macros, I noticed that the `#[graphql]` attribute was required. Since I want to use the same names as my structs, it was weird that I needed to specify these.

Seems like it was just an unwrap bug (`unwrap` sure is unsafe 😉), so I got that fixed up and things seem to be working correctly.

I wish I could improve the tests to make sure the generated code was correct, but I think this is good for now.