### PR TITLE
Update subscription.md

### DIFF
--- a/docs/en/src/subscription.md
+++ b/docs/en/src/subscription.md
@@ -11,12 +11,13 @@ struct Subscription;
 
 #[Subscription]
 impl Subscription {
-    async fn integers(&self, #[graphql(default = "1")] step: i32) -> impl Stream<Item = i32> {
+    async fn integers(&self, #[graphql(default = 1)] step: i32) -> impl Stream<Item = i32> {
         let mut value = 0;
-        tokio::time::interval(Duration::from_secs(1)).map(move |_| {
-            value += step;
-            value
-        })
+        tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(Duration::from_secs(1)))
+            .map(move |_| {
+                value += step;
+                value
+            })
     }
 }
 ```

--- a/docs/zh-CN/src/subscription.md
+++ b/docs/zh-CN/src/subscription.md
@@ -11,12 +11,13 @@ struct Subscription;
 
 #[Subscription]
 impl Subscription {
-    async fn integers(&self, #[graphql(default = "1")] step: i32) -> impl Stream<Item = i32> {
+    async fn integers(&self, #[graphql(default = 1)] step: i32) -> impl Stream<Item = i32> {
         let mut value = 0;
-        tokio::time::interval(Duration::from_secs(1)).map(move |_| {
-            value += step;
-            value
-        })
+        tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(Duration::from_secs(1)))
+            .map(move |_| {
+                value += step;
+                value
+            })
     }
 }
 ```


### PR DESCRIPTION
The current example cannot be compiled with the latest async-graphql and tokio because:

- `#[graphql(default)]` on integer types accepts only integer literals.
  ```text
   error[E0308]: mismatched types
     --> src/main.rs:5:5
      |
  5   |     #[Subscription]
      |     ^^^^^^^^^^^^^^^ expected `i32`, found struct `std::string::String`
      |
   ```
- In tokio 1, [stream impls are moved to tokio_stream crate](https://docs.rs/tokio/1.2.0/tokio/stream/index.html#why-was-stream-not-included-in-tokio-10).
  ```text
  error[E0599]: the method `map` exists for struct `Interval`, but its trait bounds were not satisfied
     --> src/main.rs:13:72
      |
  13  |             tokio::time::interval(tokio::time::Duration::from_secs(1)).map(move |_| {
      |                                                                        ^^^ method cannot be called on `Interval` due to unsatisfied trait bounds
      |
   ```