### PR TITLE
Remove dependency on serde_derive, satisfy Clippy, improve docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ anyhow = "1.0.26"
 thiserror = "1.0.11"
 async-trait = "0.1.30"
 serde = "1.0.104"
-serde_derive = "1.0.104"
 serde_json = "1.0.48"
 bytes = "0.5.4"
 Inflector = "0.11.4"
@@ -55,7 +54,6 @@ chrono-tz = { version = "0.5.1", optional = true }
 [dev-dependencies]
 async-std = { version = "1.5.0", features = ["attributes"] }
 serde = "1.0.104"
-serde_derive = "1.0.104"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ chrono-tz = { version = "0.5.1", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.5.0", features = ["attributes"] }
-serde = "1.0.104"
 
 [workspace]
 members = [

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,7 +8,7 @@ use async_graphql_parser::query::Document;
 use async_graphql_parser::UploadValue;
 use fnv::FnvHashMap;
 use serde::ser::SerializeSeq;
-use serde::Serializer;
+use serde::{Serialize, Serializer};
 use std::any::{Any, TypeId};
 use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};

--- a/src/error.rs
+++ b/src/error.rs
@@ -174,7 +174,10 @@ pub enum QueryError {
 
     /// Parsing of an input value failed.
     #[error("Failed to parse input value: {reason}")]
-    ParseInputValue { reason: String },
+    ParseInputValue {
+        /// The reason for the failure to resolve.
+        reason: String,
+    },
 
     /// A field was not found on an object type.
     #[error("Cannot query field \"{field_name}\" on type \"{object}\".")]
@@ -287,9 +290,11 @@ pub enum QueryError {
         extended_error: Option<serde_json::Value>,
     },
 
+    /// Entity not found.
     #[error("Entity not found")]
     EntityNotFound,
 
+    /// "__typename" must be an existing string.
     #[error("\"__typename\" must be an existing string")]
     TypeNameNotExists,
 }
@@ -324,12 +329,15 @@ pub enum ParseRequestError {
     #[error("Invalid multipart data")]
     InvalidMultipart(multer::Error),
 
+    /// Missing "operators" part for multipart request.
     #[error("Missing \"operators\" part")]
     MissingOperatorsPart,
 
+    /// Missing "map" part for multipart request.
     #[error("Missing \"map\" part")]
     MissingMapPart,
 
+    /// It's not an upload operation
     #[error("It's not an upload operation")]
     NotUpload,
 
@@ -342,10 +350,13 @@ pub enum ParseRequestError {
     PayloadTooLarge,
 }
 
-#[allow(missing_docs)]
+/// Verification error.
 #[derive(Debug, PartialEq)]
 pub struct RuleError {
+    /// Location of this error in query string.
     pub locations: Vec<Pos>,
+
+    /// A description of this error.
     pub message: String,
 }
 
@@ -361,11 +372,18 @@ pub enum Error {
     Query {
         /// The position at which the processing failed.
         pos: Pos,
+
+        /// Node path.
         path: Option<serde_json::Value>,
+
         /// The query error.
         err: QueryError,
     },
 
+    /// The query statement verification failed.
     #[error("Rule error")]
-    Rule { errors: Vec<RuleError> },
+    Rule {
+        /// List of errors.
+        errors: Vec<RuleError>,
+    },
 }

--- a/src/extensions/logger.rs
+++ b/src/extensions/logger.rs
@@ -2,6 +2,7 @@ use crate::extensions::{Extension, ResolveInfo};
 use crate::{Error, Variables};
 use async_graphql_parser::query::{Definition, Document, OperationDefinition, Selection};
 use itertools::Itertools;
+use log::{error, info, trace};
 use std::borrow::Cow;
 use uuid::Uuid;
 

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -5,14 +5,16 @@ use serde::export::PhantomData;
 
 /// Field guard
 ///
-/// Guard is a pre-condition for a field that is resolved if `Ok(()` is returned, otherwise an error is returned.
+/// Guard is a pre-condition for a field that is resolved if `Ok(())` is returned, otherwise an error is returned.
+///
+/// This trait is defined through the [`async-trait`](https://crates.io/crates/async-trait) macro.
 #[async_trait::async_trait]
 pub trait Guard {
-    #[allow(missing_docs)]
+    /// Check whether the guard will allow access to the field.
     async fn check(&self, ctx: &Context<'_>) -> FieldResult<()>;
 }
 
-/// An extension trait for `Guard`
+/// An extension trait for `Guard`.
 pub trait GuardExt: Guard + Sized {
     /// Merge the two guards.
     fn and<R: Guard>(self, other: R) -> And<Self, R> {
@@ -22,7 +24,7 @@ pub trait GuardExt: Guard + Sized {
 
 impl<T: Guard> GuardExt for T {}
 
-/// Guard for `GuardExt::and`
+/// Guard for [`GuardExt::and`](trait.GuardExt.html#method.and).
 pub struct And<A: Guard, B: Guard>(A, B);
 
 #[async_trait::async_trait]
@@ -35,10 +37,12 @@ impl<A: Guard + Send + Sync, B: Guard + Send + Sync> Guard for And<A, B> {
 
 /// Field post guard
 ///
-/// Guard is a post-condition for a field that is resolved if `Ok(()` is returned, otherwise an error is returned.
+/// This is a post-condition for a field that is resolved if `Ok(()` is returned, otherwise an error is returned.
+///
+/// This trait is defined through the [`async-trait`](https://crates.io/crates/async-trait) macro.
 #[async_trait::async_trait]
 pub trait PostGuard<T: Send + Sync> {
-    #[allow(missing_docs)]
+    /// Check whether to allow the result of the field through.
     async fn check(&self, ctx: &Context<'_>, result: &T) -> FieldResult<()>;
 }
 
@@ -52,7 +56,7 @@ pub trait PostGuardExt<T: Send + Sync>: PostGuard<T> + Sized {
 
 impl<T: PostGuard<R>, R: Send + Sync> PostGuardExt<R> for T {}
 
-/// PostGuard for `PostGuardExt<T>::and`
+/// PostGuard for [`PostGuardExt<T>::and`](trait.PostGuardExt.html#method.and).
 pub struct PostAnd<T: Send + Sync, A: PostGuard<T>, B: PostGuard<T>>(A, B, PhantomData<T>);
 
 #[async_trait::async_trait]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     Error, ParseRequestError, Pos, QueryBuilder, QueryError, QueryResponse, Result, Variables,
 };
 use serde::ser::{SerializeMap, SerializeSeq};
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 
 /// Deserializable GraphQL Request object
 #[derive(Deserialize, Clone, PartialEq, Debug)]
@@ -241,7 +241,7 @@ mod tests {
             },
         };
 
-        let resp = GQLResponse(Err(err.into()));
+        let resp = GQLResponse(Err(err));
 
         assert_eq!(
             serde_json::to_value(resp).unwrap(),

--- a/src/http/playground_source.rs
+++ b/src/http/playground_source.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use std::collections::HashMap;
 
 /// Generate the page for GraphQL Playground

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! * Custom scalars
 //! * Minimal overhead
 //! * Easy integration (hyper, actix_web, tide ...)
-//! * Upload files (Multipart request)
+//! * File upload (Multipart request)
 //! * Subscriptions (WebSocket transport)
 //! * Custom extensions
 //! * Apollo Tracing extension
@@ -89,7 +89,7 @@
 //! cargo bench
 //! ```
 //!
-//! Now HTML report is available at `benchmark/target/criterion/report`
+//! Now a HTML report is available at `benchmark/target/criterion/report`.
 //!
 
 #![warn(missing_docs)]
@@ -97,13 +97,6 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 #![recursion_limit = "256"]
 #![forbid(unsafe_code)]
-
-#[macro_use]
-extern crate thiserror;
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate log;
 
 mod base;
 mod context;
@@ -182,7 +175,11 @@ pub use subscription::SubscriptionType;
 #[doc(hidden)]
 pub use types::{EnumItem, EnumType};
 
-/// Define a GraphQL object
+/// Define a GraphQL object with methods
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/define_complex_object.html).*
+///
+/// All methods are converted to camelCase.
 ///
 /// # Macro parameters
 ///
@@ -218,16 +215,17 @@ pub use types::{EnumItem, EnumType};
 /// | default_with | Expression to generate default value     | code string | Y        |
 /// | validator    | Input value validator                    | [`InputValueValidator`](validators/trait.InputValueValidator.html) | Y        |
 ///
-/// # The field returns the value type
+/// # Valid field return types
 ///
-/// - A scalar value, such as `i32`, `bool`
-/// - Borrowing of scalar values, such as `&i32`, `&bool`
-/// - Vec<T>, such as `Vec<i32>`
-/// - Slice<T>, such as `&[i32]`
-/// - Option<T>, such as `Option<i32>`
-/// - Object and &Object
-/// - Enum
-/// - FieldResult<T, E>, such as `FieldResult<i32, E>`
+/// - Scalar values, such as `i32` and `bool`. `usize`, `isize`, `u128` and `i128` are not
+/// supported
+/// - `Vec<T>`, such as `Vec<i32>`
+/// - Slices, such as `&[i32]`
+/// - `Option<T>`, such as `Option<i32>`
+/// - GraphQL objects.
+/// - GraphQL enums.
+/// - References to any of the above types, such as `&i32` or `&Option<String>`.
+/// - `FieldResult<T, E>`, such as `FieldResult<i32, E>`
 ///
 /// # Context
 ///
@@ -272,7 +270,7 @@ pub use types::{EnumItem, EnumType};
 /// }
 ///
 /// async_std::task::block_on(async move {
-///     let schema = Schema::new(QueryRoot{ value: 10 }, EmptyMutation, EmptySubscription);
+///     let schema = Schema::new(QueryRoot { value: 10 }, EmptyMutation, EmptySubscription);
 ///     let res = schema.execute(r#"{
 ///         value
 ///         valueRef
@@ -291,9 +289,13 @@ pub use types::{EnumItem, EnumType};
 /// ```
 pub use async_graphql_derive::Object;
 
-/// Define a GraphQL object
+/// Define a GraphQL object with fields
 ///
-/// Similar to `Object`, but defined on a structure that automatically generates getters for all fields.
+/// You can also [derive this](derive.GQLSimpleObject.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/define_simple_object.html).*
+///
+/// Similar to `Object`, but defined on a structure that automatically generates getters for all fields. For a list of valid field types, see [`Object`](attr.Object.html). All fields are converted to camelCase.
 ///
 /// # Macro parameters
 ///
@@ -340,6 +342,12 @@ pub use async_graphql_derive::SimpleObject;
 
 /// Derive a GraphQL enum
 ///
+/// You can also [use an attribute](attr.Enum.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/define_enum.html).*
+///
+/// All variants are converted to SCREAMING_SNAKE_CASE.
+///
 /// # Examples
 ///
 /// ```rust
@@ -356,6 +364,10 @@ pub use async_graphql_derive::GQLEnum;
 
 /// Derive a GraphQL input object
 ///
+/// You can also [use an attribute](attr.InputObject.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/define_input_object.html).*
+///
 /// # Examples
 ///
 /// ```rust
@@ -368,7 +380,11 @@ pub use async_graphql_derive::GQLEnum;
 /// ```
 pub use async_graphql_derive::GQLInputObject;
 
-/// Derive a GraphQL simple object
+/// Derive a GraphQL object with fields
+///
+/// You can also [use an attribute](attr.SimpleObject.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/define_simple_object.html).*
 ///
 /// # Examples
 ///
@@ -383,6 +399,10 @@ pub use async_graphql_derive::GQLInputObject;
 pub use async_graphql_derive::GQLSimpleObject;
 
 /// Define a GraphQL enum
+///
+/// You can also [derive this](derive.GQLEnum.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/define_enum.html).*
 ///
 /// # Macro parameters
 ///
@@ -438,6 +458,10 @@ pub use async_graphql_derive::Enum;
 
 /// Define a GraphQL input object
 ///
+/// You can also [derive this](derive.GQLInputObject.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/define_input_object.html).*
+///
 /// # Macro parameters
 ///
 /// | Attribute   | description               | Type     | Optional |
@@ -491,6 +515,10 @@ pub use async_graphql_derive::Enum;
 pub use async_graphql_derive::InputObject;
 
 /// Define a GraphQL interface
+///
+/// You can also [derive this](derive.GQLInterface.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/define_interface.html).*
 ///
 /// # Macro parameters
 ///
@@ -616,10 +644,17 @@ pub use async_graphql_derive::InputObject;
 pub use async_graphql_derive::Interface;
 
 /// Derive a GraphQL interface
+///
+/// You can also [use an attribute](attr.Interface.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/define_interface.html).*
 pub use async_graphql_derive::GQLInterface;
 
 /// Define a GraphQL union
 ///
+/// You can also [derive this](derive.GQLUnion.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/define_union.html).*
 ///
 /// # Macro parameters
 ///
@@ -684,9 +719,15 @@ pub use async_graphql_derive::GQLInterface;
 pub use async_graphql_derive::Union;
 
 /// Derive a GraphQL union
+///
+/// You can also [use an attribute](attr.Union.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/define_union.html).*
 pub use async_graphql_derive::GQLUnion;
 
 /// Define a GraphQL subscription
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/subscription.html).*
 ///
 /// The field function is a synchronization function that performs filtering. When true is returned, the message is pushed to the client.
 /// The second parameter is the type of the field.
@@ -756,6 +797,10 @@ pub use async_graphql_derive::Scalar;
 
 /// Define a merged object with multiple object types.
 ///
+/// You can also [derive this](derive.GQLMergedObject.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/merging_objects.html).*
+///
 /// # Macro parameters
 ///
 /// | Attribute     | description               | Type     | Optional |
@@ -793,9 +838,17 @@ pub use async_graphql_derive::Scalar;
 pub use async_graphql_derive::MergedObject;
 
 /// Derive a GraphQL Merged object
+///
+/// You can also [use an attribute](attr.MergedObject.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/merging_objects.html).*
 pub use async_graphql_derive::GQLMergedObject;
 
 /// Define a merged subscription with multiple subscription types.
+///
+/// You can also [derive this](derive.GQLMergedSubscription.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/merging_objects.html).*
 ///
 /// # Macro parameters
 ///
@@ -835,5 +888,9 @@ pub use async_graphql_derive::GQLMergedObject;
 /// ```
 pub use async_graphql_derive::MergedSubscription;
 
-/// Derive a GraphQL Merged object
+/// Derive a GraphQL merged subscription with multiple subscription types.
+///
+/// You can also [use an attribute](attr.MergedSubscription.html).
+///
+/// *[See also the Book](https://async-graphql.github.io/async-graphql/en/merging_objects.html).*
 pub use async_graphql_derive::GQLMergedSubscription;

--- a/src/scalars/json.rs
+++ b/src/scalars/json.rs
@@ -6,7 +6,7 @@ use crate::{
 use async_graphql_derive::Scalar;
 use async_graphql_parser::query::Field;
 use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
@@ -100,6 +100,7 @@ impl<T: Serialize + Send + Sync> OutputValueType for OutputJson<T> {
 #[cfg(test)]
 mod test {
     use crate::*;
+    use serde::{Deserialize, Serialize};
     use std::collections::HashMap;
 
     #[async_std::test]

--- a/src/subscription/ws_transport.rs
+++ b/src/subscription/ws_transport.rs
@@ -5,6 +5,7 @@ use crate::{
     QueryResponse, Result, Schema, SubscriptionStreams, SubscriptionType, Variables,
 };
 use bytes::Bytes;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/src/validation/rules/default_values_of_correct_type.rs
+++ b/src/validation/rules/default_values_of_correct_type.rs
@@ -42,7 +42,7 @@ mod tests {
     use super::*;
     use crate::{expect_fails_rule, expect_passes_rule};
 
-    pub fn factory<'a>() -> DefaultValuesOfCorrectType {
+    pub fn factory() -> DefaultValuesOfCorrectType {
         DefaultValuesOfCorrectType
     }
 

--- a/src/validation/rules/fields_on_correct_type.rs
+++ b/src/validation/rules/fields_on_correct_type.rs
@@ -55,7 +55,7 @@ mod tests {
     use super::*;
     use crate::{expect_fails_rule, expect_passes_rule};
 
-    pub fn factory<'a>() -> FieldsOnCorrectType {
+    pub fn factory() -> FieldsOnCorrectType {
         FieldsOnCorrectType
     }
 

--- a/src/validation/rules/fragments_on_composite_types.rs
+++ b/src/validation/rules/fragments_on_composite_types.rs
@@ -49,7 +49,7 @@ mod tests {
     use super::*;
     use crate::{expect_fails_rule, expect_passes_rule};
 
-    pub fn factory<'a>() -> FragmentsOnCompositeTypes {
+    fn factory() -> FragmentsOnCompositeTypes {
         FragmentsOnCompositeTypes
     }
 

--- a/src/validation/test_harness.rs
+++ b/src/validation/test_harness.rs
@@ -381,7 +381,7 @@ where
     V: Visitor<'a> + 'a,
     F: Fn() -> V,
 {
-    if let Ok(_) = validate(doc, factory) {
+    if validate(doc, factory).is_ok() {
         panic!("Expected rule to fail, but no errors were found");
     }
 }

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -43,7 +43,7 @@ pub async fn test_connection_additional_fields() {
                         end < 10000,
                         ConnectionFields { total_count: 10000 },
                     );
-                    connection.append((start..end).into_iter().map(|n| {
+                    connection.append((start..end).map(|n| {
                         Edge::with_additional_fields(
                             n,
                             n as i32,

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -33,13 +33,12 @@ pub async fn test_enum_type() {
     }
 
     let schema = Schema::new(Root { value: MyEnum::A }, EmptyMutation, EmptySubscription);
-    let query = format!(
-        r#"{{
+    let query = r#"{{
             value
             testArg(input: A)
             testInput(input: {{value: B}}) }}
             "#
-    );
+    .to_owned();
     assert_eq!(
         schema.execute(&query).await.unwrap().data,
         serde_json::json!({
@@ -52,7 +51,7 @@ pub async fn test_enum_type() {
 
 #[async_std::test]
 pub async fn test_enum_derive_and_item_attributes() {
-    use serde_derive::Deserialize;
+    use serde::Deserialize;
 
     #[async_graphql::Enum]
     #[derive(Deserialize, Debug)]

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -33,11 +33,11 @@ pub async fn test_enum_type() {
     }
 
     let schema = Schema::new(Root { value: MyEnum::A }, EmptyMutation, EmptySubscription);
-    let query = r#"{{
+    let query = r#"{
             value
             testArg(input: A)
-            testInput(input: {{value: B}}) }}
-            "#
+            testInput(input: {value: B})
+        }"#
     .to_owned();
     assert_eq!(
         schema.execute(&query).await.unwrap().data,

--- a/tests/input_object.rs
+++ b/tests/input_object.rs
@@ -67,11 +67,11 @@ pub async fn test_input_object_default_value() {
     }
 
     let schema = Schema::new(Root, EmptyMutation, EmptySubscription);
-    let query = r#"{{
-            a(input:{{e:777}}) {{
+    let query = r#"{
+            a(input:{e:777}) {
                 a b c d e
-            }}
-        }}"#
+            }
+        }"#
     .to_owned();
     assert_eq!(
         schema.execute(&query).await.unwrap().data,

--- a/tests/input_object.rs
+++ b/tests/input_object.rs
@@ -67,13 +67,12 @@ pub async fn test_input_object_default_value() {
     }
 
     let schema = Schema::new(Root, EmptyMutation, EmptySubscription);
-    let query = format!(
-        r#"{{
+    let query = r#"{{
             a(input:{{e:777}}) {{
                 a b c d e
             }}
         }}"#
-    );
+    .to_owned();
     assert_eq!(
         schema.execute(&query).await.unwrap().data,
         serde_json::json!({
@@ -90,7 +89,7 @@ pub async fn test_input_object_default_value() {
 
 #[async_std::test]
 pub async fn test_inputobject_derive_and_item_attributes() {
-    use serde_derive::Deserialize;
+    use serde::Deserialize;
 
     #[async_graphql::InputObject]
     #[derive(Deserialize, PartialEq, Debug)]

--- a/tests/input_validators.rs
+++ b/tests/input_validators.rs
@@ -292,9 +292,9 @@ pub async fn test_input_validator_string_email() {
                 case
             );
             let field_error_msg =
-                format!("Invalid value for argument \"email\", invalid email format");
+                "Invalid value for argument \"email\", invalid email format".to_owned();
             let object_error_msg =
-                format!("Invalid value for argument \"input.email\", invalid email format");
+                "Invalid value for argument \"input.email\", invalid email format".to_owned();
 
             // Testing FieldValidator
             assert_eq!(
@@ -437,9 +437,9 @@ pub async fn test_input_validator_string_mac() {
             "MAC validation case {} should have failed, but did not",
             mac
         );
-        let field_error_msg = format!("Invalid value for argument \"mac\", invalid MAC format");
+        let field_error_msg = "Invalid value for argument \"mac\", invalid MAC format".to_owned();
         let object_error_msg =
-            format!("Invalid value for argument \"input.mac\", invalid MAC format");
+            "Invalid value for argument \"input.mac\", invalid MAC format".to_owned();
 
         assert_eq!(
             schema_without_colon
@@ -511,14 +511,14 @@ pub async fn test_input_validator_string_mac() {
     for mac in valid_macs {
         let field_query = format!("{{fieldParameter(mac: \"{}\")}}", mac);
         let object_query = format!("{{inputObject(input: {{mac: \"{}\"}})}}", mac);
-        let contains_colon = mac.contains(":");
+        let contains_colon = mac.contains(':');
         let should_fail_msg = format!(
             "MAC validation case {} should have failed, but did not",
             mac
         );
-        let field_error_msg = format!("Invalid value for argument \"mac\", invalid MAC format");
+        let field_error_msg = "Invalid value for argument \"mac\", invalid MAC format".to_owned();
         let object_error_msg =
-            format!("Invalid value for argument \"input.mac\", invalid MAC format");
+            "Invalid value for argument \"input.mac\", invalid MAC format".to_owned();
         let error_msg = format!("Schema returned error with test_string = {}", mac);
 
         if contains_colon {
@@ -1413,9 +1413,10 @@ pub async fn test_input_validator_operator_or() {
                 case
             );
 
-            let field_error_msg = format!("Invalid value for argument \"id\", invalid MAC format");
+            let field_error_msg =
+                "Invalid value for argument \"id\", invalid MAC format".to_owned();
             let object_error_msg =
-                format!("Invalid value for argument \"input.id\", invalid MAC format");
+                "Invalid value for argument \"input.id\", invalid MAC format".to_owned();
             assert_eq!(
                 schema
                     .execute(&field_query)
@@ -1518,13 +1519,13 @@ pub async fn test_input_validator_operator_and() {
             );
 
             let field_error_msg = if *should_be_invalid_email {
-                format!("Invalid value for argument \"email\", invalid email format")
+                "Invalid value for argument \"email\", invalid email format".to_owned()
             } else {
                 format!("Invalid value for argument \"email\", the value length is {}, must be greater than or equal to {}", case_length, min_length)
             };
 
             let object_error_msg = if *should_be_invalid_email {
-                format!("Invalid value for argument \"input.email\", invalid email format")
+                "Invalid value for argument \"input.email\", invalid email format".to_owned()
             } else {
                 format!("Invalid value for argument \"input.email\", the value length is {}, must be greater than or equal to {}", case_length, min_length)
             };

--- a/tests/introspection.rs
+++ b/tests/introspection.rs
@@ -52,7 +52,7 @@ enum TestEnum {
     #[item(desc = "Kind 1")]
     Kind1,
 
-    #[item(desc = "Kind 2", deprecation = "Kind 2 depracted")]
+    #[item(desc = "Kind 2", deprecation = "Kind 2 deprecated")]
     Kind2,
 }
 
@@ -269,10 +269,10 @@ impl Subscription {
 // }
 
 #[async_std::test]
-pub async fn test_introspection_depraction() {
+pub async fn test_introspection_deprecation() {
     let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
 
-    let get_object_query = |obj, is_depracted| {
+    let get_object_query = |obj, is_deprecated| {
         format!(
             r#"
         {{
@@ -285,11 +285,11 @@ pub async fn test_introspection_depraction() {
             }}
        }}
        "#,
-            obj, is_depracted
+            obj, is_deprecated
         )
     };
 
-    // SimpleObject with depracted inclusive
+    // SimpleObject with deprecated inclusive
     let mut query = get_object_query("SimpleObject", "true");
 
     let mut res_json = serde_json::json!({
@@ -353,7 +353,7 @@ pub async fn test_introspection_depraction() {
 
     assert_eq!(res, res_json);
 
-    // SimpleObject with depracted fields exclusive
+    // SimpleObject with deprecated fields exclusive
     query = get_object_query("SimpleObject", "false");
 
     res_json = serde_json::json!({
@@ -412,7 +412,7 @@ pub async fn test_introspection_depraction() {
 
     assert_eq!(res, res_json);
 
-    // Object with only one depracted field inclusive
+    // Object with only one deprecated field inclusive
     query = get_object_query("Square", "true");
 
     res_json = serde_json::json!({
@@ -431,7 +431,7 @@ pub async fn test_introspection_depraction() {
 
     assert_eq!(res, res_json);
 
-    // Object with only one depracted field exclusive
+    // Object with only one deprecated field exclusive
     query = get_object_query("Square", "false");
 
     res_json = serde_json::json!({
@@ -444,7 +444,7 @@ pub async fn test_introspection_depraction() {
 
     assert_eq!(res, res_json);
 
-    let get_enum_query = |obj, is_depracted| {
+    let get_enum_query = |obj, is_deprecated| {
         format!(
             r#"
         {{
@@ -457,11 +457,11 @@ pub async fn test_introspection_depraction() {
             }}
        }}
        "#,
-            obj, is_depracted
+            obj, is_deprecated
         )
     };
 
-    // Enum with depracted value inclusive
+    // Enum with deprecated value inclusive
     query = get_enum_query("TestEnum", "true");
 
     res_json = serde_json::json!({
@@ -475,7 +475,7 @@ pub async fn test_introspection_depraction() {
               {
                 "name": "KIND_2",
                 "isDeprecated": true,
-                "deprecationReason": "Kind 2 depracted"
+                "deprecationReason": "Kind 2 deprecated"
               }
             ]
         }
@@ -485,7 +485,7 @@ pub async fn test_introspection_depraction() {
 
     assert_eq!(res, res_json);
 
-    // Enum with depracted value exclusive
+    // Enum with deprecated value exclusive
     query = get_enum_query("TestEnum", "false");
 
     res_json = serde_json::json!({
@@ -841,7 +841,7 @@ pub async fn test_introspection_enum() {
                 "name": "KIND_2",
                 "description": "Kind 2",
                 "isDeprecated": true,
-                "deprecationReason": "Kind 2 depracted"
+                "deprecationReason": "Kind 2 deprecated"
               }
             ]
         }

--- a/tests/optional.rs
+++ b/tests/optional.rs
@@ -15,7 +15,7 @@ pub async fn test_optional_type() {
     #[Object]
     impl Root {
         async fn value1(&self) -> Option<i32> {
-            self.value1.clone()
+            self.value1
         }
 
         async fn value1_ref(&self) -> &Option<i32> {
@@ -23,7 +23,7 @@ pub async fn test_optional_type() {
         }
 
         async fn value2(&self) -> Option<i32> {
-            self.value2.clone()
+            self.value2
         }
 
         async fn value2_ref(&self) -> &Option<i32> {
@@ -35,7 +35,7 @@ pub async fn test_optional_type() {
         }
 
         async fn test_input<'a>(&self, input: MyInput) -> Option<i32> {
-            input.value.clone()
+            input.value
         }
     }
 
@@ -47,8 +47,7 @@ pub async fn test_optional_type() {
         EmptyMutation,
         EmptySubscription,
     );
-    let query = format!(
-        r#"{{
+    let query = r#"{{
             value1
             value1Ref
             value2
@@ -58,7 +57,7 @@ pub async fn test_optional_type() {
             testInput1: testInput(input: {{value: 10}})
             testInput2: testInput(input: {{}})
             }}"#
-    );
+    .to_owned();
     assert_eq!(
         schema.execute(&query).await.unwrap().data,
         serde_json::json!({

--- a/tests/optional.rs
+++ b/tests/optional.rs
@@ -47,16 +47,16 @@ pub async fn test_optional_type() {
         EmptyMutation,
         EmptySubscription,
     );
-    let query = r#"{{
+    let query = r#"{
             value1
             value1Ref
             value2
             value2Ref
             testArg1: testArg(input: 10)
             testArg2: testArg
-            testInput1: testInput(input: {{value: 10}})
-            testInput2: testInput(input: {{}})
-            }}"#
+            testInput1: testInput(input: {value: 10})
+            testInput2: testInput(input: {})
+            }"#
     .to_owned();
     assert_eq!(
         schema.execute(&query).await.unwrap().data,

--- a/tests/subscription_websocket.rs
+++ b/tests/subscription_websocket.rs
@@ -88,7 +88,7 @@ pub async fn test_subscription_ws_transport_with_token() {
     let schema = Schema::new(QueryRoot, EmptyMutation, SubscriptionRoot);
 
     let (mut sink, mut stream) = schema.subscription_connection(WebSocketTransport::new(|value| {
-        #[derive(serde_derive::Deserialize)]
+        #[derive(serde::Deserialize)]
         struct Payload {
             token: String,
         }


### PR DESCRIPTION
Since `serde` reexports `serde_derive`, I removed the dependency on it and did everything through Serde itself. I also removed usages of `extern crate` and `#[macro_use]` since they are obsoleted by the 2018 edition.

I tried to add docs where I could but I left out the places that I didn't understand well enough to properly document - it will show warnings for this.

I'll make some more docs improvements tomorrow, and eventually get round to solving #223.