### PR TITLE
Allow the ability to set GraphQL Playground settings

### DIFF
--- a/src/http/playground_source.rs
+++ b/src/http/playground_source.rs
@@ -596,15 +596,15 @@ impl<'a> GraphQLPlaygroundConfig<'a> {
         self
     }
 
-     /// Set Playground setting for per query.
-     pub fn with_setting(mut self, name: &'a str, value: &'a str) -> Self {
-      if let Some(settings) = &mut self.settings {
-        settings.insert(name, value);
-      } else {
-          let mut settings = HashMap::new();
-          settings.insert(name, value);
-          self.settings = Some(settings);
-      }
-      self
-  }
+    /// Set Playground setting for per query.
+    pub fn with_setting(mut self, name: &'a str, value: &'a str) -> Self {
+        if let Some(settings) = &mut self.settings {
+            settings.insert(name, value);
+        } else {
+            let mut settings = HashMap::new();
+            settings.insert(name, value);
+            self.settings = Some(settings);
+        }
+        self
+    }
 }

--- a/src/http/playground_source.rs
+++ b/src/http/playground_source.rs
@@ -564,6 +564,7 @@ pub struct GraphQLPlaygroundConfig<'a> {
     endpoint: &'a str,
     subscription_endpoint: Option<&'a str>,
     headers: Option<HashMap<&'a str, &'a str>>,
+    settings: Option<HashMap<&'a str, &'a str>>,
 }
 
 impl<'a> GraphQLPlaygroundConfig<'a> {
@@ -573,6 +574,7 @@ impl<'a> GraphQLPlaygroundConfig<'a> {
             endpoint,
             subscription_endpoint: None,
             headers: Default::default(),
+            settings: Default::default(),
         }
     }
 
@@ -593,4 +595,16 @@ impl<'a> GraphQLPlaygroundConfig<'a> {
         }
         self
     }
+
+     /// Set Playground setting for per query.
+     pub fn with_setting(mut self, name: &'a str, value: &'a str) -> Self {
+      if let Some(settings) = &mut self.settings {
+        settings.insert(name, value);
+      } else {
+          let mut settings = HashMap::new();
+          settings.insert(name, value);
+          self.settings = Some(settings);
+      }
+      self
+  }
 }


### PR DESCRIPTION
In the GraphQL Playground UI, you can configure settings. This PR allows a default set of settings to be defined server-side similar to the default headers option that already exists in this package.

An example use case of this feature is setting the `request.credentials` setting to `include` or `same-site` instead of its default value `omit`. This allows cookies to be manipulated in the GraphQL request.