### PR TITLE
docs(default_value): fix macro syntax error

### DIFF
--- a/docs/en/src/default_value.md
+++ b/docs/en/src/default_value.md
@@ -48,7 +48,7 @@ enum MyInterface {
 ```rust
 use async_graphql::*;
 
-#derive(InputObject)
+#[derive(InputObject)]
 struct MyInputObject {
     #[graphql(default)]
     value1: i32,

--- a/docs/zh-CN/src/default_value.md
+++ b/docs/zh-CN/src/default_value.md
@@ -47,7 +47,7 @@ enum MyInterface {
 ```rust
 use async_graphql::*;
 
-#derive(InputObject)
+#[derive(InputObject)]
 struct MyInputObject {
     #[graphql(default)]
     value1: i32,


### PR DESCRIPTION
Fixes wrong macro syntax which caused the `InputObject` macro not to be displayed in the documentation.

<https://async-graphql.github.io/async-graphql/en/default_value.html#input-object-field>