### PR TITLE
Add link to license files

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ cd examples && cargo run --bin [name]
 Licensed under either of
 
 * Apache License, Version 2.0,
-  (./LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
-* MIT license (./LICENSE-MIT or http://opensource.org/licenses/MIT)
+  ([LICENSE-APACHE](./LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](./LICENSE-MIT) or http://opensource.org/licenses/MIT)
   at your option.
 
 ## References


### PR DESCRIPTION
A small request, but I think it's a bit awkward to have the path to the license files in `README.md` but not have them clickable. This commit adds links to the licenses.