### PR TITLE
fix(tracing): add name to error event

### DIFF
--- a/src/extensions/tracing.rs
+++ b/src/extensions/tracing.rs
@@ -143,7 +143,9 @@ impl Extension for TracingExtension {
         );
         next.run(ctx, info)
             .map_err(|err| {
-                tracinglib::info!(target: "async_graphql::graphql", error = %err.message);
+                tracinglib::info!(target: "async_graphql::graphql",
+                                  error = %err.message,
+                                  "error");
                 err
             })
             .instrument(span)


### PR DESCRIPTION
According to the [opentelemetry specification for traces][0], each span must have a non-empty name.

[0]: https://github.com/open-telemetry/oteps/blob/main/text/trace/0059-otlp-trace-data-format.md

>  // This field is semantically required to be set to non-empty string.
>  //
>  // This field is required.
>  string name = 6;

When enabling tracing of async-graphql, the trace receiver was rejecting these traces because the name was empty. The logs did not indicate which trace was rejected, but this seems likely and all traces have been accepted in testing since.
I don't know that this is the correct solution, particularly enforcing opentelemetry requirements on tracing (which is not exclusively used with opentelemetry subscribers) feels off.