### PR TITLE
Add Rocket integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
     "async-graphql-actix-web",
     "async-graphql-warp",
     "async-graphql-tide",
-    #    "async-graphql-lambda",
+    "async-graphql-rocket",
+#    "async-graphql-lambda",
     "benchmark",
 ]

--- a/async-graphql-rocket/Cargo.toml
+++ b/async-graphql-rocket/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "async-graphql-rocket"
+version = "1.17.18"
+authors = ["Daniel Wiesenberg <daniel@simplificAR.io>"]
+edition = "2018"
+description = "async-graphql for Rocket.rs"
+publish = true
+license = "MIT/Apache-2.0"
+documentation = "https://docs.rs/async-graphql/"
+homepage = "https://github.com/async-graphql/async-graphql"
+repository = "https://github.com/async-graphql/async-graphql"
+keywords = ["futures", "async", "graphql", "rocket"]
+categories = ["network-programming", "asynchronous"]
+
+[dependencies]
+async-graphql = { path = "..", version = "1.17.18" }
+rocket = { git = "https://github.com/SergioBenitez/Rocket/", default-features = false }
+log = "0.4.11"
+yansi = "0.5.0"
+tokio-util = { version = "0.3.1", default-features = false, features = ["compat"] }
+serde_json = "1.0.57"
+serde_urlencoded = "0.6.1"

--- a/async-graphql-rocket/Cargo.toml
+++ b/async-graphql-rocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-graphql-rocket"
-version = "1.17.18"
+version = "1.17.21"
 authors = ["Daniel Wiesenberg <daniel@simplificAR.io>"]
 edition = "2018"
 description = "async-graphql for Rocket.rs"
@@ -13,10 +13,9 @@ keywords = ["futures", "async", "graphql", "rocket"]
 categories = ["network-programming", "asynchronous"]
 
 [dependencies]
-async-graphql = { path = "..", version = "1.17.18" }
-rocket = { git = "https://github.com/SergioBenitez/Rocket/", default-features = false }
+async-graphql = { path = "..", version = "1.17.21" }
+rocket = { git = "https://github.com/SergioBenitez/Rocket/", rev = "dc2c6ec", default-features = false } #TODO: Change to Cargo crate, when Rocket 0.5.0 is released
 log = "0.4.11"
 yansi = "0.5.0"
 tokio-util = { version = "0.3.1", default-features = false, features = ["compat"] }
 serde_json = "1.0.57"
-serde_urlencoded = "0.6.1"

--- a/async-graphql-rocket/src/lib.rs
+++ b/async-graphql-rocket/src/lib.rs
@@ -12,7 +12,7 @@ use rocket::{
     data::{self, FromData},
     data::{Data, ToByteUnit},
     fairing::{AdHoc, Fairing},
-    http::{hyper::header::CACHE_CONTROL, ContentType, Header, Status},
+    http::{ContentType, Header, Status},
     request::{self, FromQuery, Outcome},
     response::{self, Responder, ResponseBuilder},
     Request, Response, State,
@@ -289,7 +289,7 @@ impl<'r> CacheControl for ResponseBuilder<'r> {
     ) -> &mut ResponseBuilder<'r> {
         match resp {
             Ok(resp) if resp.cache_control.value().is_some() => self.header(Header::new(
-                CACHE_CONTROL.as_str(),
+                "cache-control",
                 resp.cache_control.value().unwrap(),
             )),
             _ => self,

--- a/async-graphql-rocket/src/lib.rs
+++ b/async-graphql-rocket/src/lib.rs
@@ -4,21 +4,22 @@
 #![forbid(unsafe_code)]
 
 use async_graphql::{
-    IntoQueryBuilder, IntoQueryBuilderOpts, QueryBuilder, QueryResponse, Schema, Variables, ObjectType, SubscriptionType
+    IntoQueryBuilder, IntoQueryBuilderOpts, ObjectType, QueryBuilder, QueryResponse, Schema,
+    SubscriptionType, Variables,
 };
 use log::{error, info};
 use rocket::{
-    Request, Response, State,
+    data::{self, FromData},
     data::{Data, ToByteUnit},
     fairing::{AdHoc, Fairing},
-    http::{ContentType, Header, Status, hyper::header::CACHE_CONTROL},
+    http::{hyper::header::CACHE_CONTROL, ContentType, Header, Status},
     request::{self, FromQuery, Outcome},
-    response::{self, Responder, ResponseBuilder}, data::{self, FromData}
+    response::{self, Responder, ResponseBuilder},
+    Request, Response, State,
 };
 use std::{io::Cursor, sync::Arc};
 use tokio_util::compat::Tokio02AsyncReadCompatExt;
 use yansi::Paint;
-
 
 /// Contains the fairing functions, to attach GraphQL with the desired `Schema`, and optionally
 /// `QueryBuilderOpts`, to Rocket.
@@ -65,8 +66,7 @@ use yansi::Paint;
 /// ```
 pub struct GraphQL;
 
-impl GraphQL
-{
+impl GraphQL {
     /// Fairing with default `QueryBuilderOpts`. You just need to pass in your `Schema` and then can
     /// attach the `Fairing` to Rocket.
     ///
@@ -81,7 +81,7 @@ impl GraphQL
     where
         Q: ObjectType + Send + Sync + 'static,
         M: ObjectType + Send + Sync + 'static,
-        S: SubscriptionType + Send + Sync + 'static
+        S: SubscriptionType + Send + Sync + 'static,
     {
         GraphQL::attach(schema, Default::default())
     }
@@ -97,11 +97,14 @@ impl GraphQL
     ///         .attach(GraphQL::fairing_with_opts(schema, opts))
     ///         .mount("/", routes![graphql_query, graphql_request])
     /// ```
-    pub fn fairing_with_opts<Q, M, S>(schema: Schema<Q, M, S>, opts: IntoQueryBuilderOpts) -> impl Fairing
+    pub fn fairing_with_opts<Q, M, S>(
+        schema: Schema<Q, M, S>,
+        opts: IntoQueryBuilderOpts,
+    ) -> impl Fairing
     where
         Q: ObjectType + Send + Sync + 'static,
         M: ObjectType + Send + Sync + 'static,
-        S: SubscriptionType + Send + Sync + 'static
+        S: SubscriptionType + Send + Sync + 'static,
     {
         GraphQL::attach(schema, opts)
     }
@@ -110,15 +113,17 @@ impl GraphQL
     where
         Q: ObjectType + Send + Sync + 'static,
         M: ObjectType + Send + Sync + 'static,
-        S: SubscriptionType + Send + Sync + 'static
+        S: SubscriptionType + Send + Sync + 'static,
     {
         AdHoc::on_attach("GraphQL", move |rocket| async move {
-            let emoji = if cfg!(windows) {""} else {"📄 "};
-            info!("{}{}", Paint::masked(emoji), Paint::magenta(format!("GraphQL {}:", Paint::blue(""))).wrap());
+            let emoji = if cfg!(windows) { "" } else { "📄 " };
+            info!(
+                "{}{}",
+                Paint::masked(emoji),
+                Paint::magenta(format!("GraphQL {}:", Paint::blue(""))).wrap()
+            );
 
-            Ok(rocket.manage(schema)
-                    .manage(Arc::new(opts))
-            )
+            Ok(rocket.manage(schema).manage(Arc::new(opts)))
         })
     }
 }
@@ -150,15 +155,12 @@ impl GQLRequest {
     where
         Q: ObjectType + Send + Sync + 'static,
         M: ObjectType + Send + Sync + 'static,
-        S: SubscriptionType + Send + Sync + 'static
+        S: SubscriptionType + Send + Sync + 'static,
     {
-        self.0.execute(schema)
-            .await
-            .map(GQLResponse)
-            .map_err(|e| {
-                error!("{}", e);
-                Status::BadRequest
-            })
+        self.0.execute(schema).await.map(GQLResponse).map_err(|e| {
+            error!("{}", e);
+            Status::BadRequest
+        })
     }
 }
 
@@ -177,26 +179,21 @@ impl<'q> FromQuery<'q> for GQLRequest {
                     if query.is_some() {
                         return Err(r#"Multiple parameters named "query" found. Only one parameter by that name is allowed."#.to_string());
                     } else {
-                        query = value.url_decode()
-                            .map_err(|e| e.to_string())?
-                            .into();
+                        query = value.url_decode().map_err(|e| e.to_string())?.into();
                     }
                 }
                 "operation_name" => {
                     if operation_name.is_some() {
                         return Err(r#"Multiple parameters named "operation_name" found. Only one parameter by that name is allowed."#.to_string());
                     } else {
-                        operation_name = value.url_decode()
-                            .map_err(|e| e.to_string())?
-                            .into();
+                        operation_name = value.url_decode().map_err(|e| e.to_string())?.into();
                     }
                 }
                 "variables" => {
                     if variables.is_some() {
                         return Err(r#"Multiple parameters named "variables" found. Only one parameter by that name is allowed."#.to_string());
                     } else {
-                        let decoded= value.url_decode()
-                            .map_err(|e| e.to_string())?;
+                        let decoded = value.url_decode().map_err(|e| e.to_string())?;
                         let json_value = serde_json::from_str::<serde_json::Value>(&decoded)
                             .map_err(|e| e.to_string())?;
                         variables = Variables::parse_from_json(json_value)
@@ -205,7 +202,10 @@ impl<'q> FromQuery<'q> for GQLRequest {
                     }
                 }
                 _ => {
-                    return Err(format!(r#"Extra parameter named "{}" found. Extra parameters are not allowed."#, key));
+                    return Err(format!(
+                        r#"Extra parameter named "{}" found. Extra parameters are not allowed."#,
+                        key
+                    ));
                 }
             }
         }
@@ -235,7 +235,12 @@ impl FromData for GQLRequest {
     async fn from_data(req: &Request<'_>, data: Data) -> data::Outcome<Self, Self::Error> {
         let opts = match req.guard::<State<'_, Arc<IntoQueryBuilderOpts>>>().await {
             Outcome::Success(opts) => opts,
-            Outcome::Failure(_) => return data::Outcome::Failure((Status::InternalServerError, "Missing IntoQueryBuilderOpts in State".to_string())),
+            Outcome::Failure(_) => {
+                return data::Outcome::Failure((
+                    Status::InternalServerError,
+                    "Missing IntoQueryBuilderOpts in State".to_string(),
+                ))
+            }
             Outcome::Forward(()) => unreachable!(),
         };
 
@@ -272,17 +277,21 @@ impl<'r> Responder<'r, 'static> for GQLResponse {
 }
 
 /// Extension trait, to allow the use of `cache_control` with for example `ResponseBuilder`.
-pub trait CacheControl{
+pub trait CacheControl {
     /// Add the `async-graphql::query::QueryResponse` cache control value as header to the Rocket response.
     fn cache_control(&mut self, resp: &async_graphql::Result<QueryResponse>) -> &mut Self;
 }
 
 impl<'r> CacheControl for ResponseBuilder<'r> {
-    fn cache_control(&mut self, resp: &async_graphql::Result<QueryResponse>) -> &mut ResponseBuilder<'r> {
+    fn cache_control(
+        &mut self,
+        resp: &async_graphql::Result<QueryResponse>,
+    ) -> &mut ResponseBuilder<'r> {
         match resp {
-            Ok(resp) if resp.cache_control.value().is_some() => {
-                self.header(Header::new(CACHE_CONTROL.as_str(), resp.cache_control.value().unwrap()))
-            }
+            Ok(resp) if resp.cache_control.value().is_some() => self.header(Header::new(
+                CACHE_CONTROL.as_str(),
+                resp.cache_control.value().unwrap(),
+            )),
             _ => self,
         }
     }

--- a/async-graphql-rocket/src/lib.rs
+++ b/async-graphql-rocket/src/lib.rs
@@ -1,0 +1,202 @@
+//! Async-graphql integration with Rocket
+
+#![warn(missing_docs)]
+#![forbid(unsafe_code)]
+
+use async_graphql::{
+    IntoQueryBuilder, IntoQueryBuilderOpts, QueryBuilder, QueryResponse, Schema, Variables, ObjectType, SubscriptionType
+};
+use log::{error, info};
+use rocket::{
+    Request, Response, State,
+    data::{Data, ToByteUnit},
+    fairing::{AdHoc, Fairing},
+    http::{ContentType, Header, Status, hyper::header::CACHE_CONTROL},
+    request::{self, FromQuery, Outcome},
+    response::{self, Responder, ResponseBuilder}, data::{self, FromData}
+};
+use std::{io::Cursor, sync::Arc};
+use tokio_util::compat::Tokio02AsyncReadCompatExt;
+use yansi::Paint;
+
+
+
+pub struct GraphQL;
+
+impl GraphQL
+{
+    pub fn fairing<Q, M, S>(schema: Schema<Q, M, S>) -> impl Fairing
+    where
+        Q: ObjectType + Send + Sync + 'static,
+        M: ObjectType + Send + Sync + 'static,
+        S: SubscriptionType + Send + Sync + 'static
+    {
+        GraphQL::attach(schema, Default::default())
+    }
+
+    pub fn fairing_with_opts<Q, M, S>(schema: Schema<Q, M, S>, opts: IntoQueryBuilderOpts) -> impl Fairing
+    where
+        Q: ObjectType + Send + Sync + 'static,
+        M: ObjectType + Send + Sync + 'static,
+        S: SubscriptionType + Send + Sync + 'static
+    {
+        GraphQL::attach(schema, opts)
+    }
+
+    fn attach<Q, M, S>(schema: Schema<Q, M, S>, opts: IntoQueryBuilderOpts) -> impl Fairing
+    where
+        Q: ObjectType + Send + Sync + 'static,
+        M: ObjectType + Send + Sync + 'static,
+        S: SubscriptionType + Send + Sync + 'static
+    {
+        AdHoc::on_attach("GraphQL", move |rocket| async move {
+            let emoji = if cfg!(windows) {""} else {"📄 "};
+            info!("{}{}", Paint::masked(emoji), Paint::magenta(format!("GraphQL {}:", Paint::blue(""))).wrap());
+
+            Ok(rocket.manage(schema)
+                    .manage(Arc::new(opts))
+            )
+        })
+    }
+}
+
+pub struct GQLRequest(pub QueryBuilder);
+
+impl GQLRequest {
+    pub async fn execute<Q, M, S>(self, schema: &Schema<Q, M, S>) -> Result<GQLResponse, Status>
+    where
+        Q: ObjectType + Send + Sync + 'static,
+        M: ObjectType + Send + Sync + 'static,
+        S: SubscriptionType + Send + Sync + 'static
+    {
+        self.0.execute(schema)
+            .await
+            .map(GQLResponse)
+            .map_err(|e| {
+                error!("{}", e);
+                Status::BadRequest
+            })
+    }
+}
+
+impl<'q> FromQuery<'q> for GQLRequest {
+    type Error = String;
+
+    fn from_query(query_items: request::Query) -> Result<Self, Self::Error> {
+        let mut query = None;
+        let mut operation_name = None;
+        let mut variables = None;
+
+        for query_item in query_items {
+            let (key, value) = query_item.key_value();
+            match key.as_str() {
+                "query" => {
+                    if query.is_some() {
+                        return Err(r#"Multiple parameters named \"query\" found. Only one parameter by that name is allowed."#.to_string());
+                    } else {
+                        query = value.url_decode()
+                            .map_err(|e| e.to_string())?
+                            .into();
+                    }
+                }
+                "operation_name" => {
+                    if operation_name.is_some() {
+                        return Err(r#"Multiple parameters named \"operation_name\" found. Only one parameter by that name is allowed."#.to_string());
+                    } else {
+                        operation_name = value.url_decode()
+                            .map_err(|e| e.to_string())?
+                            .into();
+                    }
+                }
+                "variables" => {
+                    if variables.is_some() {
+                        return Err(r#"Multiple parameters named \"variables\" found. Only one parameter by that name is allowed."#.to_string());
+                    } else {
+                        let decoded= value.url_decode()
+                            .map_err(|e| e.to_string())?;
+                        let json_value = serde_json::from_str::<serde_json::Value>(&decoded)
+                            .map_err(|e| e.to_string())?;
+                        variables = Variables::parse_from_json(json_value)
+                            .map_err(|e| e.to_string())?
+                            .into();
+                    }
+                }
+                _ => {
+                    return Err(format!(r#"Extra parameter named \"{}\" found. Extra parameters are not allowed."#, key));
+                }
+            }
+        }
+
+        if let Some(query_source) = query {
+            let mut builder = QueryBuilder::new(query_source);
+
+            if let Some(variables) = variables {
+                builder = builder.variables(variables);
+            }
+
+            if let Some(operation_name) = operation_name {
+                builder = builder.operation_name(operation_name);
+            }
+
+            Ok(GQLRequest(builder))
+        } else {
+            Err(r#"Parameter "query" missing from request."#.to_string())
+        }
+    }
+}
+
+#[rocket::async_trait]
+impl FromData for GQLRequest {
+    type Error = String;
+
+    async fn from_data(req: &Request<'_>, data: Data) -> data::Outcome<Self, Self::Error> {
+        let opts = match req.guard::<State<'_, Arc<IntoQueryBuilderOpts>>>().await {
+            Outcome::Success(opts) => opts,
+            Outcome::Failure(_) => return data::Outcome::Failure((Status::InternalServerError, "Missing IntoQueryBuilderOpts in State".to_string())),
+            Outcome::Forward(()) => unreachable!(),
+        };
+
+        let stream = data.open(100.kibibytes());
+        let builder = (req.headers().get_one("Content-Type"), stream.compat())
+            .into_query_builder_opts(&opts)
+            .await;
+
+        match builder {
+            Ok(builder) => data::Outcome::Success(GQLRequest(builder)),
+            Err(e) => data::Outcome::Failure((Status::BadRequest, format!("{}", e))),
+        }
+    }
+}
+
+pub struct GQLResponse(pub QueryResponse);
+
+impl<'r> Responder<'r, 'static> for GQLResponse {
+    fn respond_to(self, _: &'r Request<'_>) -> response::Result<'static> {
+        let gql_resp = async_graphql::http::GQLResponse(Ok(self.0));
+        let body = serde_json::to_string(&gql_resp).unwrap();
+
+        Response::build()
+            .header(ContentType::new("application", "json"))
+            .status(Status::Ok)
+            .sized_body(body.len(), Cursor::new(body))
+            .cache_control(&gql_resp.0)
+            .ok()
+    }
+}
+
+/// Extension trait, to allow the use of `cache_control` with for example `ResponseBuilder`.
+pub trait CacheControl{
+    /// Add the `async-graphql::query::QueryResponse` cache control value as header to the Rocket response.
+    fn cache_control(&mut self, resp: &async_graphql::Result<QueryResponse>) -> &mut Self;
+}
+
+impl<'r> CacheControl for ResponseBuilder<'r> {
+    fn cache_control(&mut self, resp: &async_graphql::Result<QueryResponse>) -> &mut ResponseBuilder<'r> {
+        match resp {
+            Ok(resp) if resp.cache_control.value().is_some() => {
+                self.header(Header::new(CACHE_CONTROL.as_str(), resp.cache_control.value().unwrap()))
+            }
+            _ => self,
+        }
+    }
+}

--- a/async-graphql-rocket/src/lib.rs
+++ b/async-graphql-rocket/src/lib.rs
@@ -29,7 +29,7 @@ use yansi::Paint;
 ///
 /// ```rust,no_run
 ///
-/// use async_graphql::*;
+/// use async_graphql::{EmptyMutation, EmptySubscription, Schema};
 /// use async_graphql_rocket::{GQLRequest, GraphQL, GQLResponse};
 /// use rocket::{response::content, routes, State, http::Status};
 ///
@@ -72,7 +72,7 @@ impl GraphQL {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```rust,no_run,ignore
     ///     rocket::ignite()
     ///         .attach(GraphQL::fairing(schema))
     ///         .mount("/", routes![graphql_query, graphql_request])
@@ -91,7 +91,7 @@ impl GraphQL {
     ///
     /// # Examples
     ///
-    /// ```rust,no_run
+    /// ```rust,no_run,ignore
     ///     let opts: IntoQueryBuilderOpts = Default::default();
     ///     rocket::ignite()
     ///         .attach(GraphQL::fairing_with_opts(schema, opts))
@@ -133,7 +133,7 @@ impl GraphQL {
 ///
 /// # Examples
 ///
-/// ```rust,no_run
+/// ```rust,no_run,ignore
 /// #[rocket::post("/?<query..>")]
 /// async fn graphql_query(schema: State<'_, ExampleSchema>, query: GQLRequest) -> Result<GQLResponse, Status> {
 ///     query.execute(&schema)


### PR DESCRIPTION
This PR addresses #222 and adds initial Rocket.rs support to `async-graphql`. Another [PR](https://github.com/async-graphql/examples/pull/26) adds the `StarWars` example to the `examples` repo.

Initial support means, that it currently depends on a specific commit of Rocket's github repository, which needs to be changed as soon as version 0.5 gets released. It also means, that subscription is not support as that need Websocket support (this is correct, right?) and that is currently not supported or to be more precise, integrated into Rocket.

