### PR TITLE
Update apollo_tracing.md

### DIFF
--- a/docs/en/src/apollo_tracing.md
+++ b/docs/en/src/apollo_tracing.md
@@ -9,6 +9,6 @@ use async_graphql::*;
 use async_graphql::extensions::ApolloTracing;
 
 let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
-    .extension(ApolloTracing::default) // Enable ApolloTracing extension
+    .extension(ApolloTracing) // Enable ApolloTracing extension
     .finish();
 ```

--- a/docs/zh-CN/src/apollo_tracing.md
+++ b/docs/zh-CN/src/apollo_tracing.md
@@ -9,7 +9,7 @@ use async_graphql::*;
 use async_graphql::extensions::ApolloTracing;
 
 let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
-    .extension(|| ApolloTracing::default()) // 启用ApolloTracing扩展
+    .extension(ApolloTracing) // 启用ApolloTracing扩展
     .finish();
 
 ```


### PR DESCRIPTION
`SchemaBuilder::extension` no longer takes a closure as an argument.