### PR TITLE
Tracing Extension: Default Implementation + More Filtering + Better Readability

### DIFF
--- a/src/extensions/tracing.rs
+++ b/src/extensions/tracing.rs
@@ -8,6 +8,7 @@ use tracing::{span, Id, Level};
 /// # References
 ///
 /// https://crates.io/crates/tracing
+#[derive(Default)]
 pub struct Tracing {
     root_id: Option<Id>,
     fields: BTreeMap<usize, Id>,

--- a/src/extensions/tracing.rs
+++ b/src/extensions/tracing.rs
@@ -18,7 +18,7 @@ pub struct Tracing {
 impl Extension for Tracing {
     fn parse_start(&mut self, query_source: &str, variables: &Variables) {
         let root_span: tracing::Span = span!(
-            target: "async_graphql",
+            target: "async_graphql::graphql",
             parent:None,
             Level::INFO,
             "graphql",

--- a/src/extensions/tracing.rs
+++ b/src/extensions/tracing.rs
@@ -1,7 +1,8 @@
 use crate::extensions::{Extension, ResolveInfo};
-use crate::{QueryPathSegment, Variables};
+use crate::{Variables};
 use std::collections::BTreeMap;
-use tracing::{span, Id, Level};
+use tracing::{span, event, Id, Level};
+use uuid::Uuid;
 
 /// Tracing extension
 ///
@@ -15,12 +16,26 @@ pub struct Tracing {
 }
 
 impl Extension for Tracing {
-    fn parse_start(&mut self, query_source: &str, _variables: &Variables) {
-        let root_span = span!(target: "async-graphql", parent:None, Level::INFO, "query", source = query_source);
+    fn parse_start(&mut self, query_source: &str, variables: &Variables) {
+        let root_span: tracing::Span = span!(
+            target: "async_graphql",
+            parent:None,
+            Level::INFO,
+            "graphql",
+            id = %Uuid::new_v4().to_string(),
+        );
+
         if let Some(id) = root_span.id() {
             tracing::dispatcher::get_default(|d| d.enter(&id));
             self.root_id.replace(id);
         }
+
+        event!(
+            target: "async_graphql::query",
+            Level::DEBUG,
+            %variables,
+            query = %query_source
+        );
     }
 
     fn execution_end(&mut self) {
@@ -34,27 +49,15 @@ impl Extension for Tracing {
             .resolve_id
             .parent
             .and_then(|id| self.fields.get(&id))
+            .or_else(|| self.root_id.as_ref())
             .cloned();
-        let span = match &info.path_node.segment {
-            QueryPathSegment::Index(idx) => span!(
-                target: "async-graphql",
-                parent: parent_span,
-                Level::INFO,
-                "field",
-                index = *idx,
-                parent_type = info.parent_type,
-                return_type = info.return_type
-            ),
-            QueryPathSegment::Name(name) => span!(
-                target: "async-graphql",
-                parent: parent_span,
-                Level::INFO,
-                "field",
-                name = name,
-                parent_type = info.parent_type,
-                return_type = info.return_type
-            ),
-        };
+        let span = span!(
+            target: "async_graphql::field",
+            parent: parent_span,
+            Level::INFO,
+            "field",
+            path = %info.path_node,
+        );
         if let Some(id) = span.id() {
             tracing::dispatcher::get_default(|d| d.enter(&id));
             self.fields.insert(info.resolve_id.current, id);


### PR DESCRIPTION
## Changes
- Added `#[derive(Default)]` (Fixes #249)
- Field spans now associate with their parent graphql root span
- Added a uuid to the graphql span - closer to how the Logger extension works
- Moved query to a seperate event so that the entire query is no longer inlined with each log entry
- Field spans log the path similarly to Logger extension
- Namespaces spans and events to allow filtering eg. `async_graphql::graphql=INFO,async_graphql::query=WARN,async_graphql::field=WARN`

## Example Output
![Screenshot from 2020-08-30 20-55-13](https://user-images.githubusercontent.com/145184/91674346-55cc3980-eb06-11ea-8126-027ae5e0d89d.png)
Note: This example has `async_graphql::field=WARN` set to remove the `field` spans.