### PR TITLE
docs(merging_objects): add missing structs in example

### DIFF
--- a/docs/en/src/merging_objects.md
+++ b/docs/en/src/merging_objects.md
@@ -25,12 +25,18 @@ Instead, the `#[derive(MergedObject)]` macro allows you to split an object's res
 **Note:** This works for queries and mutations. For subscriptions, see "Merging Subscriptions" below.
 
 ```rust
+#[derive(Default)]
+struct UserQuery;
+
 #[Object]
 impl UserQuery {
     async fn users(&self) -> Vec<User> {
         todo!()
     }
 }
+
+#[derive(Default)]
+struct MovieQuery;
 
 #[Object]
 impl MovieQuery {

--- a/docs/zh-CN/src/merging_objects.md
+++ b/docs/zh-CN/src/merging_objects.md
@@ -25,12 +25,18 @@ impl MyObject {
 **提示:** 每个`#[Object]`需要一个唯一的名称，即使在一个`MergedObject`内，所以确保每个对象有单独的名称。
 
 ```rust
+#[derive(Default)]
+struct UserQuery;
+
 #[Object]
 impl UserQuery {
     async fn users(&self) -> Vec<User> {
         todo!()
     }
 }
+
+#[derive(Default)]
+struct MovieQuery;
 
 #[Object]
 impl MovieQuery {


### PR DESCRIPTION
Hey there @sunli829,

Given the structs are included in the merging subscriptions example, I thought it might be nice to add them to the merging objects section for consistency.

Thanks for the library, works great.