### PR TITLE
Add Decimal scalar (from 'rust_decimal' crate)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ unblock = ["blocking"]
 string_number = ["num-traits"]
 dataloader = ["futures-timer", "futures-channel", "lru"]
 tracing = ["tracinglib", "tracing-futures"]
+decimal = ["rust_decimal"]
 
 [dependencies]
 async-graphql-derive = { path = "derive", version = "=2.9.5" }
@@ -53,6 +54,7 @@ tracing-futures = { version = "0.2.5", optional = true, features = ["std-future"
 opentelemetry = { version = "0.13.0", optional = true }
 url = { version = "2.2.1", optional = true }
 uuid = { version = "0.8.2", optional = true, features = ["v4", "serde"] }
+rust_decimal = { version = "1.14.3", optional = true }
 
 # Non-feature optional dependencies
 blocking = { version = "1.0.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This crate offers the following features, all of which are not activated by defa
 - `string_number`: Enable the [StringNumber](types/struct.StringNumber.html).
 - `dataloader`: Support [DataLoader](dataloader/struct.DataLoader.html).
 - `secrecy`: Integrate with the [`secrecy` crate](https://crates.io/crates/secrecy).
+- `decimal`: Integrate with the [`rust_decimal` crate](https://crates.io/crates/rust_decimal).
 
 ## Examples
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@
 //! - `uuid`: Integrate with the [`uuid` crate](https://crates.io/crates/uuid).
 //! - `string_number`: Enable the [StringNumber](types/struct.StringNumber.html).
 //! - `dataloader`: Support [DataLoader](dataloader/struct.DataLoader.html).
+//! - `decimal`: Integrate with the [`rust_decimal` crate](https://crates.io/crates/rust_decimal).
 //!
 //! ## Integrations
 //!

--- a/src/types/external/decimal.rs
+++ b/src/types/external/decimal.rs
@@ -1,0 +1,19 @@
+use std::str::FromStr;
+
+use rust_decimal::Decimal;
+
+use crate::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
+
+#[Scalar(internal, name = "Decimal")]
+impl ScalarType for Decimal {
+    fn parse(value: Value) -> InputValueResult<Self> {
+        match &value {
+            Value::String(s) => Ok(Decimal::from_str(s)?),
+            _ => Err(InputValueError::expected_type(value)),
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        Value::String(self.to_string())
+    }
+}

--- a/src/types/external/mod.rs
+++ b/src/types/external/mod.rs
@@ -17,6 +17,8 @@ mod bson;
 mod chrono_tz;
 #[cfg(feature = "chrono")]
 mod datetime;
+#[cfg(feature = "decimal")]
+mod decimal;
 #[cfg(feature = "chrono")]
 mod naive_time;
 #[cfg(feature = "secrecy")]


### PR DESCRIPTION
When your application has to deal with financials (i.e. billing/accounting/invoicing) you often need to deal with decimals.
Needed it for my use case so thought a `decimal` feature will be handy.

I prefer it being supported by `async-graphql` natively.  sqlx supports a similar feature, meaning I can conveniently query decimals from my DB and serve it through graphql api directly without needing a custom newtype and scalar.