### PR TITLE
Add Note About Using Same Struct for In/Out

### DIFF
--- a/docs/en/src/define_input_object.md
+++ b/docs/en/src/define_input_object.md
@@ -27,6 +27,37 @@ impl Mutation {
 }
 ```
 
+## Using the Same Struct for `InputObject`s and `SimpleObject`s
+
+It is not currently possible to derive `InputObject` and `SimpleObject` on the same struct ( see [#149] ). In some cases, though, it may be desireable to use the same Rust struct to represent both the input and output types. In this case you can use the [`Json`] struct as a wrapper for the input type, and then derive `SimpleObject` on the output type like normal. For instance:
+
+```rust
+#[derive(SimpleObject)]
+struct Coordinate {
+    latitude: f64,
+    longitude: f64
+}
+
+struct Mutation;
+
+#[Object]
+impl Mutation {
+    async fn add_coordinate(&self, coordinate: Json<Coordinate>) -> Coordinate {
+        // Writes coordination to database.
+        // ...
+        
+        // Returns coordinate
+    }
+}
+```
+
+The disadvantage of this technique is that the input will not be statically typed in the GraphQL schema. The input type of the mutation in this instance would simply show the type `JSON` instead of outlining all of the fields that are accepted by the input. Note that errors _will_ still be reported when running the mutation if the input does not match the Rust structure.
+
+This limitation should be removed in a future release making this workaround unnecessary.
+
+[`Json`]: https://docs.rs/async-graphql/latest/async_graphql/types/struct.Json.html
+[#149]: https://github.com/async-graphql/async-graphql/issues/149
+
 ## Generic `InputObject`s
 
 If you want to reuse an `InputObject` for other types, you can define a generic InputObject


### PR DESCRIPTION
Added some documentation to the book that covers a workaround for #149.