### PR TITLE
Correct import path for cursor connection in docs

### DIFF
--- a/docs/en/src/cursor_connections.md
+++ b/docs/en/src/cursor_connections.md
@@ -6,7 +6,7 @@ Defining a cursor connection in `async-graphql` is very simple, you just call th
 
 ```rust
 use async_graphql::*;
-use async_graphql::connection::*;
+use async_graphql::types::connection::*;
 
 struct Query;
 

--- a/docs/zh-CN/src/cursor_connections.md
+++ b/docs/zh-CN/src/cursor_connections.md
@@ -8,7 +8,7 @@ Relay定义了一套游标连接规范，以提供一致性的分页查询方式
 
 ```rust
 use async_graphql::*;
-use async_graphql::connection::*;
+use async_graphql::types::connection::*;
 
 struct Query;
 

--- a/src/types/connection/mod.rs
+++ b/src/types/connection/mod.rs
@@ -26,7 +26,7 @@ pub struct EmptyFields;
 ///
 /// ```rust
 /// use async_graphql::*;
-/// use async_graphql::connection::*;
+/// use async_graphql::types::connection::*;
 ///
 /// struct Query;
 ///
@@ -116,7 +116,7 @@ where
 ///
 /// ```rust
 /// use async_graphql::*;
-/// use async_graphql::connection::*;
+/// use async_graphql::types::connection::*;
 ///
 /// #[derive(SimpleObject)]
 /// struct MyEdge {


### PR DESCRIPTION
As in title, just a little correction of paths for the book