### PR TITLE
Prevent Warp WS Close, Ping, and Pong messages from being parsed as GraphQL

### DIFF
--- a/integrations/warp/src/subscription.rs
+++ b/integrations/warp/src/subscription.rs
@@ -100,6 +100,9 @@ where
                         ws_receiver
                             .take_while(|msg| future::ready(msg.is_ok()))
                             .map(Result::unwrap)
+                            .filter(|msg | {
+                                future::ready(msg.is_text() || msg.is_binary())
+                            })
                             .map(ws::Message::into_bytes),
                         initializer,
                         protocol,

--- a/integrations/warp/src/subscription.rs
+++ b/integrations/warp/src/subscription.rs
@@ -100,9 +100,7 @@ where
                         ws_receiver
                             .take_while(|msg| future::ready(msg.is_ok()))
                             .map(Result::unwrap)
-                            .filter(|msg | {
-                                future::ready(msg.is_text() || msg.is_binary())
-                            })
+                            .filter(|msg| future::ready(msg.is_text() || msg.is_binary()))
                             .map(ws::Message::into_bytes),
                         initializer,
                         protocol,


### PR DESCRIPTION
This allows Web Socket clients to send pings to the Warp server in order to keep long lived connections alive.

Pings are supported by and automatically responded to by Tungstenite: https://docs.rs/tungstenite/0.13.0/tungstenite/enum.Message.html#variant.Ping