### PR TITLE
add context in ResolveInfo and add headerMap in warp integration

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -140,7 +140,7 @@ impl<'a> Display for QueryPathNode<'a> {
 }
 
 impl<'a> QueryPathNode<'a> {
-    pub(crate) fn field_name(&self) -> &str {
+    pub fn field_name(&self) -> &str {
         let mut p = self;
         loop {
             if let QueryPathSegment::Name(name) = &p.segment {

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -4,7 +4,7 @@ mod apollo_tracing;
 mod logger;
 mod tracing;
 
-use crate::context::{QueryPathNode, ResolveId};
+use crate::context::{Context, QueryPathNode, ResolveId};
 use crate::{Result, Variables};
 
 pub use self::apollo_tracing::ApolloTracing;
@@ -27,6 +27,9 @@ pub struct ResolveInfo<'a> {
 
     /// Current path node, You can go through the entire path.
     pub path_node: &'a QueryPathNode<'a>,
+
+    /// Context
+    pub context: &'a Context<'a>,
 
     /// Parent type
     pub parent_type: &'a str,
@@ -56,7 +59,7 @@ pub trait Extension: Sync + Send + 'static {
     fn validation_end(&mut self) {}
 
     /// Called at the begin of the execution.
-    fn execution_start(&mut self) {}
+    fn execution_start<'a>(&mut self) {}
 
     /// Called at the end of the execution.
     fn execution_end(&mut self) {}

--- a/src/mutation_resolver.rs
+++ b/src/mutation_resolver.rs
@@ -65,6 +65,7 @@ fn do_resolve<'a, T: ObjectType + Send + Sync>(
                         resolve_id: ctx_field.resolve_id,
                         path_node: ctx_field.path_node.as_ref().unwrap(),
                         parent_type: &T::type_name(),
+                        context: &ctx_field,
                         return_type: match ctx_field
                             .schema_env
                             .registry

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -96,6 +96,7 @@ pub fn collect_fields<'a, T: ObjectType + Send + Sync>(
                             resolve_id: ctx_field.resolve_id,
                             path_node: ctx_field.path_node.as_ref().unwrap(),
                             parent_type: &T::type_name(),
+                            context: &ctx_field,
                             return_type: match ctx_field
                                 .schema_env
                                 .registry


### PR DESCRIPTION
The use case here is to let the user indicate in a header if we want to enable or disable a specific feature in an extension. So basically I added support for headers in warp integration and added context inside `ResolveInfo` to let me pass header data to my extension for a query inside the context.