### PR TITLE
Use FieldResult for data(), add data_unchecked() for panic

### DIFF
--- a/docs/en/src/context.md
+++ b/docs/en/src/context.md
@@ -11,11 +11,11 @@ struct Query;
 
 #[Object]
 impl Query {
-    async fn borrow_from_context_data<'ctx'>(
+    async fn borrow_from_context_data<'ctx>(
         &self,
         ctx: &'ctx Context<'_>
-    ) -> &'ctx String {
-        ctx.data::<String>
+    ) -> FieldResult<&'ctx String> {
+        ctx.data::<String>()
     }
 }
 ```

--- a/docs/en/src/define_complex_object.md
+++ b/docs/en/src/define_complex_object.md
@@ -28,7 +28,7 @@ impl MyObject {
         ctx: &Context<'_>,
         #[arg(desc = "Id of object")] id: i64
     ) -> FieldResult<String> {
-        let conn = ctx.data::<DbPool>().take();
+        let conn = ctx.data::<DbPool>()?.take();
         Ok(conn.query_something(id)?.name)
     }
 }

--- a/docs/zh-CN/src/context.md
+++ b/docs/zh-CN/src/context.md
@@ -11,11 +11,11 @@ struct Query;
 
 #[Object]
 impl Query {
-    async fn borrow_from_context_data<'ctx'>(
+    async fn borrow_from_context_data<'ctx>(
         &self,
         ctx: &'ctx Context<'_>
-    ) -> &'ctx String {
-        ctx.data::<String>
+    ) -> FieldResult<&'ctx String> {
+        ctx.data::<String>()
     }
 }
 ```

--- a/docs/zh-CN/src/define_complex_object.md
+++ b/docs/zh-CN/src/define_complex_object.md
@@ -26,7 +26,7 @@ impl MyObject {
         ctx: &Context<'_>,
         #[arg(desc = "Id of object")] id: i64
     ) -> FieldResult<String> {
-        let conn = ctx.data::<DbPool>().take();
+        let conn = ctx.data::<DbPool>()?.take();
         Ok(conn.query_something(id)?.name)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,8 +549,8 @@ pub use async_graphql_derive::InputObject;
 /// #[Object]
 /// impl TypeA {
 ///     /// Returns data borrowed from the context
-///     async fn value_a<'a>(&self, ctx: &'a Context<'_>) -> &'a str {
-///         ctx.data::<String>().as_str()
+///     async fn value_a<'a>(&self, ctx: &'a Context<'_>) -> FieldResult<&'a str> {
+///         Ok(ctx.data::<String>()?.as_str())
 ///     }
 ///
 ///     /// Returns data borrowed self

--- a/tests/mutation.rs
+++ b/tests/mutation.rs
@@ -16,13 +16,13 @@ pub async fn test_mutation_execution_order() {
     impl MutationRoot {
         async fn append1(&self, ctx: &Context<'_>) -> bool {
             async_std::task::sleep(Duration::from_secs(1)).await;
-            ctx.data::<List>().lock().await.push(1);
+            ctx.data_unchecked::<List>().lock().await.push(1);
             true
         }
 
         async fn append2(&self, ctx: &Context<'_>) -> bool {
             async_std::task::sleep(Duration::from_millis(500)).await;
-            ctx.data::<List>().lock().await.push(2);
+            ctx.data_unchecked::<List>().lock().await.push(2);
             true
         }
     }

--- a/tests/subscription.rs
+++ b/tests/subscription.rs
@@ -157,7 +157,7 @@ pub async fn test_subscription_with_ctx_data() {
     #[Object]
     impl MyObject {
         async fn value(&self, ctx: &Context<'_>) -> i32 {
-            *ctx.data::<i32>()
+            *ctx.data_unchecked::<i32>()
         }
     }
 
@@ -166,7 +166,7 @@ pub async fn test_subscription_with_ctx_data() {
     #[Subscription]
     impl SubscriptionRoot {
         async fn values(&self, ctx: &Context<'_>) -> impl Stream<Item = i32> {
-            let value = *ctx.data::<i32>();
+            let value = *ctx.data_unchecked::<i32>();
             futures::stream::once(async move { value })
         }
 
@@ -217,7 +217,7 @@ pub async fn test_subscription_with_token() {
     #[Subscription]
     impl SubscriptionRoot {
         async fn values(&self, ctx: &Context<'_>) -> FieldResult<impl Stream<Item = i32>> {
-            if ctx.data::<Token>().0 != "123456" {
+            if ctx.data_unchecked::<Token>().0 != "123456" {
                 return Err("forbidden".into());
             }
             Ok(futures::stream::once(async move { 100 }))

--- a/tests/subscription_websocket.rs
+++ b/tests/subscription_websocket.rs
@@ -78,7 +78,7 @@ pub async fn test_subscription_ws_transport_with_token() {
     #[Subscription]
     impl SubscriptionRoot {
         async fn values(&self, ctx: &Context<'_>) -> FieldResult<impl Stream<Item = i32>> {
-            if ctx.data::<Token>().0 != "123456" {
+            if ctx.data_unchecked::<Token>().0 != "123456" {
                 return Err("forbidden".into());
             }
             Ok(futures::stream::iter(0..10))


### PR DESCRIPTION
This implements the `FieldResult` suggestion @sunli829 made in #185 and moves the panic version to `data_unchecked` which seems to be a common pattern in libraries that panic if something dynamic is missing.