### PR TITLE
Added graphql_subscription_upgrade_with_data_sink.

### DIFF
--- a/integrations/warp/src/lib.rs
+++ b/integrations/warp/src/lib.rs
@@ -13,5 +13,6 @@ pub use error::BadRequest;
 pub use request::{graphql, graphql_opts, Response};
 pub use subscription::{
     graphql_protocol, graphql_subscription, graphql_subscription_upgrade,
-    graphql_subscription_upgrade_with_data, graphql_subscription_with_data,
+    graphql_subscription_upgrade_with_data, graphql_subscription_upgrade_with_data_sink,
+    graphql_subscription_with_data,
 };

--- a/integrations/warp/src/subscription.rs
+++ b/integrations/warp/src/subscription.rs
@@ -209,7 +209,15 @@ pub async fn graphql_subscription_upgrade_with_data<Query, Mutation, Subscriptio
     .await;
 }
 
-pub async fn graphql_subscription_upgrade_with_data_sink<Query, Mutation, Subscription, F, R, SenderSink, ReceiverStream>(
+pub async fn graphql_subscription_upgrade_with_data_sink<
+    Query,
+    Mutation,
+    Subscription,
+    F,
+    R,
+    SenderSink,
+    ReceiverStream,
+>(
     ws_sender: SenderSink,
     ws_receiver: ReceiverStream,
     protocol: WebSocketProtocols,


### PR DESCRIPTION
Greetings!

I'm suggesting adding such function. With this function we can do things like this:
```rust
                    let (sender_wrapper, receiver_wrapper) = futures_channel::mpsc::channel(10);
                    let (ws_sender, ws_receiver) = websocket.split();
                    let wrapper = receiver_wrapper.map(Ok).forward(ws_sender);

                    tokio::task::spawn({
                        let mut sender_wrapper = sender_wrapper.clone();
                        async move {
                            futures_timer::Delay::new(std::time::Duration::from_secs(5)).await;
                            sender_wrapper.send(warp::ws::Message::close_with(
                                1002 as u16,
                                "token expiration",
                            ));
                        }
                    });

                    let gql = graphql_subscription_upgrade_with_data_sink(
                        sender_wrapper,
                        ws_receiver,
<...>
                    let _res = join!(wrapper, gql);
```

Fixes #513 