### PR TITLE
Implement `TryFrom<&[SelectionField<'a>]>` for `Lookahead<'a>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add binary types to `ConstValue` and `Value`. [#569](https://github.com/async-graphql/async-graphql/issues/569)
-- Changed Lookahead to support multiple fields. [#574](https://github.com/async-graphql/async-graphql/issues/547)
+- Changed Lookahead to support multiple fields. [#574](https://github.com/async-graphql/async-graphql/issues/574)
+- Implement `TryFrom<&[SelectionField<'a>]>` for `Lookahead<'a>`. [#575](https://github.com/async-graphql/async-graphql/issues/575)
 
 ## [2.9.8] 2021-07-12
 

--- a/src/look_ahead.rs
+++ b/src/look_ahead.rs
@@ -53,6 +53,24 @@ impl<'a> From<SelectionField<'a>> for Lookahead<'a> {
     }
 }
 
+/// Convert a slice of `SelectionField`s to a `Lookahead`.
+///
+/// This assumes that the `SelectionField`s are all from the same query.
+///
+/// # Panics
+/// Panics if 0 `SelectionField`s are provided.
+impl<'a> From<&[SelectionField<'a>]> for Lookahead<'a> {
+    fn from(selection_fields: &[SelectionField<'a>]) -> Self {
+        Lookahead {
+            fragments: selection_fields[0].fragments,
+            fields: selection_fields
+                .iter()
+                .map(|selection_field| selection_field.field)
+                .collect(),
+        }
+    }
+}
+
 fn filter<'a>(
     fields: &mut Vec<&'a Field>,
     fragments: &'a HashMap<Name, Positioned<FragmentDefinition>>,

--- a/src/look_ahead.rs
+++ b/src/look_ahead.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::convert::TryFrom;
 
 use crate::parser::types::{Field, FragmentDefinition, Selection, SelectionSet};
 use crate::{Name, Positioned, SelectionField};
@@ -54,19 +55,23 @@ impl<'a> From<SelectionField<'a>> for Lookahead<'a> {
 }
 
 /// Convert a slice of `SelectionField`s to a `Lookahead`.
+/// Assumes all `SelectionField`s are from the same query and thus have the same fragments.
 ///
-/// This assumes that the `SelectionField`s are all from the same query.
-///
-/// # Panics
-/// Panics if 0 `SelectionField`s are provided.
-impl<'a> From<&[SelectionField<'a>]> for Lookahead<'a> {
-    fn from(selection_fields: &[SelectionField<'a>]) -> Self {
-        Lookahead {
-            fragments: selection_fields[0].fragments,
-            fields: selection_fields
-                .iter()
-                .map(|selection_field| selection_field.field)
-                .collect(),
+/// Fails if either no `SelectionField`s were provided.
+impl<'a> TryFrom<&[SelectionField<'a>]> for Lookahead<'a> {
+    type Error = ();
+
+    fn try_from(selection_fields: &[SelectionField<'a>]) -> Result<Self, Self::Error> {
+        if selection_fields.is_empty() {
+            Err(())
+        } else {
+            Ok(Lookahead {
+                fragments: selection_fields[0].fragments,
+                fields: selection_fields
+                    .iter()
+                    .map(|selection_field| selection_field.field)
+                    .collect(),
+            })
         }
     }
 }


### PR DESCRIPTION
Sorry this really should have been part of #574, this adds support to do what #557 mentioned but for multiple `SelectionField<'a>`. It does assume `fragments` are the same for all, I presume `fragments` is the same for everything in the same query and therefore it's okay to assume this?