### PR TITLE
Update Headers to use `http::HeaderMap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ serde_json = "1.0.48"
 spin = "0.7.0"
 thiserror = "1.0.21"
 static_assertions = "1.1.0"
+http = "0.2.3"
 
 # Feature optional dependencies
 bson = { version = "1.0.0", optional = true }

--- a/integrations/rocket/src/lib.rs
+++ b/integrations/rocket/src/lib.rs
@@ -169,17 +169,17 @@ impl<'r> Responder<'r, 'static> for Response {
         let body = serde_json::to_string(&self.0).unwrap();
 
         let mut response = rocket::Response::new();
+        response.set_header(ContentType::new("application", "json"));
 
         if self.0.is_ok() {
             if let Some(cache_control) = self.0.cache_control().value() {
                 response.set_header(Header::new("cache-control", cache_control));
             }
             for (name, value) in self.0.http_headers() {
-                response.set_header(Header::new(name.to_string(), value.to_string()));
+                response.adjoin_header(Header::new(name.to_string(), value.to_string()));
             }
         }
 
-        response.set_header(ContentType::new("application", "json"));
         response.set_sized_body(body.len(), Cursor::new(body));
 
         Ok(response)

--- a/integrations/tide/src/lib.rs
+++ b/integrations/tide/src/lib.rs
@@ -164,7 +164,7 @@ pub fn respond(resp: impl Into<async_graphql::BatchResponse>) -> tide::Result {
             response.insert_header(headers::CACHE_CONTROL, cache_control);
         }
         for (name, value) in resp.http_headers() {
-            response.insert_header(name, value);
+            response.append_header(name, value);
         }
     }
     response.set_body(Body::from_json(&resp)?);

--- a/integrations/warp/src/batch_request.rs
+++ b/integrations/warp/src/batch_request.rs
@@ -86,7 +86,7 @@ impl Reply for BatchResponse {
                 if let (Ok(name), Ok(value)) =
                     (TryInto::<HeaderName>::try_into(name), value.try_into())
                 {
-                    resp.headers_mut().insert(name, value);
+                    resp.headers_mut().append(name, value);
                 }
             }
         }

--- a/src/extensions/logger.rs
+++ b/src/extensions/logger.rs
@@ -70,7 +70,7 @@ impl Extension for LoggerExtension {
         struct DisplayError<'a> {
             log: &'a LoggerExtension,
             e: &'a ServerError,
-        };
+        }
         impl<'a> Display for DisplayError<'a> {
             fn fmt(&self, f: &mut Formatter) -> fmt::Result {
                 write!(f, "[Error] ")?;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use http::header::HeaderMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -25,7 +25,7 @@ pub struct Response {
 
     /// HTTP headers
     #[serde(skip)]
-    pub http_headers: HashMap<String, String>,
+    pub http_headers: HeaderMap<String>,
 }
 
 impl Response {
@@ -116,20 +116,20 @@ impl BatchResponse {
         }
     }
 
-    /// Gets HTTP headers
+    /// Provides an iterator over all of the HTTP headers set on the response
     pub fn http_headers(&self) -> impl Iterator<Item = (&str, &str)> {
         let it: Box<dyn Iterator<Item = (&str, &str)>> = match self {
             BatchResponse::Single(resp) => Box::new(
                 resp.http_headers
                     .iter()
-                    .map(|item| (item.0.as_str(), item.1.as_str())),
+                    .map(|(key, value)| (key.as_str(), value.as_str())),
             ),
             BatchResponse::Batch(resp) => Box::new(
                 resp.iter()
                     .map(|r| {
                         r.http_headers
                             .iter()
-                            .map(|item| (item.0.as_str(), item.1.as_str()))
+                            .map(|(key, value)| (key.as_str(), value.as_str()))
                     })
                     .flatten(),
             ),


### PR DESCRIPTION
Relates to issue #370;

I think the current implementation of headers `HashMap<String, String>` doesn't fully support all possible use cases for headers that can support multiple values. A good example of this would be `Set-Cookies` where you would possibly want to set multiple Cookies on a single response.

This PR updates the underlying implementation to use `http::HeaderMap`, which was already an implicit dependency in the crate, but is now an explicit one. It's also the header implementation most (but not all) of the integration frameworks use for headers.

I've only implemented a subset of the `HeaderMap` functionality through the context, however I'm happy to go back and implement more/change things if you'd prefer.