### PR TITLE
time: add date

### DIFF
--- a/src/types/external/time_date.rs
+++ b/src/types/external/time_date.rs
@@ -1,0 +1,72 @@
+use crate::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
+use time::{format_description::FormatItem, macros::format_description, Date};
+
+const DATE_FORMAT: &[FormatItem<'_>] = format_description!("[year]-[month]-[day]");
+
+/// A local datetime without timezone offset.
+///
+/// The input/output is a string in ISO 8601 format without timezone, including
+/// subseconds. E.g. "2022-01-12T07:30:19.12345".
+
+#[Scalar(internal, name = "Date")]
+/// ISO 8601 calendar date without timezone.
+/// Format: %Y-%m-%d
+///
+/// # Examples
+///
+/// * `1994-11-13`
+/// * `2000-02-24`
+impl ScalarType for Date {
+    fn parse(value: Value) -> InputValueResult<Self> {
+        match &value {
+            Value::String(s) => Ok(Self::parse(s, &DATE_FORMAT)?),
+            _ => Err(InputValueError::expected_type(value)),
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        Value::String(
+            self.format(&DATE_FORMAT)
+                .unwrap_or_else(|e| panic!("Failed to format `Date`: {}", e)),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ScalarType, Value};
+    use time::{macros::date, Date};
+
+    #[test]
+    fn test_date_to_value() {
+        let cases = [
+            (date!(1994 - 11 - 13), "1994-11-13"),
+            (date!(2000 - 00 - 24), "2000-00-24"),
+        ];
+        for (value, expected) in cases {
+            let value = value.to_value();
+
+            if let Value::String(s) = value {
+                assert_eq!(s, expected);
+            } else {
+                panic!(
+                    "Unexpected Value type when formatting PrimitiveDateTime: {:?}",
+                    value
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_date_parse() {
+        let cases = [
+            (date!(1994 - 11 - 13), "1994-11-13"),
+            (date!(2000 - 00 - 24), "2000-00-24"),
+        ];
+        for (value, expected) in cases {
+            let value = Value::String(value.to_string());
+            let parsed = <Date as ScalarType>::parse(value).unwrap();
+            assert_eq!(parsed, expected);
+        }
+    }
+}


### PR DESCRIPTION
Hey, thank you for the awesome crate!

This PR just adds the `Date` struct from the time crate. I mostly copied and pasted from relevant code. I couldn't run the tests on local as I had weird compilation errors. Maybe compiling this requires nightly ? (I was using stable 1.58.1)

in the transition from chrono (that is unmaintained and has a security vulnerability) to time, I found myself needing this `Date` struct.