### PR TITLE
add missing fonts to http::playground_source's html

### DIFF
--- a/src/http/playground_source.rs
+++ b/src/http/playground_source.rs
@@ -24,7 +24,7 @@ pub fn playground_source(config: GraphQLPlaygroundConfig) -> String {
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
   <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
   <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
-
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Source+Code+Pro:400,700" />
 </head>
 
 <body>


### PR DESCRIPTION
Hi. Thanks for creating this library. I was playing around with it and found the typography a bit off in the playground. Turned out the playground was using a font that was not being included by the code in this crate.