### PR TITLE
Validate the query hash before persisting queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default = [
 	"uuid",
 ]
 apollo_tracing = ["chrono"]
-apollo_persisted_queries = ["async-mutex", "lru"]
+apollo_persisted_queries = ["async-mutex", "lru", "sha2"]
 multipart = ["bytes", "multer", "tempfile"]
 unblock = ["blocking"]
 string_number = ["num-traits"]
@@ -70,6 +70,7 @@ bytes = { version = "0.5.4", optional = true }
 lru = { version = "0.6.0", optional = true }
 multer = { version = "1.2.2", optional = true }
 num-traits = { version = "0.2.12", optional = true }
+sha2 = { version = "0.9.1", optional = true }
 tempfile = { version = "3.1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Updates the `ApolloPersistedQueries` extension to verify the SHA-256 hash of queries before storing them in the cache.

1. This prevents malicious or broken clients from corrupting the cache.
2. This also more closely matches the [implementation in apollo-server](https://github.com/apollographql/apollo-server/blob/1af2792ed9e18f2bf218a29c2f4f128b6588f9ca/packages/apollo-server-core/src/requestPipeline.ts#L201-L210)