### PR TITLE
Update async_graphql_tide to support tide-0.12.0

### DIFF
--- a/async-graphql-tide/Cargo.toml
+++ b/async-graphql-tide/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 async-graphql = { path = "..", version = "1.16.1" }
-tide = "0.11.0"
-async-trait = "0.1.30"
-serde_json = "1.0.51"
-futures = "0.3.4"
-async-std = "1.6.0"
+tide = "0.12.0"
+async-trait = "0.1.36"
+serde_json = "1.0.56"
+futures = "0.3.5"
+async-std = "1.6.2"
 
 [dev-dependencies]
-smol = { version = "0.1.10", features = ["tokio02"] }
-reqwest = "0.10.4"
+smol = { version = "0.1.18", features = ["tokio02"] }
+reqwest = "0.10.6"

--- a/async-graphql-tide/src/lib.rs
+++ b/async-graphql-tide/src/lib.rs
@@ -62,7 +62,7 @@ where
     Query: ObjectType + Send + Sync + 'static,
     Mutation: ObjectType + Send + Sync + 'static,
     Subscription: SubscriptionType + Send + Sync + 'static,
-    TideState: Send + Sync + 'static,
+    TideState: Clone + Send + Sync + 'static,
     F: Fn(QueryBuilder) -> QueryBuilder + Send,
 {
     graphql_opts(req, schema, query_builder_configuration, Default::default()).await
@@ -79,7 +79,7 @@ where
     Query: ObjectType + Send + Sync + 'static,
     Mutation: ObjectType + Send + Sync + 'static,
     Subscription: SubscriptionType + Send + Sync + 'static,
-    TideState: Send + Sync + 'static,
+    TideState: Clone + Send + Sync + 'static,
     F: Fn(QueryBuilder) -> QueryBuilder + Send,
 {
     let query_builder = req.body_graphql_opts(opts).await?;
@@ -93,7 +93,7 @@ where
 /// Tide request extension
 ///
 #[async_trait]
-pub trait RequestExt<State: Send + Sync + 'static>: Sized {
+pub trait RequestExt<State: Clone + Send + Sync + 'static>: Sized {
     /// Convert a query to `async_graphql::QueryBuilder`.
     async fn body_graphql(self) -> tide::Result<QueryBuilder> {
         self.body_graphql_opts(Default::default()).await
@@ -104,7 +104,7 @@ pub trait RequestExt<State: Send + Sync + 'static>: Sized {
 }
 
 #[async_trait]
-impl<State: Send + Sync + 'static> RequestExt<State> for Request<State> {
+impl<State: Clone + Send + Sync + 'static> RequestExt<State> for Request<State> {
     async fn body_graphql_opts(self, opts: IntoQueryBuilderOpts) -> tide::Result<QueryBuilder> {
         if self.method() == Method::Get {
             let gql_request: GQLRequest = self.query::<GQLRequest>()?;

--- a/async-graphql-tide/tests/graphql.rs
+++ b/async-graphql-tide/tests/graphql.rs
@@ -35,7 +35,7 @@ fn quickstart() -> Result<()> {
 
             let mut app = tide::new();
             app.at("/").post(graphql).get(graphql);
-            app.listen(&listen_addr).await?;
+            app.listen(listen_addr).await?;
 
             Ok(())
         });
@@ -109,6 +109,7 @@ fn hello() -> Result<()> {
                 }
             }
 
+            #[derive(Clone)]
             struct AppState {
                 schema: Schema<QueryRoot, EmptyMutation, EmptySubscription>,
             }
@@ -131,7 +132,7 @@ fn hello() -> Result<()> {
                 })
                 .await
             });
-            app.listen(&listen_addr).await?;
+            app.listen(listen_addr).await?;
 
             Ok(())
         });
@@ -229,7 +230,7 @@ fn upload() -> Result<()> {
                 let schema = Schema::build(QueryRoot, MutationRoot, EmptySubscription).finish();
                 async_graphql_tide::graphql(req, schema, |query_builder| query_builder).await
             });
-            app.listen(&listen_addr).await?;
+            app.listen(listen_addr).await?;
 
             Ok(())
         });


### PR DESCRIPTION
Since tide released 0.12.0 two days ago with several changes. This PR is to update async_graphql_tide to support tide-0.12.0.

Ref:
https://github.com/http-rs/tide/releases/tag/v0.12.0
