### PR TITLE
Document SDL schema export in the book

### DIFF
--- a/docs/en/src/SUMMARY.md
+++ b/docs/en/src/SUMMARY.md
@@ -16,6 +16,7 @@
 - [Schema](define_schema.md)
     - [Query and Mutation](query_and_mutation.md)
     - [Subscription](subscription.md)
+    - [SDL Export](sdl_export.md)
 - [Utilities](utilities.md)
     - [Field guard](field_guard.md)
     - [Input value validators](input_value_validators.md)

--- a/docs/en/src/sdl_export.md
+++ b/docs/en/src/sdl_export.md
@@ -1,0 +1,25 @@
+# SDL Export
+
+You can export your schema in Schema Definition Language (SDL) by using the `Schema::sdl()` method.
+
+
+```rust
+use async_graphql::*;
+
+struct Query;
+
+#[Object]
+impl Query {
+    async fn add(&self, u: i32, v: i32) -> i32 {
+        u + v
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let schema = Schema::build(Query, EmptyMutation, EmptySubscription).finish();
+    
+    // Print the schema in SDL format
+    println!("{}", &schema.sdl());
+}
+```


### PR DESCRIPTION
This pull request adds an example to the book of how the code-first schema can be exported as SDL.

I was looking for a way to export the schema as SDL and it took me some time to find out how it's done, because this feature is mentioned nowhere in the docs.
