### PR TITLE
Add support for cbor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ pin-project-lite = "0.2.6"
 regex = "1.4.5"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
+serde_cbor = "0.11.1"
 thiserror = "1.0.24"
 static_assertions = "1.1.0"
 http = "0.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ http = "0.2.3"
 multer = "2.0.0"
 tempfile = "3.2.0"
 bytes = { version = "1.0.1", features = ["serde"] }
-
 # Feature optional dependencies
 bson = { version = "2.0.0-beta.1", optional = true, features = ["chrono-0_4"] }
 chrono = { version = "0.4.19", optional = true }
@@ -57,7 +56,7 @@ opentelemetry = { version = "0.13.0", optional = true }
 url = { version = "2.2.1", optional = true }
 uuid = { version = "0.8.2", optional = true, features = ["v4", "serde"] }
 rust_decimal = { version = "1.14.3", optional = true }
-
+mime = "0.3.15"
 # Non-feature optional dependencies
 blocking = { version = "1.0.2", optional = true }
 lru = { version = "0.6.5", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{parser, InputType, Pos, Value};
-use serde::de::Error as SerdeError;
 
 /// Extensions to the error.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -256,6 +255,12 @@ impl From<multer::Error> for ParseRequestError {
             }
             _ => ParseRequestError::InvalidMultipart(err),
         }
+    }
+}
+
+impl From<mime::FromStrError> for ParseRequestError {
+    fn from(e: mime::FromStrError) -> Self {
+        Self::InvalidRequest(Box::new(e))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -212,11 +212,11 @@ pub enum ParseRequestError {
 
     /// The request's syntax was invalid.
     #[error("Invalid request: {0}")]
-    InvalidRequest(Box<dyn std::error::Error>),
+    InvalidRequest(Box<dyn std::error::Error + Send + Sync>),
 
     /// The request's files map was invalid.
     #[error("Invalid files map: {0}")]
-    InvalidFilesMap(Box<dyn std::error::Error>),
+    InvalidFilesMap(Box<dyn std::error::Error + Send + Sync>),
 
     /// The request's multipart data was invalid.
     #[error("Invalid multipart data")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -216,7 +216,7 @@ pub enum ParseRequestError {
 
     /// The request's files map was invalid.
     #[error("Invalid files map: {0}")]
-    InvalidFilesMap(serde_json::Error),
+    InvalidFilesMap(Box<dyn std::error::Error>),
 
     /// The request's multipart data was invalid.
     #[error("Invalid multipart data")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{parser, InputType, Pos, Value};
+use serde::de::Error as SerdeError;
 
 /// Extensions to the error.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -52,6 +52,7 @@ pub async fn receive_batch_json(body: impl AsyncRead) -> Result<BatchRequest, Pa
     body.read_to_end(&mut data)
         .await
         .map_err(ParseRequestError::Io)?;
+    println!("{}", String::from_utf8_lossy(&data));
     Ok(serde_json::from_slice::<BatchRequest>(&data)
         .map_err(|e| ParseRequestError::InvalidRequest(Box::new(e)))?)
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -36,7 +36,7 @@ pub async fn receive_batch_body(
     if let Some(Ok(boundary)) = content_type.map(multer::parse_boundary) {
         multipart::receive_batch_multipart(body, boundary, opts).await
     } else {
-        receive_batch_json(body).await
+        receive_batch_cbor(body).await
     }
 }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -54,3 +54,13 @@ pub async fn receive_batch_json(body: impl AsyncRead) -> Result<BatchRequest, Pa
         .map_err(ParseRequestError::Io)?;
     Ok(serde_json::from_slice::<BatchRequest>(&data).map_err(ParseRequestError::InvalidRequest)?)
 }
+
+
+pub async fn receive_batch_cbor(body: impl AsyncRead) -> Result<BatchRequest, ParseRequestError> {
+    let mut data = Vec::new();
+    futures_util::pin_mut!(body);
+    body.read_to_end(&mut data)
+        .await
+        .map_err(ParseRequestError::Io)?;
+    Ok(serde_cbor::from_slice::<BatchRequest>(&data).map_err(ParseRequestError::InvalidRequest)?)
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -4,7 +4,7 @@ mod graphiql_source;
 mod multipart;
 mod playground_source;
 mod websocket;
-
+use mime::{self};
 use futures_util::io::{AsyncRead, AsyncReadExt};
 
 use crate::{BatchRequest, ParseRequestError, Request};
@@ -31,12 +31,27 @@ pub async fn receive_batch_body(
     body: impl AsyncRead + Send,
     opts: MultipartOptions,
 ) -> Result<BatchRequest, ParseRequestError> {
-    let content_type = content_type.as_ref().map(AsRef::as_ref);
+    // if no content-type header is set, we default to json
+    let content_type = content_type.as_ref().map(AsRef::as_ref).unwrap_or("application/json");
+        
+    let content_type: mime::Mime = content_type.parse()?;
+    match (content_type.type_(), content_type.subtype()) {
+        // application/json -> try json
+        (mime::APPLICATION, mime::JSON) => receive_batch_json(body).await,
+        // cbor is in application/octet-stream.
+        // TODO: wait for mime to add application/cbor and match against that too
+        (mime::OCTET_STREAM, _) | (mime::APPLICATION, mime::OCTET_STREAM) => receive_batch_cbor(body).await,
+        // try to use multipart
+        (mime::MULTIPART, _) => {
+            if let Some(boundary) = content_type.get_param("boundary") {
+                multipart::receive_batch_multipart(body, boundary.to_string(), opts).await
+            } else {
+                Err(ParseRequestError::InvalidMultipart(multer::Error::NoBoundary))
+            }
+        }
 
-    if let Some(Ok(boundary)) = content_type.map(multer::parse_boundary) {
-        multipart::receive_batch_multipart(body, boundary, opts).await
-    } else {
-        receive_batch_cbor(body).await
+        // default to json and try that
+        _ => receive_batch_json(body).await
     }
 }
 
@@ -52,7 +67,6 @@ pub async fn receive_batch_json(body: impl AsyncRead) -> Result<BatchRequest, Pa
     body.read_to_end(&mut data)
         .await
         .map_err(ParseRequestError::Io)?;
-    println!("{}", String::from_utf8_lossy(&data));
     Ok(serde_json::from_slice::<BatchRequest>(&data)
         .map_err(|e| ParseRequestError::InvalidRequest(Box::new(e)))?)
 }

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -77,7 +77,7 @@ pub(super) async fn receive_batch_multipart(
                 let map_str = field.text().await?;
                 map = Some(
                     serde_json::from_str::<HashMap<String, Vec<String>>>(&map_str)
-                        .map_err(ParseRequestError::InvalidFilesMap)?,
+                        .map_err(|e| ParseRequestError::InvalidFilesMap(Box::new(e)))?,
                 );
             }
             _ => {


### PR DESCRIPTION
A while back we discussed the ability to use cbor as encoding. Back then, we got that to work and used it since on our fork. I thought that we could make a PR too.

# Note

We use it to build a graphql server and haven't encountered any errors *yet*. Multipart (for the file upload extension) probably won't work just yet, because it still uses serde_json.