### PR TITLE
Added instructions for returning errors from subscription resolvers

### DIFF
--- a/docs/en/src/error_handling.md
+++ b/docs/en/src/error_handling.md
@@ -25,3 +25,12 @@ impl Query {
     }
 }
 ```
+
+#### Errors in subscriptions
+
+Errors can be returned from subscription resolvers as well, using a return type of the form:
+```rust
+async fn my_subscription_resolver(&self) -> impl Stream<Item = Result<MyItem, MyError>> { ... }
+```
+
+Note however that the `MyError` struct must have `Clone` implemented, due to the restrictions placed by the `Subscription` macro. One way to accomplish this is by creating a custom error type, with `#[derive(Clone)]`, as [seen here](https://github.com/async-graphql/async-graphql/issues/845#issuecomment-1090933464).


### PR DESCRIPTION
^Title.

The example code in the linked comment is fairly long, so I just linked to it rather than including it in the page (also because my solution for changing the error-type within the resolver is probably more verbose than needed).

But the new explanation on the page at least sets people on the correct path.

Resolves #845 (mostly anyway).