### PR TITLE
Add minimum rust version support in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - { rust: stable, os: ubuntu-latest }
-          - { rust: 1.50.0, os: ubuntu-latest }
+          - { rust: 1.51.0, os: ubuntu-latest }
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,15 @@ on:
       - master
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  tests:
+    name: Run tests - Rust (${{ matrix.rust }}) on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { rust: stable, os: ubuntu-latest }
+          - { rust: 1.49.0, os: ubuntu-latest }
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -18,7 +25,7 @@ jobs:
           submodules: true
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
           components: clippy, rustfmt
       - name: Check format
@@ -34,7 +41,24 @@ jobs:
       - name: Clean
         run: cargo clean
 
-      # examples
+  examples:
+    name: Build examples - Rust (${{ matrix.rust }}) on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { rust: stable, os: ubuntu-latest }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: clippy, rustfmt
       - name: Check examples format
         run: cargo fmt --all -- --check
         working-directory: ./examples
@@ -48,10 +72,22 @@ jobs:
         run: cargo clean
         working-directory: ./examples
 
-      # build on nightly
+  build-nightly:
+    name: Build nightly - Rust (${{ matrix.rust }}) on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { rust: nightly, os: ubuntu-latest }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ matrix.rust }}
           override: true
           components: clippy, rustfmt
       - name: Build on nightly with all features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - { rust: stable, os: ubuntu-latest }
-          - { rust: 1.51.0, os: ubuntu-latest }
+          - { rust: 1.49.0, os: ubuntu-latest }
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -27,11 +27,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-          components: clippy, rustfmt
-      - name: Check format
-        run: cargo fmt --all -- --check
-      - name: Check with clippy
-        run: cargo clippy --all
       - name: Build with all features
         run: cargo build --all-features
       - name: Build
@@ -40,6 +35,48 @@ jobs:
         run: cargo test --all --all-features
       - name: Clean
         run: cargo clean
+
+  rustfmt:
+    name: Run rustfmt - Rust (${{ matrix.rust }}) on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { rust: stable, os: ubuntu-latest }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt
+      - name: Check format
+        run: cargo fmt --all -- --check
+
+  clippy:
+    name: Run clippy - Rust (${{ matrix.rust }}) on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { rust: stable, os: ubuntu-latest }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: clippy
+      - name: Check with clippy
+        run: cargo clippy --all
 
   examples:
     name: Build examples - Rust (${{ matrix.rust }}) on ${{ matrix.os }}
@@ -89,7 +126,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-          components: clippy, rustfmt
       - name: Build on nightly with all features
         run: cargo build --all-features
       - name: Build on nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - { rust: stable, os: ubuntu-latest }
-          - { rust: 1.49.0, os: ubuntu-latest }
+          - { rust: 1.50.0, os: ubuntu-latest }
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 * [Docs](https://docs.rs/async-graphql)
 * [GitHub repository](https://github.com/async-graphql/async-graphql)
 * [Cargo package](https://crates.io/crates/async-graphql)
-* Minimum supported Rust version: 1.49.0 or later
+* Minimum supported Rust version: 1.50.0 or later
 
 ## Safety
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 * [Docs](https://docs.rs/async-graphql)
 * [GitHub repository](https://github.com/async-graphql/async-graphql)
 * [Cargo package](https://crates.io/crates/async-graphql)
-* Minimum supported Rust version: 1.51.0 or later
+* Minimum supported Rust version: 1.49.0 or later
 
 ## Safety
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 * [Docs](https://docs.rs/async-graphql)
 * [GitHub repository](https://github.com/async-graphql/async-graphql)
 * [Cargo package](https://crates.io/crates/async-graphql)
-* Minimum supported Rust version: 1.50.0 or later
+* Minimum supported Rust version: 1.51.0 or later
 
 ## Safety
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 * [Docs](https://docs.rs/async-graphql)
 * [GitHub repository](https://github.com/async-graphql/async-graphql)
 * [Cargo package](https://crates.io/crates/async-graphql)
-* Minimum supported Rust version: 1.46 or later
+* Minimum supported Rust version: 1.49.0 or later
 
 ## Safety
 


### PR DESCRIPTION
Resolves #468 by adding tests for the minimum version of Rust that async graphql supports.