### PR TITLE
fix: call instrument span later

### DIFF
--- a/src/extensions/tracing.rs
+++ b/src/extensions/tracing.rs
@@ -137,11 +137,11 @@ impl Extension for TracingExtension {
             return_type = %info.return_type,
         );
         next.run(ctx, info)
-            .instrument(span)
             .map_err(|err| {
                 tracinglib::error!(target: "async_graphql::graphql", error = %err.message);
                 err
             })
+            .instrument(span)
             .await
     }
 }


### PR DESCRIPTION
the instrument span won't apply to `map_err` in current code.