### PR TITLE
Feature: Add Error with Extension in Validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.8] 2021-07-09
+
+- Add Extensions in Error of `InputValueValidator`. [#564](https://github.com/async-graphql/async-graphql/pull/564)
+
 ## [2.9.7] 2021-07-04
 
 - Add support for generic `ComplexObject`. [#562](https://github.com/async-graphql/async-graphql/pull/562)

--- a/src/validation/rules/arguments_of_correct_type.rs
+++ b/src/validation/rules/arguments_of_correct_type.rs
@@ -58,9 +58,10 @@ impl<'a> Visitor<'a> for ArgumentsOfCorrectType<'a> {
             if let Some(validator) = &arg.validator {
                 if let Some(value) = &value {
                     if let Err(reason) = validator.is_valid(value) {
-                        ctx.report_error(
+                        ctx.report_error_with_extensions(
                             vec![name.pos],
                             format!("Invalid value for argument \"{}\", {}", arg.name, reason),
+                            None,
                         );
                         return;
                     }

--- a/src/validation/rules/arguments_of_correct_type.rs
+++ b/src/validation/rules/arguments_of_correct_type.rs
@@ -57,11 +57,11 @@ impl<'a> Visitor<'a> for ArgumentsOfCorrectType<'a> {
 
             if let Some(validator) = &arg.validator {
                 if let Some(value) = &value {
-                    if let Err(reason) = validator.is_valid(value) {
+                    if let Err(e) = validator.is_valid_with_extensions(value) {
                         ctx.report_error_with_extensions(
                             vec![name.pos],
-                            format!("Invalid value for argument \"{}\", {}", arg.name, reason),
-                            None,
+                            format!("Invalid value for argument \"{}\", {}", arg.name, e.message),
+                            e.extensions,
                         );
                         return;
                     }

--- a/src/validation/rules/arguments_of_correct_type.rs
+++ b/src/validation/rules/arguments_of_correct_type.rs
@@ -68,7 +68,7 @@ impl<'a> Visitor<'a> for ArgumentsOfCorrectType<'a> {
                 }
             }
 
-            if let Some(reason) = value.and_then(|value| {
+            if let Some(e) = value.and_then(|value| {
                 is_valid_input_value(
                     ctx.registry,
                     &arg.ty,
@@ -79,9 +79,10 @@ impl<'a> Visitor<'a> for ArgumentsOfCorrectType<'a> {
                     },
                 )
             }) {
-                ctx.report_error(
+                ctx.report_error_with_extensions(
                     vec![name.pos],
-                    format!("Invalid value for argument {}", reason),
+                    format!("Invalid value for argument {}", e.message),
+                    e.extensions,
                 );
             }
         }

--- a/src/validation/rules/default_values_of_correct_type.rs
+++ b/src/validation/rules/default_values_of_correct_type.rs
@@ -18,7 +18,7 @@ impl<'a> Visitor<'a> for DefaultValuesOfCorrectType {
                     "Argument \"{}\" has type \"{}\" and is not nullable, so it can't have a default value",
                     variable_definition.node.name, variable_definition.node.var_type,
                 ));
-            } else if let Some(reason) = is_valid_input_value(
+            } else if let Some(e) = is_valid_input_value(
                 ctx.registry,
                 &variable_definition.node.var_type.to_string(),
                 &value.node,
@@ -27,9 +27,10 @@ impl<'a> Visitor<'a> for DefaultValuesOfCorrectType {
                     segment: QueryPathSegment::Name(&variable_definition.node.name.node),
                 },
             ) {
-                ctx.report_error(
+                ctx.report_error_with_extensions(
                     vec![variable_definition.pos],
-                    format!("Invalid default value for argument {}", reason),
+                    format!("Invalid default value for argument {}", e.message),
+                    e.extensions,
                 )
             }
         }

--- a/src/validation/rules/no_fragment_cycles.rs
+++ b/src/validation/rules/no_fragment_cycles.rs
@@ -31,10 +31,11 @@ impl<'a> CycleDetector<'a> {
                     *pos
                 };
 
-                self.errors.push(RuleError {
-                    locations: vec![err_pos],
-                    message: format!("Cannot spread fragment \"{}\"", name),
-                });
+                self.errors.push(RuleError::new(
+                    vec![err_pos],
+                    format!("Cannot spread fragment \"{}\"", name),
+                    None,
+                ));
             } else if !self.visited.contains(name) {
                 path.push((name, *pos));
                 self.detect_from(name, path);

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -4,7 +4,7 @@ mod int_validators;
 mod list_validators;
 mod string_validators;
 
-use crate::Value;
+use crate::{Error, Value};
 
 pub use int_validators::{IntEqual, IntGreaterThan, IntLessThan, IntNonZero, IntRange};
 pub use list_validators::{ListMaxLength, ListMinLength};
@@ -47,7 +47,42 @@ where
     /// Check value is valid, returns the reason for the error if it fails, otherwise None.
     ///
     /// If the input type is different from the required type, return `Ok(())` directly, and other validators will find this error.
-    fn is_valid(&self, value: &Value) -> Result<(), String>;
+    fn is_valid(&self, _value: &Value) -> Result<(), String> {
+        Ok(())
+    }
+
+    /// Check value is valid, returns the reason include extensions for the error if it fails, otherwise None.
+    ///
+    /// If the input type is different from the required type, return `Ok(())` directly, and other validators will find this error.
+    ///
+    /// # Examples:
+    ///
+    /// ```no_run
+    /// use async_graphql::validators::InputValueValidator;
+    /// use async_graphql::{Value, Error, ErrorExtensions};
+    ///
+    /// pub struct IntGreaterThanZero;
+    ///
+    /// impl InputValueValidator for IntGreaterThanZero {
+    ///     fn is_valid_with_extensions(&self, value: &Value) -> Result<(), Error> {
+    ///         if let Value::Number(n) = value {
+    ///             if let Some(n) = n.as_i64() {
+    ///                 if n <= 0 {
+    ///                     return Err(
+    ///                         Error::new("Value must be greater than 0").extend_with(|_, e| e.set("code", 400))
+    ///                     );
+    ///                 }
+    ///             }
+    ///         }
+    ///         Ok(())
+    ///     }
+    /// }
+    /// ```
+    fn is_valid_with_extensions(&self, value: &Value) -> Result<(), Error> {
+        // By default, use is_valid method to keep compatible with previous version
+        self.is_valid(value)?;
+        Ok(())
+    }
 }
 
 /// An extension trait for `InputValueValidator`

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -80,7 +80,7 @@ where
     /// ```
     fn is_valid_with_extensions(&self, value: &Value) -> Result<(), Error> {
         // By default, use is_valid method to keep compatible with previous version
-        self.is_valid(value).map_err(|reason| Error::new(reason))
+        self.is_valid(value).map_err(Error::new)
     }
 }
 


### PR DESCRIPTION
Hi guys, this is my first contribution, please correct me.
My PR to help error data of input validator can contain more information by `ErrorExtentionValues`.

There are some use cases that I can imagine:
- Use code number or code string for show exactly error (Bad Request, Internal Server Error) on Client Side.
- Support localization (i18n) by adding key and its data on extensions.
- ...

Example implementation:
```rust
    use async_graphql::*;
    pub struct IntGreaterThanZero;

    impl InputValueValidator for IntGreaterThanZero {
        fn is_valid_with_extensions(&self, value: &Value) -> Result<(), Error> {
            if let Value::Number(n) = value {
                if let Some(n) = n.as_i64() {
                    if n <= 0 {
                        let e = Error::new("Value must be greater than 0")
                            .extend_with(|_, e| e.set("code", 400));
                        return Err(e);
                    }
                }
            }
            Ok(())
        }
    }
```

Expected Output:

```json
{
  "data": null,
  "errors": [
    {
      "message": "... Value must be greater than 0",
      "locations": [],
      "extensions": { "code": 400 }
    }
  ]
}
```

Compatible note:
- Compatible with all logic code of fn is_valid.
- ~Break MapErr logic on `src/validators/mod.rs`. Closure from `fn(String) -> String` to `fn(Error) -> Error`~. Compatible.

