### PR TITLE
Upgrade MSRV to 1.43

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 * [Docs](https://docs.rs/async-graphql)
 * [GitHub repository](https://github.com/async-graphql/async-graphql)
 * [Cargo package](https://crates.io/crates/async-graphql)
-* Minimum supported Rust version: 1.42 or later
+* Minimum supported Rust version: 1.43 or later
 
 ## Safety
 


### PR DESCRIPTION
Hi there!

The README says MSRV is 1.42 but I couldn't compile it in 1.42 because of [this code](https://github.com/async-graphql/async-graphql/blob/dcfdcb0cc550bd98b911a6f0358d7f78be07d885/src/scalars/integers.rs#L13).

That feature was added at 1.43.0.
https://doc.rust-lang.org/std/primitive.i32.html#associatedconstant.MAX