### PR TITLE
Include full link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! ## Documentation
 //!
-//! * [Feature Comparison](feature-comparison.md)
+//! * [Feature Comparison](https://github.com/async-graphql/async-graphql/blob/master/feature-comparison.md)
 //! * [Book](https://async-graphql.github.io/async-graphql/en/index.html)
 //! * [中文文档](https://async-graphql.github.io/async-graphql/zh-CN/index.html)
 //! * [Docs](https://docs.rs/async-graphql)


### PR DESCRIPTION
Include the full link to ensure it is always accessible, whether from
github, doc.rs or elsewhere.