### PR TITLE
Introduce process_with for input object

### DIFF
--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -154,6 +154,8 @@ pub struct SimpleObjectField {
     pub visible: Option<Visible>,
     #[darling(default, multiple)]
     pub derived: Vec<DerivedField>,
+    #[darling(default)]
+    pub process_with: Option<String>,
     // for InputObject
     #[darling(default)]
     pub default: Option<DefaultValue>,
@@ -212,6 +214,8 @@ pub struct Argument {
     pub default: Option<DefaultValue>,
     pub default_with: Option<LitStr>,
     pub validator: Option<Validators>,
+    #[darling(default)]
+    pub process_with: Option<String>,
     pub key: bool, // for entity
     pub visible: Option<Visible>,
     pub secret: bool,
@@ -549,6 +553,8 @@ pub struct SubscriptionFieldArgument {
     pub default: Option<DefaultValue>,
     pub default_with: Option<LitStr>,
     pub validator: Option<Validators>,
+    #[darling(default)]
+    pub process_with: Option<String>,
     pub visible: Option<Visible>,
     pub secret: bool,
 }

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -372,6 +372,8 @@ pub struct InputObjectField {
     pub skip: bool,
     #[darling(default)]
     pub skip_input: bool,
+    #[darling(default)]
+    pub process_with: Option<String>,
     // for SimpleObject
     #[darling(default)]
     pub skip_output: bool,

--- a/derive/src/input_object.rs
+++ b/derive/src/input_object.rs
@@ -77,7 +77,7 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
 
         let process_with = match field.process_with.as_ref() {
             Some(fn_path) => {
-                let fn_path: syn::ExprPath = syn::parse_str(&fn_path)?;
+                let fn_path: syn::ExprPath = syn::parse_str(fn_path)?;
                 quote! {
                     #fn_path(&mut #ident);
                 }

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -189,7 +189,7 @@ pub fn generate(
                     if is_key {
                         get_federation_key.push(quote! {
                             if let Some(fields) = <#ty as #crate_name::InputType>::federation_fields() {
-                                key_str.push(format!("{} {}", #name, fields));                                
+                                key_str.push(format!("{} {}", #name, fields));
                             } else {
                                 key_str.push(#name.to_string());
                             }
@@ -360,6 +360,17 @@ pub fn generate(
                     });
                     use_params.push(quote! { #ident });
 
+                    let param_ident = &ident.ident;
+                    let process_with = match argument.process_with.as_ref() {
+                        Some(fn_path) => {
+                            let fn_path: syn::ExprPath = syn::parse_str(fn_path)?;
+                            quote! {
+                                #fn_path(&mut #param_ident);
+                            }
+                        }
+                        None => Default::default(),
+                    };
+
                     let validators = argument
                         .validator
                         .clone()
@@ -370,10 +381,15 @@ pub fn generate(
                             quote!(#ty),
                             Some(quote!(.map_err(|err| err.into_server_error(__pos)))),
                         )?;
+                    let mut non_mut_ident = ident.clone();
+                    non_mut_ident.mutability = None;
                     get_params.push(quote! {
-                        #[allow(non_snake_case, unused_variables)]
-                        let (__pos, #ident) = ctx.oneof_param_value::<#ty>()?;
+                        #[allow(non_snake_case, unused_variables, unused_mut)]
+                        let (__pos, mut #non_mut_ident) = ctx.oneof_param_value::<#ty>()?;
+                        #process_with
                         #validators
+                        #[allow(non_snake_case, unused_variables)]
+                        let #ident = #non_mut_ident;
                     });
                 } else {
                     for (
@@ -384,6 +400,7 @@ pub fn generate(
                             desc,
                             default,
                             default_with,
+                            process_with,
                             validator,
                             visible,
                             secret,
@@ -434,6 +451,16 @@ pub fn generate(
                             None => quote! { ::std::option::Option::None },
                         };
 
+                        let process_with = match process_with.as_ref() {
+                            Some(fn_path) => {
+                                let fn_path: syn::ExprPath = syn::parse_str(fn_path)?;
+                                quote! {
+                                    #fn_path(&mut #param_ident);
+                                }
+                            }
+                            None => Default::default(),
+                        };
+
                         let validators = validator.clone().unwrap_or_default().create_validators(
                             &crate_name,
                             quote!(&#ident),
@@ -441,10 +468,15 @@ pub fn generate(
                             Some(quote!(.map_err(|err| err.into_server_error(__pos)))),
                         )?;
 
+                        let mut non_mut_ident = ident.clone();
+                        non_mut_ident.mutability = None;
                         get_params.push(quote! {
-                            #[allow(non_snake_case, unused_variables)]
-                            let (__pos, #ident) = ctx.param_value::<#ty>(#name, #default)?;
+                            #[allow(non_snake_case, unused_variables, unused_mut)]
+                            let (__pos, mut #non_mut_ident) = ctx.param_value::<#ty>(#name, #default)?;
+                            #process_with
                             #validators
+                            #[allow(non_snake_case, unused_variables)]
+                            let #ident = #non_mut_ident;
                         });
                     }
                 }

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -92,6 +92,17 @@ pub fn generate(
                     });
                 use_params.push(quote! { #ident });
 
+                let param_ident = &ident.ident;
+                let process_with = match argument.process_with.as_ref() {
+                    Some(fn_path) => {
+                        let fn_path: syn::ExprPath = syn::parse_str(fn_path)?;
+                        quote! {
+                            #fn_path(&mut #param_ident);
+                        }
+                    }
+                    None => Default::default(),
+                };
+
                 let validators = argument
                     .validator
                     .clone()
@@ -102,10 +113,15 @@ pub fn generate(
                         quote!(#ty),
                         Some(quote!(.map_err(|err| err.into_server_error(__pos)))),
                     )?;
+                let mut non_mut_ident = ident.clone();
+                non_mut_ident.mutability = None;
                 get_params.push(quote! {
-                    #[allow(non_snake_case, unused_variables)]
-                    let (__pos, #ident) = ctx.oneof_param_value::<#ty>()?;
+                    #[allow(non_snake_case, unused_variables, unused_mut)]
+                    let (__pos, mut #non_mut_ident) = ctx.oneof_param_value::<#ty>()?;
+                    #process_with
                     #validators
+                    #[allow(non_snake_case, unused_variables)]
+                    let #ident = #non_mut_ident;
                 });
             } else {
                 for (
@@ -117,6 +133,7 @@ pub fn generate(
                         default,
                         default_with,
                         validator,
+                        process_with,
                         visible: arg_visible,
                         secret,
                     },
@@ -164,6 +181,18 @@ pub fn generate(
                         }
                         None => quote! { ::std::option::Option::None },
                     };
+
+                    let param_ident = &ident.ident;
+                    let process_with = match process_with.as_ref() {
+                        Some(fn_path) => {
+                            let fn_path: syn::ExprPath = syn::parse_str(fn_path)?;
+                            quote! {
+                                #fn_path(&mut #param_ident);
+                            }
+                        }
+                        None => Default::default(),
+                    };
+
                     let validators = validator.clone().unwrap_or_default().create_validators(
                         &crate_name,
                         quote!(&#ident),
@@ -171,10 +200,15 @@ pub fn generate(
                         Some(quote!(.map_err(|err| err.into_server_error(__pos)))),
                     )?;
 
+                    let mut non_mut_ident = ident.clone();
+                    non_mut_ident.mutability = None;
                     get_params.push(quote! {
-                        #[allow(non_snake_case)]
-                        let (__pos, #ident) = ctx.param_value::<#ty>(#name, #default)?;
+                        #[allow(non_snake_case, unused_mut)]
+                        let (__pos, mut #non_mut_ident) = ctx.param_value::<#ty>(#name, #default)?;
+                        #process_with
                         #validators
+                        #[allow(non_snake_case)]
+                        let #ident = #non_mut_ident;
                     });
                 }
             }

--- a/src/docs/complex_object.md
+++ b/src/docs/complex_object.md
@@ -52,6 +52,7 @@ some simple fields, and use the `ComplexObject` macro to define some other field
 | visible      | If `false`, it will not be displayed in introspection. *[See also the Book](https://async-graphql.github.io/async-graphql/en/visibility.html).* | bool        | Y        |
 | visible      | Call the specified function. If the return value is `false`, it will not be displayed in introspection.                                         | string      | Y        |
 | secret       | Mark this field as a secret, it will not output the actual value in the log.                                                                    | bool        | Y        |
+| process_with | Upon successful parsing, invokes specified function. Its signature must be `fn(&mut T)`.                                                        | code path   | Y        |
 
 # Examples
 
@@ -68,7 +69,7 @@ struct MyObj {
 #[ComplexObject]
 impl MyObj {
     async fn c(&self) -> i32 {
-        self.a + self.b     
+        self.a + self.b
     }
 }
 

--- a/src/docs/input_object.md
+++ b/src/docs/input_object.md
@@ -24,8 +24,7 @@ Define a GraphQL input object
 | flatten      | Similar to serde (flatten)                                                                                                                      | boolean     | Y        |
 | skip         | Skip this field, use `Default::default` to get a default value for this field.                                                                  | bool        | Y        |
 | skip_input   | Skip this field, similar to `skip`, but avoids conflicts when this macro is used with `SimpleObject`.                                           | bool        | Y        |
-| process_with | Upon successful parsing, invokes specified function. Its signature must be `fn(&mut T)`.
-                    | code path   | Y        |
+| process_with | Upon successful parsing, invokes specified function. Its signature must be `fn(&mut T)`.                                                        | code path   | Y        |
 | visible      | If `false`, it will not be displayed in introspection. *[See also the Book](https://async-graphql.github.io/async-graphql/en/visibility.html).* | bool        | Y        |
 | visible      | Call the specified function. If the return value is `false`, it will not be displayed in introspection.                                         | string      | Y        |
 | secret       | Mark this field as a secret, it will not output the actual value in the log.                                                                    | bool        | Y        |

--- a/src/docs/input_object.md
+++ b/src/docs/input_object.md
@@ -24,6 +24,8 @@ Define a GraphQL input object
 | flatten      | Similar to serde (flatten)                                                                                                                      | boolean     | Y        |
 | skip         | Skip this field, use `Default::default` to get a default value for this field.                                                                  | bool        | Y        |
 | skip_input   | Skip this field, similar to `skip`, but avoids conflicts when this macro is used with `SimpleObject`.                                           | bool        | Y        |
+| process_with | Upon successful parsing, invokes specified function. Its signature must be `fn(&mut T)`.
+                    | code path   | Y        |
 | visible      | If `false`, it will not be displayed in introspection. *[See also the Book](https://async-graphql.github.io/async-graphql/en/visibility.html).* | bool        | Y        |
 | visible      | Call the specified function. If the return value is `false`, it will not be displayed in introspection.                                         | string      | Y        |
 | secret       | Mark this field as a secret, it will not output the actual value in the log.                                                                    | bool        | Y        |

--- a/src/docs/object.md
+++ b/src/docs/object.md
@@ -56,6 +56,7 @@ All methods are converted to camelCase.
 | visible      | Call the specified function. If the return value is `false`, it will not be displayed in introspection.                                         | string      | Y        |
 | secret       | Mark this field as a secret, it will not output the actual value in the log.                                                                    | bool        | Y        |
 | key          | Is entity key(for Federation)                                                                                                                   | bool        | Y        |
+| process_with | Upon successful parsing, invokes specified function. Its signature must be `fn(&mut T)`.                                                        | code path   | Y        |
 
 # Derived argument attributes
 

--- a/src/docs/subscription.md
+++ b/src/docs/subscription.md
@@ -47,6 +47,7 @@ The filter function should be synchronous.
 | validator    | Input value validator *[See also the Book](https://async-graphql.github.io/async-graphql/en/input_value_validators.html)*                       | object      | Y        |
 | visible      | If `false`, it will not be displayed in introspection. *[See also the Book](https://async-graphql.github.io/async-graphql/en/visibility.html).* | bool        | Y        |
 | visible      | Call the specified function. If the return value is `false`, it will not be displayed in introspection.                                         | string      | Y        |
+| process_with | Upon successful parsing, invokes specified function. Its signature must be `fn(&mut T)`.                                                        | code path   | Y        |
 
 # Examples
 

--- a/tests/input_object.rs
+++ b/tests/input_object.rs
@@ -546,3 +546,88 @@ pub async fn test_complex_output() {
         })
     );
 }
+
+#[tokio::test]
+pub async fn test_input_object_process_with() {
+    mod processor {
+        pub fn string(input: &mut String) {
+            while let Some(ch) = input.pop() {
+                if !ch.is_whitespace() {
+                    input.push(ch);
+                    break;
+                }
+            }
+        }
+    }
+    #[derive(InputObject)]
+    struct MyInput {
+        //processor does nothing on default value
+        #[graphql(default = "  ", process_with = "processor::string")]
+        a: String,
+
+        #[graphql(process_with = "processor::string")]
+        b: String,
+    }
+
+    struct MyOutput {
+        a: String,
+        b: String,
+    }
+
+    #[Object]
+    impl MyOutput {
+        async fn a(&self) -> &String {
+            &self.a
+        }
+
+        async fn b(&self) -> &String {
+            &self.b
+        }
+    }
+
+    struct Root;
+
+    #[Object]
+    impl Root {
+        async fn a(&self, input: MyInput) -> MyOutput {
+            MyOutput {
+                a: input.a,
+                b: input.b,
+            }
+        }
+    }
+
+    let schema = Schema::new(Root, EmptyMutation, EmptySubscription);
+    let query = r#"{
+            a(input:{b: "test b   "}) {
+                a b
+            }
+        }"#
+    .to_owned();
+    assert_eq!(
+        schema.execute(&query).await.data,
+        value!({
+            "a": {
+                "a": "  ",
+                "b": "test b",
+            }
+        })
+    );
+
+    let schema = Schema::new(Root, EmptyMutation, EmptySubscription);
+    let query = r#"{
+            a(input:{a: "test a ", b: "test"}) {
+                a b
+            }
+        }"#
+    .to_owned();
+    assert_eq!(
+        schema.execute(&query).await.data,
+        value!({
+            "a": {
+                "a": "test a",
+                "b": "test",
+            }
+        })
+    );
+}

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -119,6 +119,30 @@ async fn test_flatten_with_context() {
 }
 
 #[tokio::test]
+async fn test_object_process_with_field() {
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn test(
+            &self,
+            #[graphql(process_with = "str::make_ascii_uppercase")] processed_arg: String,
+        ) -> String {
+            processed_arg
+        }
+    }
+
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+    let query = "{ test(processedArg: \"smol\") }";
+    assert_eq!(
+        schema.execute(query).await.into_result().unwrap().data,
+        value!({
+            "test": "SMOL"
+        })
+    );
+}
+
+#[tokio::test]
 async fn test_oneof_field() {
     #[derive(OneofObject)]
     enum TestArg {


### PR DESCRIPTION
This PR introduces attribute `process_with` which allows to specify path to a function that would accept mutable reference to the parsed field within `InputObject`

This is only done when object is supplied by user (e.g. default value is not post-processed) before validators are invoked

@sunli829 Let me know what you think. I found myself a need for this mostly because we need empty strings as a way to delete value(because we use `None` as indication of no change) and it is much better to safeguard myself from whitespace inputs by having this post-processor instead of rejecting input in validator, or doing post-processing yourself 