### PR TITLE
Add feature(bson-uuid) which will enable Uuid's from the bson crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-graphql"
-version = "3.0.36"
+version = "3.0.37"
 authors = ["sunli <scott_s829@163.com>", "Koxiaet"]
 edition = "2021"
 description = "A GraphQL server library implemented in Rust"

--- a/src/types/external/bson.rs
+++ b/src/types/external/bson.rs
@@ -2,6 +2,8 @@ use bson::{oid::ObjectId, Bson, Document};
 
 #[cfg(feature = "chrono")]
 use bson::DateTime as UtcDateTime;
+#[cfg(feature = "bson-uuid")]
+use bson::Uuid;
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, Utc};
 
@@ -12,6 +14,21 @@ impl ScalarType for ObjectId {
     fn parse(value: Value) -> InputValueResult<Self> {
         match value {
             Value::String(s) => Ok(ObjectId::parse_str(&s)?),
+            _ => Err(InputValueError::expected_type(value)),
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        Value::String(self.to_string())
+    }
+}
+
+#[cfg(feature = "bson-uuid")]
+#[Scalar(internal, name = "UUID")]
+impl ScalarType for Uuid {
+    fn parse(value: Value) -> InputValueResult<Self> {
+        match value {
+            Value::String(s) => Ok(Uuid::parse_str(&s)?),
             _ => Err(InputValueError::expected_type(value)),
         }
     }


### PR DESCRIPTION
Simple change but has great impact when using async-graphql with a mongodb database. Adds a new feature bson-uuid which should not be used in combo with uuid (due to them defining the same scalar differently). But this adds support for bson::Uuid which ensures that bson's are stored in the database using the proper structure while returning them through graphql api as strings.