### PR TITLE
Docs for generic `SimpleObject` + `InputObject`

### DIFF
--- a/docs/en/src/define_input_object.md
+++ b/docs/en/src/define_input_object.md
@@ -1,7 +1,7 @@
 # InputObject
 
-<!--Input Object and SimpleObject inconsistant space.-->
 You can use an `Object` as an argument, and GraphQL calls it an `InputObject`.
+
 The definition of `InputObject` is similar to [SimpleObject](define_simple_object.md), but
 `SimpleObject` can only be used as output and `InputObject` can only be used as input.
 
@@ -26,3 +26,48 @@ impl Mutation {
     }
 }
 ```
+
+## Generic `InputObject`s
+
+If you want to reuse an `InputObject` for other types, you can define a generic InputObject
+and specify how its concrete types should be implemented.
+
+In the following example, two `InputObject` types are created:
+
+```rust
+#[derive(InputObject)]
+#[graphql(concrete(name = "SomeName", params(SomeType)))]
+#[graphql(concrete(name = "SomeOtherName", params(SomeOtherType)))]
+pub struct SomeGenericInput<T: InputType> {
+    field1: Option<T>,
+    field2: String
+}
+```
+
+Note: Each generic parameter must implement `InputType`, as shown above.
+
+The schema generated is:
+
+```gql
+input SomeName {
+  field1: SomeType
+  field2: String!
+}
+
+input SomeOtherName {
+  field1: SomeOtherType
+  field2: String!
+}
+```
+
+In your resolver method or field of another input object, use as a normal generic type:
+
+```rust
+#[derive(InputObject)]
+pub struct YetAnotherInput {
+    a: SomeGenericInput<SomeType>,
+    b: SomeGenericInput<SomeOtherType>,
+}
+```
+
+You can pass multiple generic types to `params()`, separated by a comma.

--- a/docs/en/src/define_simple_object.md
+++ b/docs/en/src/define_simple_object.md
@@ -11,7 +11,7 @@ use async_graphql::*;
 struct MyObject {
     /// Value a
     a: i32,
-    
+
     /// Value b
     b: i32,
 
@@ -19,3 +19,48 @@ struct MyObject {
     c: i32,
 }
 ```
+
+## Generic `SimpleObject`s
+
+If you want to reuse an `SimpleObject` for other types, you can define a generic SimpleObject
+and specify how its concrete types should be implemented.
+
+In the following example, two `SimpleObject` types are created:
+
+```rust
+#[derive(SimpleObject)]
+#[graphql(concrete(name = "SomeName", params(SomeType)))]
+#[graphql(concrete(name = "SomeOtherName", params(SomeOtherType)))]
+pub struct SomeGenericObject<T: OutputType> {
+    field1: Option<T>,
+    field2: String
+}
+```
+
+Note: Each generic parameter must implement `OutputType`, as shown above.
+
+The schema generated is:
+
+```gql
+type SomeName {
+  field1: SomeType
+  field2: String!
+}
+
+type SomeOtherName {
+  field1: SomeOtherType
+  field2: String!
+}
+```
+
+In your resolver method or field of another object, use as a normal generic type:
+
+```rust
+#[derive(SimpleObject)]
+pub struct YetAnotherObject {
+    a: SomeGenericObject<SomeType>,
+    b: SomeGenericObject<SomeOtherType>,
+}
+```
+
+You can pass multiple generic types to `params()`, separated by a comma.


### PR DESCRIPTION
Adds a section on implementing generic `SimpleObject` + `InputObject`.