### PR TITLE
WebSocket is now generic in graphql_subscription_upgrade functions.

### DIFF
--- a/integrations/warp/src/subscription.rs
+++ b/integrations/warp/src/subscription.rs
@@ -193,7 +193,7 @@ pub async fn graphql_subscription_upgrade_with_data<Query, Mutation, Subscriptio
     Query: ObjectType + 'static,
     Mutation: ObjectType + 'static,
     Subscription: SubscriptionType + 'static,
-    F: FnOnce(serde_json::Value) -> R + Clone + Send + 'static,
+    F: FnOnce(serde_json::Value) -> R + Send + 'static,
     R: Future<Output = Result<Data>> + Send + 'static,
     S: futures_util::Stream<Item = Result<warp::ws::Message, warp::Error>>
         + futures_util::Sink<warp::ws::Message>,

--- a/integrations/warp/src/subscription.rs
+++ b/integrations/warp/src/subscription.rs
@@ -172,7 +172,8 @@ pub async fn graphql_subscription_upgrade<Query, Mutation, Subscription, S>(
     Query: ObjectType + 'static,
     Mutation: ObjectType + 'static,
     Subscription: SubscriptionType + 'static,
-    S: futures_util::Stream<Item = Result<warp::ws::Message, warp::Error>> + futures_util::Sink<warp::ws::Message>,
+    S: futures_util::Stream<Item = Result<warp::ws::Message, warp::Error>>
+        + futures_util::Sink<warp::ws::Message>,
 {
     graphql_subscription_upgrade_with_data(websocket, protocol, schema, |_| async {
         Ok(Default::default())
@@ -194,7 +195,8 @@ pub async fn graphql_subscription_upgrade_with_data<Query, Mutation, Subscriptio
     Subscription: SubscriptionType + 'static,
     F: FnOnce(serde_json::Value) -> R + Clone + Send + 'static,
     R: Future<Output = Result<Data>> + Send + 'static,
-    S: futures_util::Stream<Item = Result<warp::ws::Message, warp::Error>> + futures_util::Sink<warp::ws::Message>,
+    S: futures_util::Stream<Item = Result<warp::ws::Message, warp::Error>>
+        + futures_util::Sink<warp::ws::Message>,
 {
     let (ws_sender, ws_receiver) = websocket.split();
     let _ = async_graphql::http::WebSocket::with_data(


### PR DESCRIPTION
This change needed for writing wrappers around `WebSocket`.