### PR TITLE
Control name conflict panic with feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming", "asynchronous"]
 readme = "README.md"
 
 [features]
-default = []
+default = ["disallow-name-conflict"]
 apollo_tracing = ["chrono"]
 apollo_persisted_queries = ["lru", "sha2"]
 unblock = ["blocking"]
@@ -24,6 +24,7 @@ decimal = ["rust_decimal"]
 cbor = ["serde_cbor"]
 chrono-duration = ["chrono", "iso8601-duration"]
 password-strength-validator = ["zxcvbn"]
+disallow-name-conflict = []
 
 [dependencies]
 async-graphql-derive = { path = "derive", version = "3.0.36" }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -408,10 +408,12 @@ impl Registry {
             Some(ty) => {
                 if let Some(prev_typename) = ty.rust_typename() {
                     if prev_typename != "__fake_type__" && rust_typename != prev_typename {
-                        panic!(
-                            "`{}` and `{}` have the same GraphQL name `{}`",
-                            prev_typename, rust_typename, name,
-                        );
+                        if cfg!(feature = "disallow-name-conflict") {
+                            panic!(
+                                "`{}` and `{}` have the same GraphQL name `{}`",
+                                prev_typename, rust_typename, name,
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/async-graphql/async-graphql/issues/864

I had to go the `disallow` route with default because all the tests run with `--all-features`.
Probably doesn't matter since users didn't disable default in the past considering it was empty.