### PR TITLE
Updated to support Actix Web 4

### DIFF
--- a/integrations/actix-web/Cargo.toml
+++ b/integrations/actix-web/Cargo.toml
@@ -13,16 +13,15 @@ categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 async-graphql = { path = "../..", version = "=2.9.14" }
-
-actix = "0.10.0"
-actix-http = "2.2.0"
-actix-web = { version = "3.3.2", default-features = false }
-actix-web-actors = "3.0.0"
+actix = "0.12.0"
+actix-http = "3.0.0-beta.8"
+actix-web = { version = "4.0.0-beta.8", default-features = false }
+actix-web-actors = "4.0.0-beta.6"
 async-channel = "1.6.1"
 futures-util = { version = "0.3.13", default-features = false }
 serde_json = "1.0.64"
 serde_urlencoded = "0.7.0"
 
 [dev-dependencies]
-actix-rt = "1.1.0"
+actix-rt = "2.2.0"
 async-mutex = "1.4.0"

--- a/integrations/actix-web/src/lib.rs
+++ b/integrations/actix-web/src/lib.rs
@@ -11,11 +11,11 @@ use std::future::Future;
 use std::io::{self, ErrorKind};
 use std::pin::Pin;
 
-use actix_web::client::PayloadError;
 use actix_web::dev::{Payload, PayloadStream};
+use actix_web::error::PayloadError;
 use actix_web::http::{Method, StatusCode};
 use actix_web::{http, Error, FromRequest, HttpRequest, HttpResponse, Responder, Result};
-use futures_util::future::{self, FutureExt, Ready};
+use futures_util::future::{self, FutureExt};
 use futures_util::{StreamExt, TryStreamExt};
 
 use async_graphql::http::MultipartOptions;
@@ -118,6 +118,7 @@ impl FromRequest for BatchRequest {
                             }
                             PayloadError::Http2Payload(e) if e.is_io() => e.into_io().unwrap(),
                             PayloadError::Http2Payload(e) => io::Error::new(ErrorKind::Other, e),
+                            _ => todo!(),
                         })
                         .into_async_read(),
                         config,
@@ -160,20 +161,17 @@ impl From<async_graphql::BatchResponse> for Response {
 }
 
 impl Responder for Response {
-    type Error = Error;
-    type Future = Ready<Result<HttpResponse>>;
-
-    fn respond_to(self, _req: &HttpRequest) -> Self::Future {
+    fn respond_to(self, _req: &HttpRequest) -> HttpResponse {
         let mut res = HttpResponse::build(StatusCode::OK);
         res.content_type("application/json");
         if self.0.is_ok() {
             if let Some(cache_control) = self.0.cache_control().value() {
-                res.header("cache-control", cache_control);
+                res.append_header(("cache-control", cache_control));
             }
         }
         for (name, value) in self.0.http_headers() {
-            res.header(name, value);
+            res.append_header((name, value));
         }
-        futures_util::future::ok(res.body(serde_json::to_string(&self.0).unwrap()))
+        res.body(serde_json::to_string(&self.0).unwrap())
     }
 }

--- a/integrations/actix-web/src/subscription.rs
+++ b/integrations/actix-web/src/subscription.rs
@@ -3,12 +3,13 @@ use std::str::FromStr;
 use std::time::{Duration, Instant};
 
 use actix::{
-    Actor, ActorContext, ActorFuture, ActorStream, AsyncContext, ContextFutureSpawner,
+    Actor, ActorContext, ActorFutureExt, ActorStreamExt, AsyncContext, ContextFutureSpawner,
     StreamHandler, WrapFuture, WrapStream,
 };
 use actix_http::error::PayloadError;
-use actix_http::{ws, Error};
+use actix_http::ws;
 use actix_web::web::Bytes;
+use actix_web::Error;
 use actix_web::{HttpRequest, HttpResponse};
 use actix_web_actors::ws::{CloseReason, Message, ProtocolError, WebsocketContext};
 use async_graphql::http::{WebSocket, WebSocketProtocols, WsMessage, ALL_WEBSOCKET_PROTOCOLS};
@@ -190,7 +191,7 @@ where
                     Some(std::mem::take(&mut self.continuation))
                 }
             },
-            Message::Text(s) => Some(s.into_bytes()),
+            Message::Text(s) => Some(s.into_bytes().to_vec()),
             Message::Binary(bytes) => Some(bytes.to_vec()),
             Message::Close(_) => {
                 ctx.stop();

--- a/integrations/actix-web/tests/graphql.rs
+++ b/integrations/actix-web/tests/graphql.rs
@@ -1,68 +1,88 @@
 mod test_utils;
-use actix_web::{guard, test, web, App};
+use actix_http::header;
+use actix_web::{
+    dev::{Service, ServiceResponse},
+    guard, test,
+    web::{self},
+    App,
+};
 use async_graphql::*;
 use serde_json::json;
 use test_utils::*;
 
 #[actix_rt::test]
 async fn test_playground() {
-    let srv = test::start(|| {
+    let app = test::init_service(
         App::new().service(
             web::resource("/")
                 .guard(guard::Get())
                 .to(test_utils::gql_playgound),
-        )
-    });
-    let mut response = srv.get("/").send().await.unwrap();
+        ),
+    )
+    .await;
+
+    let response = test::TestRequest::get().uri("/").send_request(&app).await;
     assert!(response.status().is_success());
-    let body = response.body().await.unwrap();
+    let body = test::read_body(response).await;
     assert!(std::str::from_utf8(&body).unwrap().contains("graphql"));
 }
 
 #[actix_rt::test]
 async fn test_add() {
-    let srv = test::start(|| {
+    let mut app = test::init_service(
         App::new()
-            .data(Schema::new(AddQueryRoot, EmptyMutation, EmptySubscription))
+            .app_data(actix_web::web::Data::new(Schema::new(
+                AddQueryRoot,
+                EmptyMutation,
+                EmptySubscription,
+            )))
             .service(
                 web::resource("/")
                     .guard(guard::Post())
                     .to(gql_handle_schema::<AddQueryRoot, EmptyMutation, EmptySubscription>),
-            )
-    });
-    let mut response = srv
-        .post("/")
-        .send_body(r#"{"query":"{ add(a: 10, b: 20) }"}"#)
-        .await
-        .unwrap();
+            ),
+    )
+    .await;
+
+    let response = test::TestRequest::post()
+        .uri("/")
+        .append_header((header::CONTENT_TYPE, "application/json"))
+        .set_payload(r#"{"query":"{ add(a: 10, b: 20) }"}"#)
+        .send_request(&mut app)
+        .await;
+
     assert!(response.status().is_success());
-    let body = response.body().await.unwrap();
+    let body = test::read_body(response).await;
+    println!("Body: {:?}", body);
     assert_eq!(body, json!({"data": {"add": 30}}).to_string());
 }
 
 #[actix_rt::test]
 async fn test_hello() {
-    let srv = test::start(|| {
+    let app = test::init_service(
         App::new()
-            .data(Schema::new(
+            .app_data(actix_web::web::Data::new(Schema::new(
                 HelloQueryRoot,
                 EmptyMutation,
                 EmptySubscription,
-            ))
+            )))
             .service(
                 web::resource("/")
                     .guard(guard::Post())
                     .to(gql_handle_schema::<HelloQueryRoot, EmptyMutation, EmptySubscription>),
-            )
-    });
+            ),
+    )
+    .await;
 
-    let mut response = srv
-        .post("/")
-        .send_body(r#"{"query":"{ hello }"}"#)
-        .await
-        .unwrap();
+    let response = test::TestRequest::post()
+        .uri("/")
+        .append_header((header::CONTENT_TYPE, "application/json"))
+        .set_payload(r#"{"query":"{ hello }"}"#)
+        .send_request(&app)
+        .await;
+
     assert!(response.status().is_success());
-    let body = response.body().await.unwrap();
+    let body = test::read_body(response).await;
     assert_eq!(
         body,
         json!({"data": {"hello": "Hello, world!"}}).to_string()
@@ -71,66 +91,81 @@ async fn test_hello() {
 
 #[actix_rt::test]
 async fn test_hello_header() {
-    let srv = test::start(|| {
+    let app = test::init_service(
         App::new()
-            .data(Schema::new(
+            .app_data(actix_web::web::Data::new(Schema::new(
                 HelloQueryRoot,
                 EmptyMutation,
                 EmptySubscription,
-            ))
+            )))
             .service(
                 web::resource("/")
                     .guard(guard::Post())
                     .to(gql_handle_schema_with_header::<HelloQueryRoot>),
-            )
-    });
+            ),
+    )
+    .await;
 
-    let mut response = srv
-        .post("/")
-        .header("Name", "Foo")
-        .send_body(r#"{"query":"{ hello }"}"#)
-        .await
-        .unwrap();
+    let response = test::TestRequest::post()
+        .uri("/")
+        .append_header((header::CONTENT_TYPE, "application/json"))
+        .append_header(("Name", "Foo"))
+        .set_payload(r#"{"query":"{ hello }"}"#)
+        .send_request(&app)
+        .await;
+
     assert!(response.status().is_success());
-    let body = response.body().await.unwrap();
+    let body = test::read_body(response).await;
     assert_eq!(body, json!({"data": {"hello": "Hello, Foo!"}}).to_string());
 }
 
 #[actix_rt::test]
 async fn test_count() {
-    let srv = test::start(|| {
+    let app = test::init_service(
         App::new()
-            .data(
+            .app_data(actix_web::web::Data::new(
                 Schema::build(CountQueryRoot, CountMutation, EmptySubscription)
                     .data(Count::default())
                     .finish(),
-            )
+            ))
             .service(
                 web::resource("/")
                     .guard(guard::Post())
                     .to(gql_handle_schema::<CountQueryRoot, CountMutation, EmptySubscription>),
-            )
-    });
-    count_action_helper(0, r#"{"query":"{ count }"}"#, &srv).await;
-    count_action_helper(10, r#"{"query":"mutation{ addCount(count: 10) }"}"#, &srv).await;
+            ),
+    )
+    .await;
+    count_action_helper(0, r#"{"query":"{ count }"}"#, &app).await;
+    count_action_helper(10, r#"{"query":"mutation{ addCount(count: 10) }"}"#, &app).await;
     count_action_helper(
         8,
         r#"{"query":"mutation{ subtractCount(count: 2) }"}"#,
-        &srv,
+        &app,
     )
     .await;
     count_action_helper(
         6,
         r#"{"query":"mutation{ subtractCount(count: 2) }"}"#,
-        &srv,
+        &app,
     )
     .await;
 }
 
-async fn count_action_helper(expected: i32, body: &'static str, srv: &test::TestServer) {
-    let mut response = srv.post("/").send_body(body).await.unwrap();
+async fn count_action_helper(
+    expected: i32,
+    body: &'static str,
+    app: &impl Service<actix_http::Request, Response = ServiceResponse, Error = actix_web::Error>,
+) -> () {
+    let response = test::TestRequest::post()
+        .uri("/")
+        .append_header((header::CONTENT_TYPE, "application/json"))
+        .append_header(("Name", "Foo"))
+        .set_payload(body)
+        .send_request(&app)
+        .await;
+
     assert!(response.status().is_success());
-    let body = response.body().await.unwrap();
+    let body = test::read_body(response).await;
     assert!(std::str::from_utf8(&body)
         .unwrap()
         .contains(&expected.to_string()));


### PR DESCRIPTION
Updating the version to the latest Beta version of Actix web 4.

I know Actix web is still in beta but I'm currently using it and I loved async-graphql and wanted to use it.

- Updated the integration for Actix web and the tests. 

Please feel free to use this as a reference when Actix web 4 is release.

thank you for your hard work in async-graphql

Regards,
Abdulrhman