### PR TITLE
Make HashMap more generic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [3.0.35] 2022-3-11
+
+- Make `HashMap` more generics for `InputOutput` and `OutputType`.
+
 # [3.0.34] 2022-3-5
 
 - Export `@oneOf` directive to SDL when Oneof type is defined. [#766](https://github.com/async-graphql/async-graphql/issues/766)

--- a/src/types/external/json_object/hashmap.rs
+++ b/src/types/external/json_object/hashmap.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::hash::Hash;
+use std::hash::{BuildHasher, Hash};
 use std::str::FromStr;
 
 use async_graphql_parser::types::Field;
@@ -17,11 +17,12 @@ use crate::{
     ServerResult, Value,
 };
 
-impl<K, V> InputType for HashMap<K, V>
+impl<K, V, S> InputType for HashMap<K, V, S>
 where
     K: ToString + FromStr + Eq + Hash + Send + Sync,
     K::Err: Display,
     V: Serialize + DeserializeOwned + Send + Sync,
+    S: Default + BuildHasher + Send + Sync,
 {
     type RawValueType = Self;
 
@@ -75,10 +76,11 @@ where
 }
 
 #[async_trait::async_trait]
-impl<K, V> OutputType for HashMap<K, V>
+impl<K, V, S> OutputType for HashMap<K, V, S>
 where
     K: ToString + Eq + Hash + Send + Sync,
     V: Serialize + Send + Sync,
+    S: Send + Sync,
 {
     fn type_name() -> Cow<'static, str> {
         Cow::Borrowed("JSONObject")


### PR DESCRIPTION
Greetings!

This adds state to `HashMap` generic to use different hashes (like for example `ahash`).