### PR TITLE
Support generics in Subscription types

### DIFF
--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -20,6 +20,8 @@ pub fn generate(
 ) -> GeneratorResult<TokenStream> {
     let crate_name = get_crate_name(subscription_args.internal);
     let (self_ty, self_name) = get_type_path_and_name(item_impl.self_ty.as_ref())?;
+    let generics = &item_impl.generics;
+    let where_clause = &item_impl.generics.where_clause;
     let extends = subscription_args.extends;
 
     let gql_typename = subscription_args
@@ -426,7 +428,7 @@ pub fn generate(
         #item_impl
 
         #[allow(clippy::all, clippy::pedantic)]
-        impl #crate_name::Type for #self_ty {
+        impl #generics #crate_name::Type for #self_ty #where_clause {
             fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                 ::std::borrow::Cow::Borrowed(#gql_typename)
             }
@@ -451,7 +453,7 @@ pub fn generate(
 
         #[allow(clippy::all, clippy::pedantic)]
         #[allow(unused_braces, unused_variables)]
-        impl #crate_name::SubscriptionType for #self_ty {
+        impl #generics #crate_name::SubscriptionType for #self_ty #where_clause {
             fn create_field_stream<'__life>(
                 &'__life self,
                 ctx: &'__life #crate_name::Context<'_>,


### PR DESCRIPTION
Currently, defining a `Subscription` that contains generics causes errors.

```rust
struct MySubscription<T> {
    // ...
}

#[Subscription]
impl<T: OutputType + Type> MySubscription<T>
where
    T: Clone + Send + Sync + Unpin,
{
    async fn values(&self) -> Result<impl Stream<Item = T> + '_> {
        // ...
    }
}
```

```text
error[E0412]: cannot find type `T` in this scope
   --> tests/generic_types.rs:261:47
    |
261 |     impl<T: OutputType + Type> MySubscription<T>
    |                                               ^ not found in this scope
```

