### PR TITLE
Add hashbrown HashMap/HashSet implementations for Input/Output type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.19] 2021-12-28
+
+- Add `InputType` / `OutputType` support for `hashbrown` crate.
+
 ## [3.0.18] 2021-12-26
 
 - Federation's `_Entity` should not be sent if empty as it's in conflict with [GraphQL Union type validation](https://spec.graphql.org/draft/#sec-Unions.Type-Validation) [#765](https://github.com/async-graphql/async-graphql/pull/765).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ async-stream = "0.3.0"
 async-trait = "0.1.48"
 fnv = "1.0.7"
 futures-util = { version = "0.3.0", default-features = false, features = ["io", "sink"] }
+hashbrown = { version="0.11.2", optional = true }
 indexmap = "1.6.2"
 once_cell = "1.7.2"
 pin-project-lite = "0.2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ async-stream = "0.3.0"
 async-trait = "0.1.48"
 fnv = "1.0.7"
 futures-util = { version = "0.3.0", default-features = false, features = ["io", "sink"] }
-hashbrown = { version="0.11.2", optional = true }
 indexmap = "1.6.2"
 once_cell = "1.7.2"
 pin-project-lite = "0.2.6"
@@ -53,6 +52,7 @@ num-traits = "0.2.14"
 bson = { version = "2.0.0", optional = true, features = ["chrono-0_4"] }
 chrono = { version = "0.4.19", optional = true }
 chrono-tz = { version = "0.5.3", optional = true }
+hashbrown = { version = "0.11.2", optional = true }
 iso8601-duration = { version = "0.1.0", optional = true }
 log = { version = "0.4.14", optional = true }
 secrecy = { version = "0.7.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@
 //! - `decimal`: Integrate with the [`rust_decimal` crate](https://crates.io/crates/rust_decimal).
 //! - `cbor`: Support for [serde_cbor](https://crates.io/crates/serde_cbor).
 //! - `smol_str`: Integrate with the [`smol_str` crate](https://crates.io/crates/smol_str).
+//! - `hashbrown`: Integrate with the [`hashbrown` crate](https://github.com/rust-lang/hashbrown).
 //!
 //! ## Integrations
 //!

--- a/src/types/external/json_object/hashbrown_hashmap.rs
+++ b/src/types/external/json_object/hashbrown_hashmap.rs
@@ -1,0 +1,111 @@
+use std::borrow::Cow;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::str::FromStr;
+
+use async_graphql_parser::types::Field;
+use async_graphql_parser::Positioned;
+use async_graphql_value::{from_value, to_value};
+use hashbrown::HashMap;
+use indexmap::IndexMap;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::registry::{MetaType, Registry};
+use crate::{
+    ContextSelectionSet, InputType, InputValueError, InputValueResult, Name, OutputType,
+    ServerResult, Value,
+};
+
+impl<K, V> InputType for HashMap<K, V>
+    where
+        K: ToString + FromStr + Eq + Hash + Send + Sync,
+        K::Err: Display,
+        V: Serialize + DeserializeOwned + Send + Sync,
+{
+    type RawValueType = Self;
+
+    fn type_name() -> Cow<'static, str> {
+        Cow::Borrowed("JSONObject")
+    }
+
+    fn create_type_info(registry: &mut Registry) -> String {
+        registry.create_input_type::<Self, _>(|_| MetaType::Scalar {
+            name: <Self as InputType>::type_name().to_string(),
+            description: Some("A scalar that can represent any JSON Object value."),
+            is_valid: |_| true,
+            visible: None,
+            specified_by_url: None,
+        })
+    }
+
+    fn parse(value: Option<Value>) -> InputValueResult<Self> {
+        let value = value.unwrap_or_default();
+        match value {
+            Value::Object(map) => map
+                .into_iter()
+                .map(|(name, value)| {
+                    Ok((
+                        K::from_str(&name).map_err(|err| {
+                            InputValueError::<Self>::custom(format!("object key: {}", err))
+                        })?,
+                        from_value(value).map_err(|err| format!("object value: {}", err))?,
+                    ))
+                })
+                .collect::<Result<_, _>>()
+                .map_err(InputValueError::propagate),
+            _ => Err(InputValueError::expected_type(value)),
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        let mut map = IndexMap::new();
+        for (name, value) in self {
+            map.insert(
+                Name::new(name.to_string()),
+                to_value(value).unwrap_or_default(),
+            );
+        }
+        Value::Object(map)
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl<K, V> OutputType for HashMap<K, V>
+    where
+        K: ToString + Eq + Hash + Send + Sync,
+        V: Serialize + Send + Sync,
+{
+    fn type_name() -> Cow<'static, str> {
+        Cow::Borrowed("JSONObject")
+    }
+
+    fn create_type_info(registry: &mut Registry) -> String {
+        registry.create_output_type::<Self, _>(|_| MetaType::Scalar {
+            name: <Self as OutputType>::type_name().to_string(),
+            description: Some("A scalar that can represent any JSON Object value."),
+            is_valid: |_| true,
+            visible: None,
+            specified_by_url: None,
+        })
+    }
+
+    async fn resolve(
+        &self,
+        _ctx: &ContextSelectionSet<'_>,
+        _field: &Positioned<Field>,
+    ) -> ServerResult<Value> {
+        let mut map = IndexMap::new();
+        for (name, value) in self {
+            map.insert(
+                Name::new(name.to_string()),
+                to_value(value).unwrap_or_default(),
+            );
+        }
+        Ok(Value::Object(map))
+    }
+}

--- a/src/types/external/json_object/hashbrown_hashmap.rs
+++ b/src/types/external/json_object/hashbrown_hashmap.rs
@@ -7,22 +7,22 @@ use async_graphql_parser::types::Field;
 use async_graphql_parser::Positioned;
 use async_graphql_value::{from_value, to_value};
 use hashbrown::HashMap;
-use std::collections::HashMap as StdHashMap;
 use indexmap::IndexMap;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::collections::HashMap as StdHashMap;
 
-use crate::registry::{Registry};
+use crate::registry::Registry;
 use crate::{
     ContextSelectionSet, InputType, InputValueError, InputValueResult, Name, OutputType,
     ServerResult, Value,
 };
 
 impl<K, V> InputType for HashMap<K, V>
-    where
-        K: ToString + FromStr + Eq + Hash + Send + Sync,
-        K::Err: Display,
-        V: Serialize + DeserializeOwned + Send + Sync,
+where
+    K: ToString + FromStr + Eq + Hash + Send + Sync,
+    K::Err: Display,
+    V: Serialize + DeserializeOwned + Send + Sync,
 {
     type RawValueType = Self;
 
@@ -71,9 +71,9 @@ impl<K, V> InputType for HashMap<K, V>
 
 #[async_trait::async_trait]
 impl<K, V> OutputType for HashMap<K, V>
-    where
-        K: ToString + Eq + Hash + Send + Sync,
-        V: Serialize + Send + Sync,
+where
+    K: ToString + Eq + Hash + Send + Sync,
+    V: Serialize + Send + Sync,
 {
     fn type_name() -> Cow<'static, str> {
         <StdHashMap<K, V> as OutputType>::type_name()

--- a/src/types/external/json_object/hashbrown_hashmap.rs
+++ b/src/types/external/json_object/hashbrown_hashmap.rs
@@ -12,7 +12,7 @@ use indexmap::IndexMap;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use crate::registry::{MetaType, Registry};
+use crate::registry::{Registry};
 use crate::{
     ContextSelectionSet, InputType, InputValueError, InputValueResult, Name, OutputType,
     ServerResult, Value,

--- a/src/types/external/json_object/hashbrown_hashmap.rs
+++ b/src/types/external/json_object/hashbrown_hashmap.rs
@@ -7,6 +7,7 @@ use async_graphql_parser::types::Field;
 use async_graphql_parser::Positioned;
 use async_graphql_value::{from_value, to_value};
 use hashbrown::HashMap;
+use std::collections::HashMap as StdHashMap;
 use indexmap::IndexMap;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -26,17 +27,11 @@ impl<K, V> InputType for HashMap<K, V>
     type RawValueType = Self;
 
     fn type_name() -> Cow<'static, str> {
-        Cow::Borrowed("JSONObject")
+        <StdHashMap<K, V> as InputType>::type_name()
     }
 
     fn create_type_info(registry: &mut Registry) -> String {
-        registry.create_input_type::<Self, _>(|_| MetaType::Scalar {
-            name: <Self as InputType>::type_name().to_string(),
-            description: Some("A scalar that can represent any JSON Object value."),
-            is_valid: |_| true,
-            visible: None,
-            specified_by_url: None,
-        })
+        <StdHashMap<K, V> as InputType>::create_type_info(registry)
     }
 
     fn parse(value: Option<Value>) -> InputValueResult<Self> {
@@ -81,17 +76,11 @@ impl<K, V> OutputType for HashMap<K, V>
         V: Serialize + Send + Sync,
 {
     fn type_name() -> Cow<'static, str> {
-        Cow::Borrowed("JSONObject")
+        <StdHashMap<K, V> as OutputType>::type_name()
     }
 
     fn create_type_info(registry: &mut Registry) -> String {
-        registry.create_output_type::<Self, _>(|_| MetaType::Scalar {
-            name: <Self as OutputType>::type_name().to_string(),
-            description: Some("A scalar that can represent any JSON Object value."),
-            is_valid: |_| true,
-            visible: None,
-            specified_by_url: None,
-        })
+        <StdHashMap<K, V> as OutputType>::create_type_info(registry)
     }
 
     async fn resolve(

--- a/src/types/external/json_object/mod.rs
+++ b/src/types/external/json_object/mod.rs
@@ -1,2 +1,4 @@
 mod btreemap;
+#[cfg(feature = "hashbrown")]
+mod hashbrown_hashmap;
 mod hashmap;

--- a/src/types/external/list/hashbrown_hash_set.rs
+++ b/src/types/external/list/hashbrown_hash_set.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::cmp::Eq;
+use std::collections::HashSet as StdHashSet;
 use std::hash::Hash;
 
 use hashbrown::HashSet;
@@ -15,16 +16,15 @@ impl<T: InputType + Hash + Eq> InputType for HashSet<T> {
     type RawValueType = Self;
 
     fn type_name() -> Cow<'static, str> {
-        Cow::Owned(format!("[{}]", T::qualified_type_name()))
+        <StdHashSet<T> as InputType>::type_name()
     }
 
     fn qualified_type_name() -> String {
-        format!("[{}]!", T::qualified_type_name())
+        <StdHashSet<T> as InputType>::qualified_type_name()
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {
-        T::create_type_info(registry);
-        Self::qualified_type_name()
+        <StdHashSet<T> as InputType>::create_type_info(registry)
     }
 
     fn parse(value: Option<Value>) -> InputValueResult<Self> {
@@ -54,16 +54,15 @@ impl<T: InputType + Hash + Eq> InputType for HashSet<T> {
 #[async_trait::async_trait]
 impl<T: OutputType + Hash + Eq> OutputType for HashSet<T> {
     fn type_name() -> Cow<'static, str> {
-        Cow::Owned(format!("[{}]", T::qualified_type_name()))
+        <StdHashSet<T> as OutputType>::type_name()
     }
 
     fn qualified_type_name() -> String {
-        format!("[{}]!", T::qualified_type_name())
+        <StdHashSet<T> as OutputType>::qualified_type_name()
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {
-        T::create_type_info(registry);
-        Self::qualified_type_name()
+        <StdHashSet<T> as OutputType>::create_type_info(registry)
     }
 
     async fn resolve(

--- a/src/types/external/list/hashbrown_hash_set.rs
+++ b/src/types/external/list/hashbrown_hash_set.rs
@@ -1,0 +1,76 @@
+use std::borrow::Cow;
+use std::cmp::Eq;
+use std::hash::Hash;
+
+use hashbrown::HashSet;
+
+use crate::parser::types::Field;
+use crate::resolver_utils::resolve_list;
+use crate::{
+    registry, ContextSelectionSet, InputType, InputValueError, InputValueResult, OutputType,
+    Positioned, Result, ServerResult, Value,
+};
+
+impl<T: InputType + Hash + Eq> InputType for HashSet<T> {
+    type RawValueType = Self;
+
+    fn type_name() -> Cow<'static, str> {
+        Cow::Owned(format!("[{}]", T::qualified_type_name()))
+    }
+
+    fn qualified_type_name() -> String {
+        format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn create_type_info(registry: &mut registry::Registry) -> String {
+        T::create_type_info(registry);
+        Self::qualified_type_name()
+    }
+
+    fn parse(value: Option<Value>) -> InputValueResult<Self> {
+        match value.unwrap_or_default() {
+            Value::List(values) => values
+                .into_iter()
+                .map(|value| InputType::parse(Some(value)))
+                .collect::<Result<_, _>>()
+                .map_err(InputValueError::propagate),
+            value => Ok({
+                let mut result = Self::default();
+                result.insert(InputType::parse(Some(value)).map_err(InputValueError::propagate)?);
+                result
+            }),
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        Value::List(self.iter().map(InputType::to_value).collect())
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: OutputType + Hash + Eq> OutputType for HashSet<T> {
+    fn type_name() -> Cow<'static, str> {
+        Cow::Owned(format!("[{}]", T::qualified_type_name()))
+    }
+
+    fn qualified_type_name() -> String {
+        format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn create_type_info(registry: &mut registry::Registry) -> String {
+        T::create_type_info(registry);
+        Self::qualified_type_name()
+    }
+
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSet<'_>,
+        field: &Positioned<Field>,
+    ) -> ServerResult<Value> {
+        resolve_list(ctx, field, self, Some(self.len())).await
+    }
+}

--- a/src/types/external/list/mod.rs
+++ b/src/types/external/list/mod.rs
@@ -1,6 +1,8 @@
 mod array;
 mod btree_set;
 mod hash_set;
+#[cfg(feature = "hashbrown")]
+mod hashbrown_hash_set;
 mod linked_list;
 mod slice;
 mod vec;


### PR DESCRIPTION
Greetings!

I don't know if that make any sense or don't look like third wheel, but `hashbrow` one in one replacement for `HashMap` from std and I using it in my project.