### PR TITLE
Fix the `Subscription` procmacro to work on Rust 2021 by adding the missing required `dyn` keywords in the generated output

### DIFF
--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -219,7 +219,7 @@ pub fn generate(
                 let mut r = None;
                 for b in bounds {
                     if let TypeParamBound::Trait(b) = b {
-                        r = Some(quote! { #b });
+                        r = Some(quote! { dyn #b });
                     }
                 }
                 quote! { #r }
@@ -303,7 +303,7 @@ pub fn generate(
                         #(#schema_args)*
                         args
                     },
-                    ty: <<dyn #stream_ty as #crate_name::futures_util::stream::Stream>::Item as #crate_name::Type>::create_type_info(registry),
+                    ty: <<#stream_ty as #crate_name::futures_util::stream::Stream>::Item as #crate_name::Type>::create_type_info(registry),
                     deprecation: #field_deprecation,
                     cache_control: ::std::default::Default::default(),
                     external: false,
@@ -364,7 +364,7 @@ pub fn generate(
                                 let ri = #crate_name::extensions::ResolveInfo {
                                     path_node: ctx_selection_set.path_node.as_ref().unwrap(),
                                     parent_type: #gql_typename,
-                                    return_type: &<<dyn #stream_ty as #crate_name::futures_util::stream::Stream>::Item as #crate_name::Type>::qualified_type_name(),
+                                    return_type: &<<#stream_ty as #crate_name::futures_util::stream::Stream>::Item as #crate_name::Type>::qualified_type_name(),
                                     name: field.node.name.node.as_str(),
                                     alias: field.node.alias.as_ref().map(|alias| alias.node.as_str()),
                                 };


### PR DESCRIPTION
Fixed #663 

This gets the `Subscription` procmacro working on Rust 2021, which is when the `dyn` keyword is now hard required.  The generated code was missing instances of the `dyn` keyword.