### PR TITLE
Fixed variable type not checked when given a default value

### DIFF
--- a/src/validation/rules/default_values_of_correct_type.rs
+++ b/src/validation/rules/default_values_of_correct_type.rs
@@ -1,3 +1,5 @@
+use async_graphql_parser::types::BaseType;
+
 use crate::context::QueryPathNode;
 use crate::parser::types::VariableDefinition;
 use crate::validation::utils::is_valid_input_value;
@@ -12,6 +14,13 @@ impl<'a> Visitor<'a> for DefaultValuesOfCorrectType {
         ctx: &mut VisitorContext<'a>,
         variable_definition: &'a Positioned<VariableDefinition>,
     ) {
+        if let BaseType::Named(vtype_name) = &variable_definition.node.var_type.node.base {
+          if !ctx.registry.types.contains_key(vtype_name.as_str()) {
+              ctx.report_error(vec![variable_definition.pos], format!(r#"Unknown type "{}""#, vtype_name));
+              return;
+          }
+        }
+
         if let Some(value) = &variable_definition.node.default_value {
             if !variable_definition.node.var_type.node.nullable {
                 ctx.report_error(vec![variable_definition.pos],format!(

--- a/src/validation/rules/default_values_of_correct_type.rs
+++ b/src/validation/rules/default_values_of_correct_type.rs
@@ -16,7 +16,10 @@ impl<'a> Visitor<'a> for DefaultValuesOfCorrectType {
     ) {
         if let BaseType::Named(vtype_name) = &variable_definition.node.var_type.node.base {
           if !ctx.registry.types.contains_key(vtype_name.as_str()) {
-              ctx.report_error(vec![variable_definition.pos], format!(r#"Unknown type "{}""#, vtype_name));
+              ctx.report_error(
+                vec![variable_definition.pos], 
+                format!(r#"Unknown type "{}""#, vtype_name)
+              );
               return;
           }
         }

--- a/src/validation/rules/default_values_of_correct_type.rs
+++ b/src/validation/rules/default_values_of_correct_type.rs
@@ -17,8 +17,8 @@ impl<'a> Visitor<'a> for DefaultValuesOfCorrectType {
         if let BaseType::Named(vtype_name) = &variable_definition.node.var_type.node.base {
             if !ctx.registry.types.contains_key(vtype_name.as_str()) {
                 ctx.report_error(
-                  vec![variable_definition.pos], 
-                  format!(r#"Unknown type "{}""#, vtype_name)
+                    vec![variable_definition.pos], 
+                    format!(r#"Unknown type "{}""#, vtype_name)
                 );
                 return;
             }

--- a/src/validation/rules/default_values_of_correct_type.rs
+++ b/src/validation/rules/default_values_of_correct_type.rs
@@ -15,13 +15,13 @@ impl<'a> Visitor<'a> for DefaultValuesOfCorrectType {
         variable_definition: &'a Positioned<VariableDefinition>,
     ) {
         if let BaseType::Named(vtype_name) = &variable_definition.node.var_type.node.base {
-          if !ctx.registry.types.contains_key(vtype_name.as_str()) {
-              ctx.report_error(
-                vec![variable_definition.pos], 
-                format!(r#"Unknown type "{}""#, vtype_name)
-              );
-              return;
-          }
+            if !ctx.registry.types.contains_key(vtype_name.as_str()) {
+                ctx.report_error(
+                  vec![variable_definition.pos], 
+                  format!(r#"Unknown type "{}""#, vtype_name)
+                );
+                return;
+            }
         }
 
         if let Some(value) = &variable_definition.node.default_value {

--- a/src/validation/rules/default_values_of_correct_type.rs
+++ b/src/validation/rules/default_values_of_correct_type.rs
@@ -17,8 +17,8 @@ impl<'a> Visitor<'a> for DefaultValuesOfCorrectType {
         if let BaseType::Named(vtype_name) = &variable_definition.node.var_type.node.base {
             if !ctx.registry.types.contains_key(vtype_name.as_str()) {
                 ctx.report_error(
-                    vec![variable_definition.pos], 
-                    format!(r#"Unknown type "{}""#, vtype_name)
+                    vec![variable_definition.pos],
+                    format!(r#"Unknown type "{}""#, vtype_name),
                 );
                 return;
             }


### PR DESCRIPTION
Given the following setup : 
```rust
 #[Object]
impl Query {
    pub async fn int_val(&self, value: Option<i32>) -> i32 {
        value.unwrap_or(10)
    }
}
```
This Request will fails and return the error message `Unknown Type "Invalid"` : 
```gql
query QueryWithVariables($intVal: invalid) {
    intVal(value: $intVal)
}
```
Whereas this one will cause a panic : 
```gql
query QueryWithVariables($intVal: invalid = 2) {
    intVal(value: $intVal)
}
```
This is because the code path for checking a variable with a default value doesn't check for the variable type. (see [this](https://github.com/async-graphql/async-graphql/blob/master/src/validation/rules/default_values_of_correct_type.rs#L21) and [this](https://github.com/async-graphql/async-graphql/blob/master/src/validation/utils.rs#L73)).

This PR adds two unit test to ensure that the problem is fixed and attempts to solve the problem by checking the variable type before checking the variable value.