### PR TITLE
Added map, contains and transpose function to MaybeUndefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `chrono::Duration` custom scalar. [#689](https://github.com/async-graphql/async-graphql/pull/689)
 - Implement `From<Option<Option<T>>>` for `MaybeUndefined<T>`.
-- Add `MaybeUndefined::as_opt_ref` and `MaybeUndefined::as_opt_deref` methods.
+- Add `MaybeUndefined::as_opt_ref`, `MaybeUndefined::as_opt_deref`, `MaybeUndefined::map`, `MaybeUndefined::map_value`, `MaybeUndefined::contains`, `MaybeUndefined::contains_value`, and `MaybeUndefined::transpose` methods.
+- Made `MaybeUndefined::is_undefined`, `MaybeUndefined::is_null`, `MaybeUndefined::is_value`, `MaybeUndefined::value` and `MaybeUndefined::as_opt_ref` const.
 - Add `Failure` type. [#671](https://github.com/async-graphql/async-graphql/issues/671)
 - [async-graphql-axum] Bump axum from `0.2.5` to `0.3`.
 

--- a/src/types/maybe_undefined.rs
+++ b/src/types/maybe_undefined.rs
@@ -143,7 +143,7 @@ impl<T> MaybeUndefined<T> {
         match self {
             MaybeUndefined::Value(y) => matches!(x, Some(v) if v == y),
             MaybeUndefined::Null => matches!(x, None),
-            _ => false,
+            MaybeUndefined::Undefined => false,
         }
     }
 

--- a/src/types/maybe_undefined.rs
+++ b/src/types/maybe_undefined.rs
@@ -64,25 +64,25 @@ impl<T> Default for MaybeUndefined<T> {
 impl<T> MaybeUndefined<T> {
     /// Returns true if the `MaybeUndefined<T>` is undefined.
     #[inline]
-    pub fn is_undefined(&self) -> bool {
+    pub const fn is_undefined(&self) -> bool {
         matches!(self, MaybeUndefined::Undefined)
     }
 
     /// Returns true if the `MaybeUndefined<T>` is null.
     #[inline]
-    pub fn is_null(&self) -> bool {
+    pub const fn is_null(&self) -> bool {
         matches!(self, MaybeUndefined::Null)
     }
 
     /// Returns true if the `MaybeUndefined<T>` contains value.
     #[inline]
-    pub fn is_value(&self) -> bool {
+    pub const fn is_value(&self) -> bool {
         matches!(self, MaybeUndefined::Value(_))
     }
 
     /// Borrow the value, returns `None` if the the `MaybeUndefined<T>` is `undefined` or `null`, otherwise returns `Some(T)`.
     #[inline]
-    pub fn value(&self) -> Option<&T> {
+    pub const fn value(&self) -> Option<&T> {
         match self {
             MaybeUndefined::Value(value) => Some(value),
             _ => None,
@@ -100,7 +100,7 @@ impl<T> MaybeUndefined<T> {
 
     /// Converts the `MaybeUndefined<T>` to `Option<Option<T>>`.
     #[inline]
-    pub fn as_opt_ref(&self) -> Option<Option<&T>> {
+    pub const fn as_opt_ref(&self) -> Option<Option<&T>> {
         match self {
             MaybeUndefined::Undefined => None,
             MaybeUndefined::Null => Some(None),
@@ -119,6 +119,61 @@ impl<T> MaybeUndefined<T> {
             MaybeUndefined::Undefined => None,
             MaybeUndefined::Null => Some(None),
             MaybeUndefined::Value(value) => Some(Some(value.deref())),
+        }
+    }
+
+    /// Returns `true` if the `MaybeUndefined<T>` contains the given value.
+    #[inline]
+    pub fn contains_value<U>(&self, x: &U) -> bool
+    where
+        U: PartialEq<T>,
+    {
+        match self {
+            MaybeUndefined::Value(y) => x == y,
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if the `MaybeUndefined<T>` contains the given nullable value.
+    #[inline]
+    pub fn contains<U>(&self, x: &Option<U>) -> bool
+    where
+        U: PartialEq<T>,
+    {
+        match self {
+            MaybeUndefined::Value(y) => matches!(x, Some(v) if v == y),
+            MaybeUndefined::Null => matches!(x, None),
+            _ => false,
+        }
+    }
+
+    /// Maps a `MaybeUndefined<T>` to `MaybeUndefined<U>` by applying a function to the contained nullable value
+    #[inline]
+    pub fn map<U, F: FnOnce(Option<T>) -> Option<U>>(self, f: F) -> MaybeUndefined<U> {
+        match self {
+            MaybeUndefined::Value(v) => {
+                match f(Some(v)) {
+                    Some(v) => MaybeUndefined::Value(v),
+                    None => MaybeUndefined::Null
+                }
+            },
+            MaybeUndefined::Null => {
+                match f(None) {
+                    Some(v) => MaybeUndefined::Value(v),
+                    None => MaybeUndefined::Null
+                }
+            },
+            MaybeUndefined::Undefined => MaybeUndefined::Undefined,
+        }
+    }
+
+    /// Maps a `MaybeUndefined<T>` to `MaybeUndefined<U>` by applying a function to the contained value
+    #[inline]
+    pub fn map_value<U, F: FnOnce(T) -> U>(self, f: F) -> MaybeUndefined<U> {
+        match self {
+            MaybeUndefined::Value(v) => MaybeUndefined::Value(f(v)),
+            MaybeUndefined::Null => MaybeUndefined::Null,
+            MaybeUndefined::Undefined => MaybeUndefined::Undefined,
         }
     }
 }
@@ -153,6 +208,24 @@ impl<T: InputType> InputType for MaybeUndefined<T> {
         match self {
             MaybeUndefined::Value(value) => value.to_value(),
             _ => Value::Null,
+        }
+    }
+}
+
+impl<T, E> MaybeUndefined<Result<T, E>> {
+    /// Transposes a `MaybeUndefined` of a [`Result`] into a [`Result`] of a `MaybeUndefined`.
+    ///
+    /// [`MaybeUndefined::Undefined`] will be mapped to [`Ok`]`(`[`MaybeUndefined::Undefined`]`)`.
+    /// [`MaybeUndefined::Null`] will be mapped to [`Ok`]`(`[`MaybeUndefined::Null`]`)`.
+    /// [`MaybeUndefined::Value`]`(`[`Ok`]`(_))` and [`MaybeUndefined::Value`]`(`[`Err`]`(_))` will be mapped to
+    /// [`Ok`]`(`[`MaybeUndefined::Value`]`(_))` and [`Err`]`(_)`.
+    #[inline]
+    pub fn transpose(self) -> Result<MaybeUndefined<T>, E> {
+        match self {
+            MaybeUndefined::Undefined => Ok(MaybeUndefined::Undefined),
+            MaybeUndefined::Null => Ok(MaybeUndefined::Null),
+            MaybeUndefined::Value(Ok(v)) => Ok(MaybeUndefined::Value(v)),
+            MaybeUndefined::Value(Err(e)) => Err(e)
         }
     }
 }
@@ -330,5 +403,77 @@ mod tests {
         value = MaybeUndefined::Value("abc".to_string());
         r = value.as_opt_deref();
         assert_eq!(r, Some(Some("abc")));
+    }
+
+    #[test]
+    fn test_contains_value() {
+        let test = "abc";
+
+        let mut value: MaybeUndefined<String> = MaybeUndefined::Undefined;
+        assert!(!value.contains_value(&test));
+
+        value = MaybeUndefined::Null;
+        assert!(!value.contains_value(&test));
+
+        value = MaybeUndefined::Value("abc".to_string());
+        assert!(value.contains_value(&test));
+    }
+
+    
+    #[test]
+    fn test_contains() {
+        let test = Some("abc");
+        let none: Option<&str> = None;
+
+        let mut value: MaybeUndefined<String> = MaybeUndefined::Undefined;
+        assert!(!value.contains(&test));
+        assert!(!value.contains(&none));
+
+        value = MaybeUndefined::Null;
+        assert!(!value.contains(&test));
+        assert!(value.contains(&none));
+
+        value = MaybeUndefined::Value("abc".to_string());
+        assert!(value.contains(&test));
+        assert!(!value.contains(&none));
+    }
+
+    #[test]
+    fn test_map_value() {
+        let mut value: MaybeUndefined<i32> = MaybeUndefined::Undefined;
+        assert_eq!(value.map_value(|v| v > 2), MaybeUndefined::Undefined);
+
+        value = MaybeUndefined::Null;
+        assert_eq!(value.map_value(|v| v > 2), MaybeUndefined::Null);
+
+        value = MaybeUndefined::Value(5);
+        assert_eq!(value.map_value(|v| v > 2), MaybeUndefined::Value(true));
+    }
+
+    #[test]
+    fn test_map() {
+        let mut value: MaybeUndefined<i32> = MaybeUndefined::Undefined;
+        assert_eq!(value.map(|v| Some(v.is_some())), MaybeUndefined::Undefined);
+
+        value = MaybeUndefined::Null;
+        assert_eq!(value.map(|v| Some(v.is_some())), MaybeUndefined::Value(false));
+
+        value = MaybeUndefined::Value(5);
+        assert_eq!(value.map(|v| Some(v.is_some())), MaybeUndefined::Value(true));
+    }
+
+    #[test]
+    fn test_transpose() {
+        let mut value: MaybeUndefined<Result<i32, &'static str>> = MaybeUndefined::Undefined;
+        assert_eq!(value.transpose(), Ok(MaybeUndefined::Undefined));
+
+        value = MaybeUndefined::Null;
+        assert_eq!(value.transpose(), Ok(MaybeUndefined::Null));
+
+        value = MaybeUndefined::Value(Ok(5));
+        assert_eq!(value.transpose(), Ok(MaybeUndefined::Value(5)));
+
+        value = MaybeUndefined::Value(Err("eror"));
+        assert_eq!(value.transpose(), Err("eror"));
     }
 }


### PR DESCRIPTION
This PR aims at improving the usability of MaybeUndefined: most operations should be possible without first converting the `MaybeUndefined<_>` into an `Option<Option<_>>`.

Exemple, decoding a base64 string given as an argument:
```rust
struct Changeset {
    bin: Option<Option<Vec<u8>>>,
}

// before
fn decode_before(param: MaybeUndefined<String>) -> Result<Changeset> {
    let decoded = Option::<Option<_>>::from(param).map(|v| v.map(base64::decode).transpose()).transpose()?;
    Ok(Changeset {
        bin: decoded
    })
}
// or
fn decode_before(param: MaybeUndefined<String>) -> Result<Changeset> {
    let decoded = match param {
        MaybeUndefined::Value(v) => Some(Some(base64::decode(v)?)),
        _ => None
    };
    
    Ok(Changeset {
        bin: decoded
    })
}

// after
fn decode_after(param: MaybeUndefined<String>) -> Result<Changeset> {
    let decoded = param.map_value(base64::decode).transpose()?;
    Ok(Changeset {
        bin: decoded.into()
    })
}
```

The name of the function might need to be changed. There is a need for two map/contains function because `MaybeUndefine` can have three states, as opposed to `Option` which only has two.

The `ok_*` and `map_*` functions from `Option` could also be ported but would be more complex to design, mainly because of the number of possible states.