### PR TITLE
fix: issue when empty with federation spec on _Entity node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+- Federation's `_Entity` should not be sent if empty as it's in conflict with [GraphQL Union type validation](https://spec.graphql.org/draft/#sec-Unions.Type-Validation) [#765](https://github.com/async-graphql/async-graphql/pull/765).
+
 ## [3.0.17] 2021-12-16
 
 - Bump poem to `1.2.2`.


### PR DESCRIPTION
Hello 👋 

There is an issue with the current implementation of the `_Entity` node for federation.

[Reference](https://www.apollographql.com/docs/federation/federation-spec/#resolve-requests-for-entities)

**If no types are annotated with the key directive, then the _Entity union and Query._entities field should be removed from the schema.**