### PR TITLE
Add Input / Output for Box<[T]> and Output for Arc<[T]>.

### DIFF
--- a/src/types/external/list/array.rs
+++ b/src/types/external/list/array.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use crate::parser::types::Field;
 use crate::resolver_utils::resolve_list;
@@ -77,3 +78,67 @@ impl<T: OutputType, const N: usize> OutputType for [T; N] {
         resolve_list(ctx, field, self.iter(), Some(self.len())).await
     }
 }
+
+#[async_trait::async_trait]
+impl<T: InputType> InputType for Box<[T]> {
+    type RawValueType = Self;
+
+    fn type_name() -> Cow<'static, str> {
+        <Vec<T> as InputType>::type_name()
+    }
+
+    fn create_type_info(registry: &mut registry::Registry) -> String {
+        <Vec<T> as InputType>::create_type_info(registry)
+    }
+
+    fn parse(value: Option<Value>) -> InputValueResult<Self> {
+        match value.unwrap_or_default() {
+            Value::List(values) => values
+                .into_iter()
+                .map(|value| InputType::parse(Some(value)))
+                .collect::<Result<_, _>>()
+                .map_err(InputValueError::propagate),
+            value => Ok(Box::<[T]>::from([
+                InputType::parse(Some(value)).map_err(InputValueError::propagate)?
+            ])),
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        Value::List(self.iter().map(InputType::to_value).collect())
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self)
+    }
+}
+
+macro_rules! impl_output_arr_for_smart_ptr {
+    ($name:ident) => {
+        #[async_trait::async_trait]
+        impl<T: OutputType> OutputType for $name<[T]> {
+            fn type_name() -> Cow<'static, str> {
+                <Vec<T> as OutputType>::type_name()
+            }
+
+            fn qualified_type_name() -> String {
+                <Vec<T> as OutputType>::qualified_type_name()
+            }
+
+            fn create_type_info(registry: &mut registry::Registry) -> String {
+                <Vec<T> as OutputType>::create_type_info(registry)
+            }
+
+            async fn resolve(
+                &self,
+                ctx: &ContextSelectionSet<'_>,
+                field: &Positioned<Field>,
+            ) -> ServerResult<Value> {
+                resolve_list(ctx, field, self.iter(), Some(self.len())).await
+            }
+        }
+    };
+}
+
+impl_output_arr_for_smart_ptr!(Box);
+impl_output_arr_for_smart_ptr!(Arc);

--- a/tests/input_value.rs
+++ b/tests/input_value.rs
@@ -55,3 +55,29 @@ pub async fn test_input_box_str() {
         })
     );
 }
+
+#[tokio::test]
+pub async fn test_input_boxed_array() {
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn box_arr(&self, arr: Box<[Box<str>]>) -> Box<[Box<str>]> {
+            arr
+        }
+
+        async fn arc_arr(&self) -> Arc<[u8]> {
+            Arc::<[u8]>::from([1, 2, 3].as_ref())
+        }
+    }
+
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+    let query = r#"{ boxArr(arr: ["a","b","c"]) arcArr }"#;
+    assert_eq!(
+        schema.execute(query).await.into_result().unwrap().data,
+        value!({
+            "boxArr": ["a","b","c"],
+            "arcArr": [1,2,3],
+        })
+    );
+}


### PR DESCRIPTION
Solves #805.
P.S. I don't see reason to implement an Input type for `Arc`, because of you can't create `Arc<[T]>` from array / vector without copying data.