### PR TITLE
docs(context): add missing finish statement

### DIFF
--- a/docs/en/src/context.md
+++ b/docs/en/src/context.md
@@ -40,6 +40,7 @@ An instance of how it would be written inside an application:
     .data(env_struct)
     .data(s3_storage)
     .data(db_core)
+    .finish();
 ```
 
 ### Request data

--- a/docs/zh-CN/src/context.md
+++ b/docs/zh-CN/src/context.md
@@ -39,6 +39,7 @@ impl Query {
     .data(env_struct)
     .data(s3_storage)
     .data(db_core)
+    .finish();
 ```
 
 ### 请求数据


### PR DESCRIPTION
Hey there, back with another thing I've found while reading the docs.

I've noticed `.finish()` was missing for the context section. Added for consistency with other sections.