### PR TITLE
Bump lru to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ smol_str = { version = "0.1.21", optional = true }
 
 # Non-feature optional dependencies
 blocking = { version = "1.0.2", optional = true }
-lru = { version = "0.6.5", optional = true }
+lru = { version = "0.7.1", optional = true }
 sha2 = { version = "0.9.3", optional = true }
 futures-timer = { version = "3.0.2", optional = true }
 futures-channel = { version = "0.3.13", optional = true }


### PR DESCRIPTION
👋 A small PR to bump lru due to a RUSTSEC.

`async-graphql` is not impacted but `cargo-audit` complains about the fact that we should update dependency which depends on it

---
Use after free in lru crate
    = ID: RUSTSEC-2021-0130
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2021-0130
    = Lru crate has use after free vulnerability.

      Lru crate has two functions for getting an iterator. Both iterators give
      references to key and value. Calling specific functions, like pop(), will remove
      and free the value, and but it's still possible to access the reference of value
      which is already dropped causing use after free.
    = Announcement: jeromefroe/lru-rs#120
    = Solution: Upgrade to >=0.7.1
---
