### PR TITLE
Strip `r#` prefix when constructing getter ident

### DIFF
--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -374,7 +374,10 @@ pub fn generate(
                         }
                         None => quote! { ::std::option::Option::None },
                     };
-                    let param_getter_name = get_param_getter_ident(&ident.ident.to_string());
+                    // We're generating a new identifier,
+                    // so remove the 'r#` prefix if present
+                    let param_getter_name =
+                        get_param_getter_ident(&ident.ident.unraw().to_string());
                     get_params.push(quote! {
                         #[allow(non_snake_case)]
                         let #param_getter_name = || -> #crate_name::ServerResult<#ty> { ctx.param_value(#name, #default) };

--- a/tests/raw_ident.rs
+++ b/tests/raw_ident.rs
@@ -11,24 +11,26 @@ pub async fn test_input_value_custom_error() {
 
     #[derive(SimpleObject)]
     struct MyObject {
-        r#i32: i32,
+        r#match: i32,
     }
 
     #[derive(InputObject)]
     struct MyInputObject {
-        r#i32: i32,
+        r#match: i32,
     }
 
     struct Query;
 
     #[Object]
     impl Query {
-        async fn r#type(&self, r#i32: i32) -> i32 {
-            r#i32
+        async fn r#type(&self, r#match: i32) -> i32 {
+            r#match
         }
 
         async fn obj(&self, obj: MyInputObject) -> MyObject {
-            MyObject { r#i32: obj.r#i32 }
+            MyObject {
+                r#match: obj.r#match,
+            }
         }
 
         async fn enum_value(&self, value: MyEnum) -> MyEnum {
@@ -48,15 +50,15 @@ pub async fn test_input_value_custom_error() {
     let schema = Schema::new(Query, EmptyMutation, SubscriptionRoot);
     let query = r#"
         {
-            type(i32: 99)
-            obj(obj: { i32: 88} ) { i32 }
+            type(match: 99)
+            obj(obj: { match: 88} ) { match }
             enumValue(value: TYPE)
         }"#;
     assert_eq!(
         schema.execute(query).await.into_result().unwrap().data,
         value!({
             "type": 99,
-            "obj": { "i32": 88 },
+            "obj": { "match": 88 },
             "enumValue": "TYPE",
         })
     );


### PR DESCRIPTION
When calling `to_string()` on an identifier, the returned string will
have an `r#` prefix if the original identifer was a raw identifier. This
prefix needs to be removed if the identifier is interpolated into
another identifier (e.g. `__some_prefix__r#other_ident`) in order for
the new identifier to be valid.

This issue was previously masked due to the fact that the relevant test
uses `r#i32`. It's possible to use `i32` as a normal (non-raw) ident -
due to a bug in rustc, this means that the user-supplied `r#` prefix
will be lost when calling `to_string()`. This bug will eventually be
fixed, causing `to_string()` to start returning `r#i32` instead of
`i32`.

This commit strips the `r#` prefix (if present) from an identifier
before using it to construct a new identifier. The relevant test is
updated to use `r#match`, which actually requires the `r#` prefix to be
a valid identifier. This causes the test to fail without this patch on
current versions of Rust.