### PR TITLE
Support macro type in enum variant

### DIFF
--- a/tests/union.rs
+++ b/tests/union.rs
@@ -419,3 +419,24 @@ pub async fn test_trait_object_in_union() {
         })
     );
 }
+
+macro_rules! generate_union {
+    ($name:ident, $variant_ty:ty) => {
+        #[derive(Union)]
+        pub enum $name {
+            Val($variant_ty),
+        }
+    };
+}
+
+#[test]
+pub fn test_macro_generated_union() {
+    #[derive(SimpleObject)]
+    pub struct IntObj {
+        pub val: i32,
+    }
+
+    generate_union!(MyEnum, IntObj);
+
+    let _ = MyEnum::Val(IntObj { val: 1 });
+}


### PR DESCRIPTION
This is useful when union types (eg. result types) are generated by some `macro_rule`s.