### PR TITLE
Remove Deserialize impl from MaybeUndefined

### DIFF
--- a/src/types/maybe_undefined.rs
+++ b/src/types/maybe_undefined.rs
@@ -46,7 +46,8 @@ use std::borrow::Cow;
 /// }
 /// ```
 #[allow(missing_docs)]
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug)]
+#[serde(untagged)]
 pub enum MaybeUndefined<T> {
     Undefined,
     Null,


### PR DESCRIPTION
Change Serialize implementation to use the `untagged` attribute. This handles the common case of directly serializing `MaybeUndefined`, but deserializing into an `Option<T>`. We could add a more sophisticated custom deserialize implementation later.

What do you think about this? I think this is much more useful behavior—maybe I am biased though because I need this right now in a project for work 🙃 .