### PR TITLE
Implemented CursorType for i32/i64

### DIFF
--- a/src/types/connection/cursor.rs
+++ b/src/types/connection/cursor.rs
@@ -31,6 +31,30 @@ impl CursorType for usize {
     }
 }
 
+impl CursorType for i32 {
+    type Error = ParseIntError;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl CursorType for i64 {
+    type Error = ParseIntError;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.to_string()
+    }
+}
+
 impl CursorType for String {
     type Error = Infallible;
 


### PR DESCRIPTION
Hi ✋ 

I implemented CursorType for i32/i64.

### Why I want to add it

Many RDB (usually backend of the GraphQL) is using i32/i64 for its id (INTEGER, BIGINT).
I think its common case that binding DB schema to the struct by using ORM.
For example I'm using async-graphql + sqlx in my production. like this.

```
#[derive(sqlx::FromRow, async_graphql::SimpleObject)]
struct User {
    pub id: i64,
    pub name: String,
};

// This id is BIGINT on Postgres.
```

I wanted to return this `User` from `async_graphql::connection::query()`.
But the CursorType only implemented for `usize` so I had to cast between `usize` and `i64` several part in my code.
And I couldn't `impl CursorType for i64` in my crate because of Rust restriction.

I think this PR is convenient for the users who are using RDB for async-graphql's backend.

Thank you 😁 


