### PR TITLE
Add support for SmolStr via a feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ opentelemetry = { version = "0.16.0", optional = true, default-features = false,
 uuid = { version = "0.8.2", optional = true, features = ["v4", "serde"] }
 rust_decimal = { version = "1.14.3", optional = true }
 url = { version = "2.2.1", optional = true }
+smol_str = { version = "0.1.21", optional = true }
 
 # Non-feature optional dependencies
 blocking = { version = "1.0.2", optional = true }

--- a/src/types/external/mod.rs
+++ b/src/types/external/mod.rs
@@ -26,6 +26,8 @@ mod duration;
 mod naive_time;
 #[cfg(feature = "secrecy")]
 mod secrecy;
+#[cfg(feature = "smol_str")]
+mod smol_str;
 #[cfg(feature = "url")]
 mod url;
 #[cfg(feature = "uuid")]

--- a/src/types/external/smol_str.rs
+++ b/src/types/external/smol_str.rs
@@ -1,0 +1,25 @@
+use smol_str::SmolStr;
+
+use crate::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
+
+#[Scalar(
+    internal,
+    name = "SmolStr",
+    specified_by_url = "https://docs.rs/smol_str/latest/smol_str/struct.SmolStr.html"
+)]
+impl ScalarType for SmolStr {
+    fn parse(value: Value) -> InputValueResult<Self> {
+        match value {
+            Value::String(s) => Ok(SmolStr::new(s)),
+            _ => Err(InputValueError::expected_type(value)),
+        }
+    }
+
+    fn is_valid(value: &Value) -> bool {
+        matches!(value, Value::String(_))
+    }
+
+    fn to_value(&self) -> Value {
+        Value::String(self.to_string())
+    }
+}


### PR DESCRIPTION
SmolStr is an immutable "packed" string that uses the space normally occupied
by a String's header if the String is short enough.

I mostly copied the implementation from Uuid, which didn't appear to have any test coverage.
Happy to add some to this if you let me know roughly what the shape of the tests should be?