### PR TITLE
Actix integration: cbor response support + error handling improvements

### DIFF
--- a/integrations/actix-web/Cargo.toml
+++ b/integrations/actix-web/Cargo.toml
@@ -21,6 +21,7 @@ actix-web-actors = "4.0.0-beta.9"
 async-channel = "1.6.1"
 futures-util = { version = "0.3.0", default-features = false }
 serde_json = "1.0.64"
+serde_cbor = "0.11"
 serde_urlencoded = "0.7.0"
 futures-channel = "0.3.13"
 thiserror = "1.0.30"

--- a/integrations/actix-web/Cargo.toml
+++ b/integrations/actix-web/Cargo.toml
@@ -21,11 +21,16 @@ actix-web-actors = "4.0.0-beta.9"
 async-channel = "1.6.1"
 futures-util = { version = "0.3.0", default-features = false }
 serde_json = "1.0.64"
-serde_cbor = "0.11"
 serde_urlencoded = "0.7.0"
 futures-channel = "0.3.13"
 thiserror = "1.0.30"
+serde_cbor = { version = "0.11.2", optional = true }
+
+[features]
+default = []
+cbor = ["serde_cbor"]
 
 [dev-dependencies]
 actix-rt = "2.2.0"
 async-mutex = "1.4.0"
+serde = { version = "1", features = ["derive"] }

--- a/integrations/actix-web/tests/graphql.rs
+++ b/integrations/actix-web/tests/graphql.rs
@@ -220,3 +220,51 @@ async fn test_count() {
             .into_bytes()
     );
 }
+
+#[cfg(feature = "cbor")]
+#[actix_rt::test]
+async fn test_cbor() {
+    let srv = test::init_service(
+        App::new()
+            .app_data(Data::new(Schema::new(
+                AddQueryRoot,
+                EmptyMutation,
+                EmptySubscription,
+            )))
+            .service(
+                web::resource("/")
+                    .guard(guard::Post())
+                    .to(gql_handle_schema::<AddQueryRoot, EmptyMutation, EmptySubscription>),
+            ),
+    )
+    .await;
+    let response = srv
+        .call(
+            test::TestRequest::with_uri("/")
+                .method(Method::POST)
+                .set_payload(r#"{"query":"{ add(a: 10, b: 20) }"}"#)
+                .insert_header((actix_http::header::ACCEPT, "application/cbor"))
+                .to_request(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    #[derive(Debug, serde::Deserialize, PartialEq)]
+    struct Response {
+        data: ResponseInner,
+    }
+    #[derive(Debug, serde::Deserialize, PartialEq)]
+    struct ResponseInner {
+        add: i32,
+    }
+    let body = actix_web::body::to_bytes(response.into_body())
+        .await
+        .unwrap();
+    let response: Response = serde_cbor::from_slice(&body).unwrap();
+    assert_eq!(
+        response,
+        Response {
+            data: ResponseInner { add: 30 }
+        }
+    );
+}


### PR DESCRIPTION
This PR does two things:
- Remove `.unwrap()` from the `Responder` impl for GraphQLResponse, instead opting to act the same way Actix's `Json` responder does it: https://docs.rs/actix-web/4.0.0-beta.20/src/actix_web/types/json.rs.html#119-137
- Add cbor support to the same impl, reading the `Accept` header and acting based on the mime type in there.

I'm not 100% sure if this PR is in a mergable state, I could feature-flag the whole cbor thing or split this up into two PRs if that's preferred.

I've also noticed that the cbor request implementation doesn't actually support the `application/cbor` mime type atm, the stated reason being that `mime` doesn't support it yet; however `mime` is unmaintained and will never add it, and also it's possible to match on `(mime::APPLICATION, "cbor")` without the crate needing to add support. That's definitely a separate PR however (and I don't need cbor requests, so I'm not sure if I'm the right person to implement that).