### PR TITLE
Update regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ futures-util = { version = "0.3.0", default-features = false, features = ["io", 
 indexmap = "1.6.2"
 once_cell = "1.7.2"
 pin-project-lite = "0.2.6"
-regex = "1.4.5"
+regex = "1.5.5"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = "1.0.24"


### PR DESCRIPTION
Updates regex to `1.5.5` as per the [security advisory](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html)