### PR TITLE
Update Axum integration to Axum 0.5.1

### DIFF
--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["network-programming", "asynchronous"]
 async-graphql = { path = "../..", version = "3.0.37" }
 
 async-trait = "0.1.51"
-axum = { version = "0.5", features = ["ws", "headers"] }
+axum = { version = "0.5.1", features = ["ws", "headers"] }
 bytes = "1.0.1"
 http-body = "0.4.2"
 serde_json = "1.0.66"

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["network-programming", "asynchronous"]
 async-graphql = { path = "../..", version = "3.0.37" }
 
 async-trait = "0.1.51"
-axum = { version = "0.4", features = ["ws", "headers"] }
+axum = { version = "0.5", features = ["ws", "headers"] }
 bytes = "1.0.1"
 http-body = "0.4.2"
 serde_json = "1.0.66"

--- a/integrations/axum/src/extract.rs
+++ b/integrations/axum/src/extract.rs
@@ -106,7 +106,7 @@ where
         } else {
             let content_type = req
                 .headers()
-                .and_then(|headers| headers.get(http::header::CONTENT_TYPE))
+                .get(http::header::CONTENT_TYPE)
                 .and_then(|value| value.to_str().ok())
                 .map(ToString::to_string);
             let body_stream = BodyStream::from_request(req)

--- a/integrations/axum/src/subscription.rs
+++ b/integrations/axum/src/subscription.rs
@@ -29,7 +29,7 @@ impl<B: Send> FromRequest<B> for GraphQLProtocol {
 
     async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection> {
         req.headers()
-            .and_then(|headers| headers.get(http::header::SEC_WEBSOCKET_PROTOCOL))
+            .get(http::header::SEC_WEBSOCKET_PROTOCOL)
             .and_then(|value| value.to_str().ok())
             .and_then(|protocols| {
                 protocols

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -91,8 +91,8 @@ pub async fn receive_batch_json(body: impl AsyncRead) -> Result<BatchRequest, Pa
     body.read_to_end(&mut data)
         .await
         .map_err(ParseRequestError::Io)?;
-    Ok(serde_json::from_slice::<BatchRequest>(&data)
-        .map_err(|e| ParseRequestError::InvalidRequest(Box::new(e)))?)
+    serde_json::from_slice::<BatchRequest>(&data)
+        .map_err(|e| ParseRequestError::InvalidRequest(Box::new(e)))
 }
 
 /// Receive a GraphQL request from a body as CBOR.

--- a/src/look_ahead.rs
+++ b/src/look_ahead.rs
@@ -38,7 +38,6 @@ impl<'a> Lookahead<'a> {
                 self.fragments,
                 &field.selection_set.node,
                 name,
-                self.context,
             )
         }
 
@@ -108,7 +107,6 @@ fn filter<'a>(
     fragments: &'a HashMap<Name, Positioned<FragmentDefinition>>,
     selection_set: &'a SelectionSet,
     name: &str,
-    context: &'a Context<'a>,
 ) {
     for item in &selection_set.items {
         match &item.node {
@@ -122,7 +120,6 @@ fn filter<'a>(
                 fragments,
                 &fragment.node.selection_set.node,
                 name,
-                context,
             ),
             Selection::FragmentSpread(spread) => {
                 if let Some(fragment) = fragments.get(&spread.node.fragment_name.node) {
@@ -131,7 +128,6 @@ fn filter<'a>(
                         fragments,
                         &fragment.node.selection_set.node,
                         name,
-                        context,
                     )
                 }
             }


### PR DESCRIPTION
## Description
As Axum is now on version `0.5.1`, I've gone ahead and updated the integration for it as my project needed it.

## Changes
Looks like `RequestParts::headers()` has changed in return value and no longer returns an `Option`. I've gone ahead and updated the locations that use this function.

This function as of `0.4`: https://docs.rs/axum/0.4.0/axum/extract/struct.RequestParts.html#method.headers

This function as of `0.5.1`: https://docs.rs/axum/0.5.1/axum/extract/struct.RequestParts.html#method.headers

Let me know if I missed something 👍🏼 