### PR TITLE
Ignored items flagged @skip in SelectionField and Lookahead

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -603,7 +603,7 @@ impl<'a> ContextBase<'a, &'a Positioned<Field>> {
     /// }
     /// ```
     pub fn look_ahead(&self) -> Lookahead {
-        Lookahead::new(&self.query_env.fragments, &self.item.node)
+        Lookahead::new(&self.query_env.fragments, &self.item.node, self)
     }
 
     /// Get the current field.
@@ -653,7 +653,7 @@ impl<'a> ContextBase<'a, &'a Positioned<Field>> {
 pub struct SelectionField<'a> {
     pub(crate) fragments: &'a HashMap<Name, Positioned<FragmentDefinition>>,
     pub(crate) field: &'a Field,
-    context: &'a Context<'a>,
+    pub(crate) context: &'a Context<'a>,
 }
 
 impl<'a> SelectionField<'a> {
@@ -727,7 +727,20 @@ impl<'a> Iterator for SelectionFieldsIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             let it = self.iter.last_mut()?;
-            match it.next() {
+            let item = it.next();
+            if let Some(item) = item {
+                // ignore any items that are skipped (i.e. @skip/@include)
+                if self
+                    .context
+                    .is_skip(&item.node.directives())
+                    .unwrap_or(false)
+                {
+                    // TODO: should we throw errors here? they will be caught later in execution and it'd cause major backwards compatibility issues
+                    continue;
+                }
+            }
+
+            match item {
                 Some(selection) => match &selection.node {
                     Selection::Field(field) => {
                         return Some(SelectionField {


### PR DESCRIPTION
Currently if you have a query with a field/fragment marked as `@skip(if: true)` or `@include(if: false)` it'll still be included by `SelectionField` and `Lookahead`. As they're used to determine what was requested they should be excluded in my opinion.

This PR simply ignored any skipped fields/fragments. Before merging, it's worth considering what to do on `is_skip` returns `Err`. For now I'm ignoring the error, as I'm assume it'll always be caught elsewhere anyway and it would introduce backwards compatibility issues having to handle `field("name")?` everywhere; but I think that should be discussed.