### PR TITLE
Use indexmap version 1.6.2 in async-graphql-value

### DIFF
--- a/value/Cargo.toml
+++ b/value/Cargo.toml
@@ -15,4 +15,4 @@ categories = ["network-programming", "asynchronous"]
 serde_json = "1.0.64"
 serde = { version = "1.0.125", features = ["derive"] }
 bytes = { version = "1.0.1", features = ["serde"] }
-indexmap = { version = "1.7.0", features = ["serde"] }
+indexmap = { version = "1.6.2", features = ["serde"] }


### PR DESCRIPTION
# Issue

`indexmap 1.7.0` is causing dependency cycles when used alongside certains crates (see https://github.com/tkaitchuck/aHash/issues/95)
Currently, the **only fix** is to downgrade to `indexmap 1.6.2`

`async-graphql` depends on `indexmap = "1.6.2"`
**but** `async-graphql-value` depends on  `indexmap = "1.7.0"` 

This is preventing me pinning indexmap to 1.6.2 in my project

# Proposed solution

Change `async-graphql-value` to depend on `indexmap = "1.6.2"`, like `async-graphql`

No other change is required