### PR TITLE
Fixed redundant_closure_for_method_calls

### DIFF
--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -85,8 +85,7 @@ pub(super) async fn receive_batch_multipart(
             _ => {
                 if let Some(name) = field.name().map(ToString::to_string) {
                     if let Some(filename) = field.file_name().map(ToString::to_string) {
-                        let content_type =
-                            field.content_type().map(std::string::ToString::to_string);
+                        let content_type = field.content_type().map(ToString::to_string);
                         let mut file = tempfile::tempfile().map_err(ParseRequestError::Io)?;
                         while let Some(chunk) = field.chunk().await.unwrap() {
                             file.write(&chunk).map_err(ParseRequestError::Io)?;

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -85,7 +85,8 @@ pub(super) async fn receive_batch_multipart(
             _ => {
                 if let Some(name) = field.name().map(ToString::to_string) {
                     if let Some(filename) = field.file_name().map(ToString::to_string) {
-                        let content_type = field.content_type().map(|mime| mime.to_string());
+                        let content_type =
+                            field.content_type().map(std::string::ToString::to_string);
                         let mut file = tempfile::tempfile().map_err(ParseRequestError::Io)?;
                         while let Some(chunk) = field.chunk().await.unwrap() {
                             file.write(&chunk).map_err(ParseRequestError::Io)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@
 #![allow(clippy::must_use_candidate)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::redundant_closure_for_method_calls)]
+#![deny(clippy::redundant_closure_for_method_calls)]
 #![allow(clippy::option_if_let_else)]
 #![allow(clippy::match_same_arms)]
 #![allow(clippy::filter_map)]

--- a/src/model/directive.rs
+++ b/src/model/directive.rs
@@ -79,7 +79,9 @@ impl<'a> __Directive<'a> {
     }
 
     async fn description(&self) -> Option<String> {
-        self.directive.description.map(|s| s.to_string())
+        self.directive
+            .description
+            .map(std::string::ToString::to_string)
     }
 
     async fn locations(&self) -> &Vec<__DirectiveLocation> {

--- a/src/model/directive.rs
+++ b/src/model/directive.rs
@@ -79,9 +79,7 @@ impl<'a> __Directive<'a> {
     }
 
     async fn description(&self) -> Option<String> {
-        self.directive
-            .description
-            .map(std::string::ToString::to_string)
+        self.directive.description.map(ToString::to_string)
     }
 
     async fn locations(&self) -> &Vec<__DirectiveLocation> {

--- a/src/model/enum_value.rs
+++ b/src/model/enum_value.rs
@@ -13,7 +13,7 @@ impl<'a> __EnumValue<'a> {
     }
 
     async fn description(&self) -> Option<String> {
-        self.value.description.map(std::string::ToString::to_string)
+        self.value.description.map(ToString::to_string)
     }
 
     async fn is_deprecated(&self) -> bool {
@@ -21,6 +21,6 @@ impl<'a> __EnumValue<'a> {
     }
 
     async fn deprecation_reason(&self) -> Option<String> {
-        self.value.deprecation.map(std::string::ToString::to_string)
+        self.value.deprecation.map(ToString::to_string)
     }
 }

--- a/src/model/enum_value.rs
+++ b/src/model/enum_value.rs
@@ -13,7 +13,7 @@ impl<'a> __EnumValue<'a> {
     }
 
     async fn description(&self) -> Option<String> {
-        self.value.description.map(|s| s.to_string())
+        self.value.description.map(std::string::ToString::to_string)
     }
 
     async fn is_deprecated(&self) -> bool {
@@ -21,6 +21,6 @@ impl<'a> __EnumValue<'a> {
     }
 
     async fn deprecation_reason(&self) -> Option<String> {
-        self.value.deprecation.map(|s| s.to_string())
+        self.value.deprecation.map(std::string::ToString::to_string)
     }
 }

--- a/src/model/field.rs
+++ b/src/model/field.rs
@@ -14,7 +14,7 @@ impl<'a> __Field<'a> {
     }
 
     async fn description(&self) -> Option<String> {
-        self.field.description.map(|s| s.to_string())
+        self.field.description.map(std::string::ToString::to_string)
     }
 
     async fn args(&self) -> Vec<__InputValue<'a>> {
@@ -38,6 +38,6 @@ impl<'a> __Field<'a> {
     }
 
     async fn deprecation_reason(&self) -> Option<String> {
-        self.field.deprecation.map(|s| s.to_string())
+        self.field.deprecation.map(std::string::ToString::to_string)
     }
 }

--- a/src/model/field.rs
+++ b/src/model/field.rs
@@ -14,7 +14,7 @@ impl<'a> __Field<'a> {
     }
 
     async fn description(&self) -> Option<String> {
-        self.field.description.map(std::string::ToString::to_string)
+        self.field.description.map(ToString::to_string)
     }
 
     async fn args(&self) -> Vec<__InputValue<'a>> {
@@ -38,6 +38,6 @@ impl<'a> __Field<'a> {
     }
 
     async fn deprecation_reason(&self) -> Option<String> {
-        self.field.deprecation.map(std::string::ToString::to_string)
+        self.field.deprecation.map(ToString::to_string)
     }
 }

--- a/src/model/input_value.rs
+++ b/src/model/input_value.rs
@@ -14,9 +14,7 @@ impl<'a> __InputValue<'a> {
     }
 
     async fn description(&self) -> Option<String> {
-        self.input_value
-            .description
-            .map(std::string::ToString::to_string)
+        self.input_value.description.map(ToString::to_string)
     }
 
     #[graphql(name = "type")]

--- a/src/model/input_value.rs
+++ b/src/model/input_value.rs
@@ -14,7 +14,9 @@ impl<'a> __InputValue<'a> {
     }
 
     async fn description(&self) -> Option<String> {
-        self.input_value.description.map(|s| s.to_string())
+        self.input_value
+            .description
+            .map(std::string::ToString::to_string)
     }
 
     #[graphql(name = "type")]

--- a/src/model/type.rs
+++ b/src/model/type.rs
@@ -70,22 +70,22 @@ impl<'a> __Type<'a> {
         match &self.detail {
             TypeDetail::Named(ty) => match ty {
                 registry::MetaType::Scalar { description, .. } => {
-                    description.map(std::string::ToString::to_string)
+                    description.map(ToString::to_string)
                 }
                 registry::MetaType::Object { description, .. } => {
-                    description.map(std::string::ToString::to_string)
+                    description.map(ToString::to_string)
                 }
                 registry::MetaType::Interface { description, .. } => {
-                    description.map(std::string::ToString::to_string)
+                    description.map(ToString::to_string)
                 }
                 registry::MetaType::Union { description, .. } => {
-                    description.map(std::string::ToString::to_string)
+                    description.map(ToString::to_string)
                 }
                 registry::MetaType::Enum { description, .. } => {
-                    description.map(std::string::ToString::to_string)
+                    description.map(ToString::to_string)
                 }
                 registry::MetaType::InputObject { description, .. } => {
-                    description.map(std::string::ToString::to_string)
+                    description.map(ToString::to_string)
                 }
             },
             TypeDetail::NonNull(_) => None,

--- a/src/model/type.rs
+++ b/src/model/type.rs
@@ -70,18 +70,22 @@ impl<'a> __Type<'a> {
         match &self.detail {
             TypeDetail::Named(ty) => match ty {
                 registry::MetaType::Scalar { description, .. } => {
-                    description.map(|s| s.to_string())
+                    description.map(std::string::ToString::to_string)
                 }
                 registry::MetaType::Object { description, .. } => {
-                    description.map(|s| s.to_string())
+                    description.map(std::string::ToString::to_string)
                 }
                 registry::MetaType::Interface { description, .. } => {
-                    description.map(|s| s.to_string())
+                    description.map(std::string::ToString::to_string)
                 }
-                registry::MetaType::Union { description, .. } => description.map(|s| s.to_string()),
-                registry::MetaType::Enum { description, .. } => description.map(|s| s.to_string()),
+                registry::MetaType::Union { description, .. } => {
+                    description.map(std::string::ToString::to_string)
+                }
+                registry::MetaType::Enum { description, .. } => {
+                    description.map(std::string::ToString::to_string)
+                }
                 registry::MetaType::InputObject { description, .. } => {
-                    description.map(|s| s.to_string())
+                    description.map(std::string::ToString::to_string)
                 }
             },
             TypeDetail::NonNull(_) => None,

--- a/src/validation/rules/fields_on_correct_type.rs
+++ b/src/validation/rules/fields_on_correct_type.rs
@@ -40,7 +40,7 @@ impl<'a> Visitor<'a> for FieldsOnCorrectType {
                                 .iter()
                                 .map(|fields| fields.keys())
                                 .flatten()
-                                .map(std::string::String::as_str),
+                                .map(String::as_str),
                             &field.node.name.node,
                         )
                         .unwrap_or_default()

--- a/src/validation/rules/fields_on_correct_type.rs
+++ b/src/validation/rules/fields_on_correct_type.rs
@@ -40,7 +40,7 @@ impl<'a> Visitor<'a> for FieldsOnCorrectType {
                                 .iter()
                                 .map(|fields| fields.keys())
                                 .flatten()
-                                .map(|s| s.as_str()),
+                                .map(std::string::String::as_str),
                             &field.node.name.node,
                         )
                         .unwrap_or_default()

--- a/src/validation/rules/no_undefined_variables.rs
+++ b/src/validation/rules/no_undefined_variables.rs
@@ -80,7 +80,7 @@ impl<'a> Visitor<'a> for NoUndefinedVariables<'a> {
         name: Option<&'a Name>,
         operation_definition: &'a Positioned<OperationDefinition>,
     ) {
-        let name = name.map(|name| name.as_str());
+        let name = name.map(async_graphql_value::Name::as_str);
         self.current_scope = Some(Scope::Operation(name));
         self.defined_variables
             .insert(name, (operation_definition.pos, HashSet::new()));

--- a/src/validation/rules/no_undefined_variables.rs
+++ b/src/validation/rules/no_undefined_variables.rs
@@ -80,7 +80,7 @@ impl<'a> Visitor<'a> for NoUndefinedVariables<'a> {
         name: Option<&'a Name>,
         operation_definition: &'a Positioned<OperationDefinition>,
     ) {
-        let name = name.map(async_graphql_value::Name::as_str);
+        let name = name.map(Name::as_str);
         self.current_scope = Some(Scope::Operation(name));
         self.defined_variables
             .insert(name, (operation_definition.pos, HashSet::new()));

--- a/src/validation/rules/no_unused_fragments.rs
+++ b/src/validation/rules/no_unused_fragments.rs
@@ -38,7 +38,7 @@ impl<'a> Visitor<'a> for NoUnusedFragments<'a> {
 
         for (name, _) in doc.operations.iter() {
             self.find_reachable_fragments(
-                &Scope::Operation(name.map(|name| name.as_str())),
+                &Scope::Operation(name.map(Name::as_str)),
                 &mut reachable,
             );
         }
@@ -59,7 +59,7 @@ impl<'a> Visitor<'a> for NoUnusedFragments<'a> {
         name: Option<&'a Name>,
         _operation_definition: &'a Positioned<OperationDefinition>,
     ) {
-        self.current_scope = Some(Scope::Operation(name.map(|name| name.as_str())));
+        self.current_scope = Some(Scope::Operation(name.map(Name::as_str)));
     }
 
     fn enter_fragment_definition(

--- a/src/validation/rules/no_unused_variables.rs
+++ b/src/validation/rules/no_unused_variables.rs
@@ -80,7 +80,7 @@ impl<'a> Visitor<'a> for NoUnusedVariables<'a> {
         name: Option<&'a Name>,
         _operation_definition: &'a Positioned<OperationDefinition>,
     ) {
-        let op_name = name.map(|name| name.as_str());
+        let op_name = name.map(Name::as_str);
         self.current_scope = Some(Scope::Operation(op_name));
         self.defined_variables.insert(op_name, HashSet::new());
     }

--- a/src/validation/rules/variables_in_allowed_position.rs
+++ b/src/validation/rules/variables_in_allowed_position.rs
@@ -76,7 +76,7 @@ impl<'a> Visitor<'a> for VariableInAllowedPosition<'a> {
         name: Option<&'a Name>,
         _operation_definition: &'a Positioned<OperationDefinition>,
     ) {
-        self.current_scope = Some(Scope::Operation(name.map(|name| name.as_str())));
+        self.current_scope = Some(Scope::Operation(name.map(Name::as_str)));
     }
 
     fn enter_fragment_definition(

--- a/src/validation/utils.rs
+++ b/src/validation/utils.rs
@@ -124,7 +124,7 @@ pub fn is_valid_input_value(
                     ConstValue::Object(values) => {
                         let mut input_names = values
                             .keys()
-                            .map(|name| name.as_ref())
+                            .map(std::convert::AsRef::as_ref)
                             .collect::<HashSet<_>>();
 
                         for field in input_fields.values() {

--- a/src/validation/utils.rs
+++ b/src/validation/utils.rs
@@ -122,10 +122,8 @@ pub fn is_valid_input_value(
                     ..
                 } => match value {
                     ConstValue::Object(values) => {
-                        let mut input_names = values
-                            .keys()
-                            .map(std::convert::AsRef::as_ref)
-                            .collect::<HashSet<_>>();
+                        let mut input_names =
+                            values.keys().map(AsRef::as_ref).collect::<HashSet<_>>();
 
                         for field in input_fields.values() {
                             input_names.remove(field.name);


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_for_method_calls

The size of library before:

```
$ cargo build --release && ls -al target/release/libasync_graphql.rlib
    Finished release [optimized] target(s) in 0.07s
-rw-rw-r-- 2 olexiyb olexiyb 7847678 Oct 23 10:57 target/release/libasync_graphql.rlib
```

after

```
$ cargo build --release && ls -al target/release/libasync_graphql.rlib
   Compiling async-graphql v2.0.8 (/home/olexiyb/b100pro/async-graphql)
    Finished release [optimized] target(s) in 10.09s
-rw-rw-r-- 2 olexiyb olexiyb 7837136 Oct 23 11:05 target/release/libasync_graphql.rlib
```

around 10kB win and I think this will improve performance as well
