### PR TITLE
#550: macros fixes for generic Context

### DIFF
--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -28,6 +28,7 @@ pub fn generate(
             let method_args: args::ObjectField =
                 parse_graphql_attrs(&method.attrs)?.unwrap_or_default();
             if method_args.skip {
+                remove_graphql_attrs(&mut method.attrs);
                 continue;
             }
 

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -18,7 +18,6 @@ pub fn generate(
     let crate_name = get_crate_name(object_args.internal);
     let (self_ty, _) = get_type_path_and_name(item_impl.self_ty.as_ref())?;
     let generics = &item_impl.generics;
-    let generics_params = &generics.params;
     let where_clause = &item_impl.generics.where_clause;
 
     let mut resolvers = Vec::new();
@@ -286,7 +285,7 @@ pub fn generate(
 
         #[allow(clippy::all, clippy::pedantic)]
         #[#crate_name::async_trait::async_trait]
-        impl #generics #crate_name::ComplexObject for #self_ty#generics_params #where_clause {
+        impl #generics #crate_name::ComplexObject for #self_ty #where_clause {
             fn fields(registry: &mut #crate_name::registry::Registry) -> ::std::vec::Vec<(::std::string::String, #crate_name::registry::MetaField)> {
                 let mut fields = ::std::vec::Vec::new();
                 #(#schema_fields)*

--- a/tests/complex_object.rs
+++ b/tests/complex_object.rs
@@ -66,7 +66,6 @@ pub async fn test_complex_object() {
     );
 }
 
-
 #[tokio::test]
 pub async fn test_complex_object_with_generic_context_data() {
     trait MyData: Send + Sync {
@@ -76,7 +75,9 @@ pub async fn test_complex_object_with_generic_context_data() {
     struct DefaultMyData {}
 
     impl MyData for DefaultMyData {
-        fn answer(&self) -> i64 { 42 }
+        fn answer(&self) -> i64 {
+            42
+        }
     }
 
     struct MyQuery<D: MyData> {
@@ -84,10 +85,15 @@ pub async fn test_complex_object_with_generic_context_data() {
     }
 
     #[Object]
-    impl<D> MyQuery<D> where D: 'static + MyData {
+    impl<D> MyQuery<D>
+    where
+        D: 'static + MyData,
+    {
         #[graphql(skip)]
         pub fn new() -> Self {
-            Self { marker: PhantomData }
+            Self {
+                marker: PhantomData,
+            }
         }
 
         async fn obj(&self, ctx: &Context<'_>) -> MyObject<D> {
@@ -107,19 +113,189 @@ pub async fn test_complex_object_with_generic_context_data() {
     impl<D: MyData> MyObject<D> {
         #[graphql(skip)]
         pub fn new(my_val: i64) -> Self {
-            Self { my_val, marker: PhantomData }
+            Self {
+                my_val,
+                marker: PhantomData,
+            }
         }
     }
 
-    let schema = Schema::build(MyQuery::<DefaultMyData>::new(), EmptyMutation, EmptySubscription)
-        .data(DefaultMyData {})
-        .finish();
+    let schema = Schema::build(
+        MyQuery::<DefaultMyData>::new(),
+        EmptyMutation,
+        EmptySubscription,
+    )
+    .data(DefaultMyData {})
+    .finish();
 
     assert_eq!(
         schema.execute("{ obj { myVal } }").await.data,
         value!({
             "obj": {
                 "myVal": 42,
+            }
+        })
+    );
+}
+
+#[tokio::test]
+pub async fn test_complex_object_with_generic_concrete_type() {
+    #[derive(SimpleObject)]
+    #[graphql(concrete(name = "MyObjIntString", params(i32, String)))]
+    #[graphql(concrete(name = "MyObji64f32", params(i64, u8)))]
+    #[graphql(complex)]
+    struct MyObj<A: OutputType, B: OutputType> {
+        a: A,
+        b: B,
+    }
+
+    #[ComplexObject]
+    impl MyObj<i32, String> {
+        async fn value_a(&self) -> String {
+            format!("i32,String {},{}", self.a, self.b)
+        }
+    }
+
+    #[ComplexObject]
+    impl MyObj<i64, u8> {
+        async fn value_b(&self) -> String {
+            format!("i64,u8 {},{}", self.a, self.b)
+        }
+    }
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn q1(&self) -> MyObj<i32, String> {
+            MyObj {
+                a: 100,
+                b: "abc".to_string(),
+            }
+        }
+
+        async fn q2(&self) -> MyObj<i64, u8> {
+            MyObj { a: 100, b: 28 }
+        }
+    }
+
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+    let query = "{ q1 { a b valueA } q2 { a b valueB } }";
+    assert_eq!(
+        schema.execute(query).await.into_result().unwrap().data,
+        value!({
+            "q1": {
+                "a": 100,
+                "b": "abc",
+                "valueA": "i32,String 100,abc",
+            },
+            "q2": {
+                "a": 100,
+                "b": 28,
+                "valueB": "i64,u8 100,28",
+            }
+        })
+    );
+
+    assert_eq!(
+        schema
+            .execute(r#"{ __type(name: "MyObjIntString") { fields { name type { kind ofType { name } } } } }"#)
+            .await
+            .into_result()
+            .unwrap()
+            .data,
+        value!({
+            "__type": {
+                "fields": [
+                    {
+                        "name": "a",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "ofType": { "name": "Int" },
+                        },
+                    },
+                    {
+                        "name": "b",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "ofType": { "name": "String" },
+                        },
+                    },
+                    {
+                        "name": "valueA",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "ofType": { "name": "String" },
+                        },
+                    },
+                ]
+            }
+        })
+    );
+
+    assert_eq!(
+        schema
+            .execute(r#"{ __type(name: "MyObji64f32") { fields { name type { kind ofType { name } } } } }"#)
+            .await
+            .into_result()
+            .unwrap()
+            .data,
+        value!({
+            "__type": {
+                "fields": [
+                    {
+                        "name": "a",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "ofType": { "name": "Int" },
+                        },
+                    },
+                    {
+                        "name": "b",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "ofType": { "name": "Int" },
+                        },
+                    },
+                    {
+                        "name": "valueB",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "ofType": { "name": "String" },
+                        },
+                    },
+                ]
+            }
+        })
+    );
+
+    assert_eq!(
+        schema
+            .execute(
+                r#"{ __type(name: "Query") { fields { name type { kind ofType { name } } } } }"#
+            )
+            .await
+            .into_result()
+            .unwrap()
+            .data,
+        value!({
+            "__type": {
+                "fields": [
+                    {
+                        "name": "q1",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "ofType": { "name": "MyObjIntString" },
+                        },
+                    },
+                    {
+                        "name": "q2",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "ofType": { "name": "MyObji64f32" },
+                        },
+                    },
+                ]
             }
         })
     );


### PR DESCRIPTION
This fixes 2 small bugs in `ComplexObject` to allow generic typing of `Context` data. See unit test for example.

Fixes #550