### PR TITLE
Get selection fields from Lookahead

### DIFF
--- a/src/look_ahead.rs
+++ b/src/look_ahead.rs
@@ -55,6 +55,9 @@ impl<'a> Lookahead<'a> {
         !self.fields.is_empty()
     }
 
+    /// Get the `SelectionField`s for each of the fields covered by this `Lookahead`.
+    ///
+    /// There will be multiple fields in situations where the same field is queried twice.
     pub fn selection_fields(&self) -> Vec<SelectionField<'a>> {
         self.fields
             .iter()

--- a/src/look_ahead.rs
+++ b/src/look_ahead.rs
@@ -54,6 +54,17 @@ impl<'a> Lookahead<'a> {
     pub fn exists(&self) -> bool {
         !self.fields.is_empty()
     }
+
+    pub fn selection_fields(&self) -> Vec<SelectionField<'a>> {
+        self.fields
+            .iter()
+            .map(|field| SelectionField {
+                fragments: self.fragments,
+                field,
+                context: self.context,
+            })
+            .collect()
+    }
 }
 
 impl<'a> From<SelectionField<'a>> for Lookahead<'a> {


### PR DESCRIPTION
In much the same was as it's useful to get `Lookahead` from `SelectionField` #557, the inverse is also quite useful.

This adds a function that generates all `SelectionField`s fo each field in the `Lookahead`. I decided to do this over implementing `From`, but I'm open to changing that.