### PR TITLE
3% speedup in chat run by allocating vector up front

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -10,7 +10,7 @@ pub async fn do_resolve<'a, T: ObjectType + Send + Sync>(
     ctx: &'a ContextSelectionSet<'a>,
     root: &'a T,
 ) -> Result<serde_json::Value> {
-    let mut futures = Vec::new();
+    let mut futures = Vec::with_capacity(ctx.item.items.len());
     collect_fields(ctx, root, &mut futures)?;
     let res = futures::future::try_join_all(futures).await?;
     let mut map = serde_json::Map::new();


### PR DESCRIPTION
According to flamegraph, growing the vector (for the chat run) takes a large chunk of time: 
![image](https://user-images.githubusercontent.com/14802865/89709166-c6f05500-d97d-11ea-8e24-7c4f224825f5.png)

This will take an optimistic approach and assume no fields will be skipped (which will be true in the majority of cases), and initialize the array with a capacity of the amount of items, lessening the amount of resizes that need to be done.

On my pc this resulted in a 3% win for the "chat run" benchmark, but also a 2% slowdown on "simple parse" benchmark, but since "chat run" is in the order of milliseconds, and more representative of a real workload, I think this tradeoff is wel worth
