### PR TITLE
Use Rust 2021 Edition

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,2 @@
-edition = "2018"
+edition = "2021"
 newline_style = "unix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-graphql"
 version = "2.10.4"
 authors = ["sunli <scott_s829@163.com>", "Koxiaet"]
-edition = "2018"
+edition = "2021"
 description = "A GraphQL server library implemented in Rust"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/async-graphql/"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-graphql-derive"
 version = "2.10.4"
 authors = ["sunli <scott_s829@163.com>", "Koxiaet"]
-edition = "2018"
+edition = "2021"
 description = "Macros for async-graphql"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/async-graphql/"

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -316,11 +316,11 @@ fn generate_default_value(lit: &Lit) -> GeneratorResult<TokenStream> {
         }
         Lit::Int(value) => {
             let value = value.base10_parse::<i32>()?;
-            Ok(quote!({ ::std::convert::TryInto::try_into(#value).unwrap() }))
+            Ok(quote!({ ::TryInto::try_into(#value).unwrap() }))
         }
         Lit::Float(value) => {
             let value = value.base10_parse::<f64>()?;
-            Ok(quote!({ ::std::convert::TryInto::try_into(#value) }))
+            Ok(quote!({ ::TryInto::try_into(#value) }))
         }
         Lit::Bool(value) => {
             let value = value.value;

--- a/integrations/actix-web/Cargo.toml
+++ b/integrations/actix-web/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-graphql-actix-web"
 version = "2.10.4"
 authors = ["sunli <scott_s829@163.com>", "Koxiaet"]
-edition = "2018"
+edition = "2021"
 description = "async-graphql for actix-web"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/async-graphql-actix-web/"

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-graphql-axum"
 version = "2.10.4"
 authors = ["sunli <scott_s829@163.com>"]
-edition = "2018"
+edition = "2021"
 description = "async-graphql for axum"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/async-graphql-axum/"

--- a/integrations/axum/src/response.rs
+++ b/integrations/axum/src/response.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use axum::body::Body;
 use axum::response::IntoResponse;
 use headers::HeaderName;

--- a/integrations/poem/Cargo.toml
+++ b/integrations/poem/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-graphql-poem"
 version = "2.10.4"
 authors = ["sunli <scott_s829@163.com>"]
-edition = "2018"
+edition = "2021"
 description = "async-graphql for poem"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/async-graphql-poem/"

--- a/integrations/rocket/Cargo.toml
+++ b/integrations/rocket/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-graphql-rocket"
 version = "2.10.4"
 authors = ["Daniel Wiesenberg <daniel@simplificAR.io>"]
-edition = "2018"
+edition = "2021"
 description = "async-graphql for Rocket.rs"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/async-graphql/"

--- a/integrations/tide/Cargo.toml
+++ b/integrations/tide/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-graphql-tide"
 version = "2.10.4"
 authors = ["vkill <vkill.net@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "async-graphql for tide"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/async-graphql-tide/"

--- a/integrations/warp/Cargo.toml
+++ b/integrations/warp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-graphql-warp"
 version = "2.10.4"
 authors = ["sunli <scott_s829@163.com>", "Koxiaet"]
-edition = "2018"
+edition = "2021"
 description = "async-graphql for warp"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/async-graphql-warp/"

--- a/integrations/warp/src/batch_request.rs
+++ b/integrations/warp/src/batch_request.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::io;
 use std::io::ErrorKind;
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-graphql-parser"
 version = "2.10.4"
 authors = ["sunli <scott_s829@163.com>", "Koxiaet"]
-edition = "2018"
+edition = "2021"
 description = "GraphQL query parser for async-graphql"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/async-graphql/"

--- a/src/look_ahead.rs
+++ b/src/look_ahead.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::convert::TryFrom;
 
 use crate::parser::types::{Field, FragmentDefinition, Selection, SelectionSet};
 use crate::Context;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,5 @@
 use std::any::Any;
 use std::collections::HashMap;
-use std::convert::TryFrom;
 use std::fmt::{self, Debug, Formatter};
 
 use serde::{Deserialize, Deserializer, Serialize};

--- a/src/types/external/list/array.rs
+++ b/src/types/external/list/array.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::convert::TryInto;
 
 use crate::parser::types::Field;
 use crate::resolver_utils::resolve_list;

--- a/src/types/id.rs
+++ b/src/types/id.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::num::ParseIntError;
 use std::ops::{Deref, DerefMut};
 

--- a/value/Cargo.toml
+++ b/value/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-graphql-value"
 version = "2.10.4"
 authors = ["sunli <scott_s829@163.com>", "Koxiaet"]
-edition = "2018"
+edition = "2021"
 description = "GraphQL value for async-graphql"
 license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/async-graphql/"

--- a/value/src/lib.rs
+++ b/value/src/lib.rs
@@ -11,9 +11,7 @@ mod variables;
 
 use std::borrow::{Borrow, Cow};
 use std::collections::BTreeMap;
-use std::convert::{TryFrom, TryInto};
 use std::fmt::{self, Display, Formatter, Write};
-use std::iter::FromIterator;
 use std::ops::Deref;
 use std::sync::Arc;
 


### PR DESCRIPTION
Hi!
I'm adding this PR to update to using the new 2021 edition of rust.

The Cargo toml editions were all updated to 2021. And then imports for the new
prelude members (TryFrom, TryInto, FromIterator) were removed.
