### PR TITLE
Add `complex_output` attribute (#802)

### DIFF
--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -182,6 +182,8 @@ pub struct SimpleObject {
     #[darling(default)]
     pub complex: bool,
     #[darling(default)]
+    pub complex_output: bool,
+    #[darling(default)]
     pub name: Option<String>,
     #[darling(default)]
     pub rename_fields: Option<RenameRule>,
@@ -384,6 +386,9 @@ pub struct InputObject {
     pub attrs: Vec<Attribute>,
     pub data: Data<Ignored, InputObjectField>,
 
+    // for SimpleObject
+    #[darling(default)]
+    pub complex_output: bool,
     #[darling(default)]
     pub internal: bool,
     #[darling(default)]

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -267,7 +267,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
     let mut concat_complex_fields = quote!();
     let mut complex_resolver = quote!();
 
-    if object_args.complex {
+    if object_args.complex || object_args.complex_output {
         concat_complex_fields = quote! {
             fields.extend(<Self as #crate_name::ComplexObject>::fields(registry));
         };

--- a/tests/input_object.rs
+++ b/tests/input_object.rs
@@ -479,3 +479,46 @@ pub async fn test_skip_output() {
         })
     );
 }
+
+#[tokio::test]
+pub async fn test_complex_output() {
+    #[derive(SimpleObject, InputObject)]
+    #[graphql(input_name = "MyObjectInput")]
+    #[graphql(complex_output)]
+    #[allow(dead_code)]
+    struct MyObject {
+        a: i32,
+    }
+
+    #[ComplexObject]
+    impl MyObject {
+        async fn double(&self) -> i32 {
+            self.a * 2
+        }
+    }
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn obj(&self, input: MyObject) -> MyObject {
+            input
+        }
+    }
+
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+    assert_eq!(
+        schema
+            .execute("{ obj(input: { a: 1 }) { a, double } }")
+            .await
+            .into_result()
+            .unwrap()
+            .data,
+        value!({
+            "obj": {
+                "a": 1,
+                "double": 2,
+            }
+        })
+    );
+}


### PR DESCRIPTION
I'm not sure `complex_input` makes sense, so this could have just been to make `InputObject` ignore `complex` entirely, but I guess this is slightly more conservative? 