### PR TITLE
feat: Add secrecy crate feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ bson = { version = "1.2.0", optional = true }
 chrono = { version = "0.4.19", optional = true }
 chrono-tz = { version = "0.5.3", optional = true }
 log = { version = "0.4.14", optional = true }
+secrecy = { version = "0.7.0", optional = true }
 tracinglib = { version = "0.1.25", optional = true, package = "tracing" }
 tracing-futures = { version = "0.2.5", optional = true, features = ["std-future", "futures-03"] }
 opentelemetry = { version = "0.13.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This crate offers the following features, all of which are not activated by defa
 - `uuid`: Integrate with the [`uuid` crate](https://crates.io/crates/uuid).
 - `string_number`: Enable the [StringNumber](types/struct.StringNumber.html).
 - `dataloader`: Support [DataLoader](dataloader/struct.DataLoader.html).
+- `secrecy`: Integrate with the [`secrecy` crate](https://crates.io/crates/secrecy).
 
 ## Examples
 

--- a/src/types/external/mod.rs
+++ b/src/types/external/mod.rs
@@ -19,6 +19,8 @@ mod chrono_tz;
 mod datetime;
 #[cfg(feature = "chrono")]
 mod naive_time;
+#[cfg(feature = "secrecy")]
+mod secrecy;
 #[cfg(feature = "url")]
 mod url;
 #[cfg(feature = "uuid")]

--- a/src/types/external/secrecy.rs
+++ b/src/types/external/secrecy.rs
@@ -1,0 +1,29 @@
+use std::borrow::Cow;
+
+use secrecy::{Secret, Zeroize};
+
+use crate::{registry, InputType, InputValueResult, Type, Value, InputValueError};
+
+impl<T: Type + Zeroize> Type for Secret<T> {
+    fn type_name() -> Cow<'static, str> {
+        T::type_name()
+    }
+
+    fn qualified_type_name() -> String {
+        T::qualified_type_name()
+    }
+
+    fn create_type_info(registry: &mut registry::Registry) -> String {
+        T::create_type_info(registry)
+    }
+}
+
+impl<T: InputType + Zeroize> InputType for Secret<T> {
+    fn parse(value: Option<Value>) -> InputValueResult<Self> {
+        T::parse(value).map(Secret::new).map_err(InputValueError::propagate)
+    }
+
+    fn to_value(&self) -> Value {
+        Value::Null
+    }
+}


### PR DESCRIPTION
Hey 👋 

This PR adds the ability to use `Secret<T>` from the [`secrecy` crate](https://crates.io/crates/secrecy) for `InputType`.

Example:

```rust
/// The user's login credentials.
#[derive(Debug, InputObject)]
struct UserLogin {
    /// The user's email address
    email_address: String,

    /// The user's password.
    password: Secret<String>,
}
```