### PR TITLE
Fix compilation with change from poem 1.2.x

### DIFF
--- a/integrations/poem/src/subscription.rs
+++ b/integrations/poem/src/subscription.rs
@@ -30,7 +30,7 @@ impl<'a> FromRequest<'a> for GraphQLProtocol {
                     .find_map(|p| WebSocketProtocols::from_str(p.trim()).ok())
             })
             .map(Self)
-            .ok_or_else(|| Error::new_with_status(StatusCode::BAD_REQUEST))
+            .ok_or_else(|| Error::from_status(StatusCode::BAD_REQUEST))
     }
 }
 


### PR DESCRIPTION
This fixes the issue when compiling with `poem` 1.2.x where `Error::new_with_status` was renamed to `Error::from_status`.

Previously, it was failing with 
```
error[E0599]: no function or associated item named `new_with_status` found for struct `poem::Error` in the current scope
  --> integrations/poem/src/subscription.rs:33:35
   |
33 |             .ok_or_else(|| Error::new_with_status(StatusCode::BAD_REQUEST))
   |                                   ^^^^^^^^^^^^^^^ function or associated item not found in `poem::Error`
```