### PR TITLE
replace custom email validation with fast_chemail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ sha2 = { version = "0.9.3", optional = true }
 futures-timer = { version = "3.0.2", optional = true }
 futures-channel = { version = "0.3.13", optional = true }
 serde_cbor = { version = "0.11.1", optional = true }
+fast_chemail = "0.9.6"
 
 [dev-dependencies]
 tokio = { version = "1.4.0", features = ["macros", "rt-multi-thread", "sync", "time"] }

--- a/src/validators/email.rs
+++ b/src/validators/email.rs
@@ -1,13 +1,8 @@
 use crate::{InputType, InputValueError};
-use once_cell::sync::Lazy;
-use regex::Regex;
-
-static EMAIL_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new("^(([0-9A-Za-z!#$%&'*+-/=?^_`{|}~&&[^@]]+)|(\"([0-9A-Za-z!#$%&'*+-/=?^_`{|}~ \"(),:;<>@\\[\\\\\\]]+)\"))@").unwrap()
-});
+use fast_chemail::is_valid_email;
 
 pub fn email<T: AsRef<str> + InputType>(value: &T) -> Result<(), InputValueError<T>> {
-    if EMAIL_RE.is_match(value.as_ref()) {
+    if is_valid_email(value.as_ref()) {
         Ok(())
     } else {
         Err("invalid email".into())
@@ -20,45 +15,13 @@ mod tests {
 
     #[test]
     fn test_email() {
-        let test_cases = [
-            // Invalid emails
-            ("plainaddress", true),
-            // ("#@%^%#$@#$@#.com", true),
-            ("@example.com", true),
-            ("Joe Smith <email@example.com>", true),
-            ("email.example.com", true),
-            // ("email@example@example.com", true),
-            // (".email@example.com", true),
-            // ("email.@example.com", true),
-            // ("email..email@example.com", true),
-            ("あいうえお@example.com", true),
-            // ("email@example.com (Joe Smith)", true),
-            // ("email@example", true),
-            // ("email@-example.com", true),
-            // ("email@example.web", true),
-            // ("email@111.222.333.44444", true),
-            // ("email@example..com", true),
-            // ("Abc..123@example.com", true),
-            // Valid Emails
-            ("email@example.com", false),
-            ("firstname.lastname@example.com", false),
-            ("email@subdomain.example.com", false),
-            ("firstname+lastname@example.com", false),
-            ("email@123.123.123.123", false),
-            ("email@[123.123.123.123]", false),
-            // This returns parsing error
-            // (r#""email"@example.com"#, false),
-            ("1234567890@example.com", false),
-            ("email@example-one.com", false),
-            ("_______@example.com", false),
-            ("email@example.name", false),
-            ("email@example.museum", false),
-            ("email@example.co.jp", false),
-            ("firstname-lastname@example.com", false),
-        ];
+        assert!(email(&"joe@example.com".to_string()).is_ok());
+        assert!(email(&"joe.test@example.com".to_string()).is_ok());
+        assert!(email(&"email@example-one.com".to_string()).is_ok());
+        assert!(email(&"1234567890@example.com".to_string()).is_ok());
 
-        for (s, res) in test_cases {
-            assert_eq!(email(&s.to_string()).is_err(), res);
-        }
+        assert!(email(&"plainaddress".to_string()).is_err());
+        assert!(email(&"@example.com".to_string()).is_err());
+        assert!(email(&"email.example.com".to_string()).is_err());
     }
 }


### PR DESCRIPTION
The current email validator is not a very good implementation as can be seen by how many tests have been included in the code while being disabled.

It also lacks any checking of the length of the email which is something I think it should definitely have to prevent storing or processing large emails which could act as a DoS vector.

After trying to write my own validator using Regex's like the current implementation I have come to the conclusion that `async-graphql` probably shouldn't be implementing something as complicated as email validation by itself as issues will always make it through.

To solve this issue I have changed the email validator to use the package [`fast_chemail`](https://crates.io/crates/fast_chemail) to do this validation. This is the library that [`lettre`](https://crates.io/crates/lettre) uses internally so I think it is a solid library to use.

I also ran all of the existing tests in the repository against this new implementation and the following tests acted differently:
 - The existing **enabled** test for `email@[123.123.123.123]` asserts it should be valid but when using `fast_chemail` it is invalid. This is due to the [HTML email validation specification](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address). **This test was enabled** so this would definitely count as a breaking change.
 - The existing **disabled** test for `email@111.222.333.44444` asserts it should be invalid but when using `fast_chemail` it is valid. This is due to the lack of IP validation in `fast_chemail`. This test however fails in the current implementation so shouldn't be of concern.
 - The existing **disabled** test for `email@example.web` asserts it should be invalid but when using `fast_chemail` it is valid. This is due to the lack of TLD validation in `fast_chemail`. This test however fails in the current implementation so shouldn't be of concern.
 - The existing **disabled** test for `"email"@example.com` asserts it should be valid but when using  `fast_chemail` it is invalid. This is due to the [HTML email validation specification](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address).

If adding the extra dependency is an issue maybe it is worth putting this validator behind a feature flag. I can do this if requested.

I think adding this is important because as a consumer of the library I want to know that the emails are being validated properly.  I also think as a bonus having the email validation code use similar logic to `<input type="email" />`  is better for web applications.