### PR TITLE
Add unset method for ErrorExtensionValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Change the signature of the `connection::query` function to allow the callback to use any type that implements `Into<Error>`.
+
 ## [2.11.3] 2021-11-13
 
 - Implemented CursorType for i32/i64. [#701](https://github.com/async-graphql/async-graphql/pull/701)

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,10 @@ impl ErrorExtensionValues {
     pub fn set(&mut self, name: impl AsRef<str>, value: impl Into<Value>) {
         self.0.insert(name.as_ref().to_string(), value.into());
     }
+    /// Unset an extension value.
+    pub fn unset(&mut self, name: impl AsRef<str>) {
+        self.0.remove(name.as_ref().to_string());
+    }
 }
 
 /// An error in a GraphQL server.

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -52,7 +52,7 @@ pub async fn test_connection_additional_fields() {
                             },
                         )
                     }));
-                    Ok(connection)
+                    Ok::<_, Error>(connection)
                 },
             )
             .await


### PR DESCRIPTION
I've been using this library to develop an API and I'm missing this particular small feature to allow me to clean up internal errors.

I can set the values to null as it is, but I'd rather not expose the existence of the field to an attacker altogether. And it doesn't seem like it would hurt anybody to have that feature.