### PR TITLE
Remove outdated documentation regarding subscriptions in Tide

### DIFF
--- a/integrations/tide/src/lib.rs
+++ b/integrations/tide/src/lib.rs
@@ -1,8 +1,5 @@
 //! Async-graphql integration with Tide
 //!
-//! Tide [does not support websockets](https://github.com/http-rs/tide/issues/67), so you can't use
-//! subscriptions with it.
-//!
 //! # Examples
 //! *[Full Example](<https://github.com/async-graphql/examples/blob/master/tide/starwars/src/main.rs>)*
 


### PR DESCRIPTION
The Tide integration documentation still said that subscriptions are not supported due to missing websocket support in Tide. As subscriptions are supported by now, this note seems outdated and misleading.