### PR TITLE
custom_scalars: i64 not encoded as string

### DIFF
--- a/docs/en/src/custom_scalars.md
+++ b/docs/en/src/custom_scalars.md
@@ -4,7 +4,7 @@ In `Async-graphql` most common scalar types are built in, but you can also creat
 
 Using `async-graphql::Scalar`, you can add support for a scalar when you implement it. You only need to implement parsing and output functions.
 
-The following example defines a 64-bit integer scalar where its input and output are strings. (Note: `Async-graphql` already supports 64-bit integers and uses strings as input and output.)
+The following example defines a 64-bit integer scalar where its input and output are strings.
 
 ```rust
 use async_graphql::*;


### PR DESCRIPTION
Remove the note that incorrectly claims that i64 are encoded as strings.

Also see https://github.com/async-graphql/async-graphql/issues/196