### PR TITLE
Update actix to 0.13

### DIFF
--- a/integrations/actix-web/Cargo.toml
+++ b/integrations/actix-web/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming", "asynchronous"]
 [dependencies]
 async-graphql = { path = "../..", version = "3.0.32" }
 
-actix = "0.12.0"
+actix = "0.13.0"
 actix-http = "3.0.0"
 actix-web = { version = "4.0.1", default-features = false }
 actix-web-actors = "4.0.0"


### PR DESCRIPTION
Building the `actix-web` integration throws an error:
```
the trait `actix::actor::Actor` is not implemented for `subscription::GraphQLSubscriptionActor<Query, Mutation, Subscription, OnInit>`
```

Updating to actix 0.13 fixes this