### PR TITLE
Modify interface SDL and bump Rocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ cargo bench -- "chat run"
 #measure all with jemalloc
 cargo bench --features jemalloc
 
-#measure only simple run with jemalloc 
+#measure only simple run with jemalloc
 cargo bench --features jemalloc -- "simple run"
 ```
 
@@ -94,6 +94,7 @@ Read more here: https://bheisler.github.io/criterion.rs/book/criterion_rs.html
 * Actix-web [async-graphql-actix-web](https://crates.io/crates/async-graphql-actix-web)
 * Warp [async-graphql-warp](https://crates.io/crates/async-graphql-warp)
 * Tide [async-graphql-tide](https://crates.io/crates/async-graphql-tide)
+* Rocket [async-graphql-rocket](https://github.com/async-graphql/async-graphql/tree/master/integrations/rocket)
 
 ## License
 

--- a/docs/en/src/integrations.md
+++ b/docs/en/src/integrations.md
@@ -5,5 +5,6 @@
 - Actix-web [async-graphql-actix-web](https://crates.io/crates/async-graphql-actix-web)
 - Warp [async-graphql-warp](https://crates.io/crates/async-graphql-warp)
 - Tide [async-graphql-tide](https://crates.io/crates/async-graphql-tide)
+- Rocket [async-graphql-rocket](https://github.com/async-graphql/async-graphql/tree/master/integrations/rocket)
 
 **Even if the server you are currently using is not in the above list, it is quite simple to implement similar functionality yourself.**

--- a/integrations/rocket/Cargo.toml
+++ b/integrations/rocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-graphql-rocket"
-version = "2.0.3"
+version = "2.0.8"
 authors = ["Daniel Wiesenberg <daniel@simplificAR.io>"]
 edition = "2018"
 description = "async-graphql for Rocket.rs"
@@ -16,7 +16,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 async-graphql = { path = "../..", version = "=2.0.8" }
 
-rocket = { git = "https://github.com/SergioBenitez/Rocket/", rev = "8da034a", default-features = false } # TODO: Change to Cargo crate when Rocket 0.5.0 is released
-serde = "1.0.116"
+rocket = { git = "https://github.com/SergioBenitez/Rocket/", rev = "0c150c2", default-features = false } # TODO: Change to Cargo crate when Rocket 0.5.0 is released
+serde = "1.0.117"
 serde_json = "1.0.59"
 tokio-util = { version = "0.3.1", default-features = false, features = ["compat"] }

--- a/integrations/rocket/src/lib.rs
+++ b/integrations/rocket/src/lib.rs
@@ -33,7 +33,7 @@ mod query_deserializer;
 /// # Examples
 ///
 /// ```ignore
-/// #[rocket::post("/graphql", data = "<request>", format = "application/json")]
+/// #[rocket::post("/graphql", data = "<request>", format = "application/json", rank = 1)]
 /// async fn graphql_request(schema: State<'_, ExampleSchema>, request: BatchRequest) -> Response {
 ///     request.execute(&schema).await
 /// }
@@ -93,12 +93,12 @@ impl FromData for BatchRequest {
 /// # Examples
 ///
 /// ```ignore
-/// #[rocket::post("/graphql?<query..>")]
+/// #[rocket::post("/graphql?<query..>", rank = 2)]
 /// async fn graphql_query(schema: State<'_, ExampleSchema>, query: Request) -> Result<Response, Status> {
 ///     query.execute(&schema).await
 /// }
 ///
-/// #[rocket::post("/graphql", data = "<request>", format = "application/json")]
+/// #[rocket::post("/graphql", data = "<request>", format = "application/json", rank = 1)]
 /// async fn graphql_request(schema: State<'_, ExampleSchema>, request: Request) -> Result<Response, Status> {
 ///     request.execute(&schema).await
 /// }

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -131,10 +131,7 @@ impl Registry {
                 write!(sdl, "type {} ", name).ok();
                 if let Some(implements) = self.implements.get(name) {
                     if !implements.is_empty() {
-                        write!(sdl, "implements ").ok();
-                        for interface in implements {
-                            write!(sdl, "& {} ", interface).ok();
-                        }
+                        write!(sdl, "implements {} ", implements.iter().map(AsRef::as_ref).collect::<Vec<&str>>().join(" & ")).ok();
                     }
                 }
 


### PR DESCRIPTION
This PR includes:
- Bump Rocket to after config revamp and change examples acordingly
- Add route ranks to Rocket to remove collision warning on startup
- Add some convenience wrappers to Rocket integration
- Change implements Interface SDL generation to adhere to [spec](http://spec.graphql.org/June2018/#sec-Interfaces). 
  Implementation of a single interface should yield a type like this `type Person implements NamedEntity`, without a `&`.