### PR TITLE
update response to correctly carry headers through

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -53,6 +53,15 @@ impl Response {
         Self { extensions, ..self }
     }
 
+    /// Set the http headers of the response.
+    #[must_use]
+    pub fn http_headers(self, http_headers: HeaderMap<String>) -> Self {
+        Self {
+            http_headers,
+            ..self
+        }
+    }
+
     /// Set the cache control of the response.
     #[must_use]
     pub fn cache_control(self, cache_control: CacheControl) -> Self {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
 use futures_util::stream::{self, Stream, StreamExt};
-use http::header::HeaderMap;
 use indexmap::map::IndexMap;
 
 use crate::context::{Data, QueryEnvInner, ResolveId};
@@ -474,16 +473,12 @@ where
         env.extensions.execution_end(&ctx_extension);
         let extensions = env.extensions.result(&ctx_extension);
 
-        let mut http_headers = HeaderMap::default();
-        let mut current_headers = env.http_headers.lock();
-        std::mem::swap(&mut http_headers, &mut current_headers);
-
         match data {
             Ok(data) => Response::new(data),
             Err(e) => Response::from_errors(vec![e]),
         }
         .extensions(extensions)
-        .http_headers(http_headers)
+        .http_headers(std::mem::take(&mut *env.http_headers.lock()))
     }
 
     /// Execute a GraphQL query.


### PR DESCRIPTION
Apologies, made a few assumptions on my previous PR #383 which didn't hold true. I've been through and tested this more rigurously with the code from a full application and believe it works as intended.

Essentially the `http_headers` weren't being transfered across from the `query_env` to the `response` when the response object was being created.