### PR TITLE
Introduce ability to pre-parse Request's query

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -91,8 +91,8 @@ pub async fn receive_batch_json(body: impl AsyncRead) -> Result<BatchRequest, Pa
     body.read_to_end(&mut data)
         .await
         .map_err(ParseRequestError::Io)?;
-    Ok(serde_json::from_slice::<BatchRequest>(&data)
-        .map_err(|e| ParseRequestError::InvalidRequest(Box::new(e)))?)
+    serde_json::from_slice::<BatchRequest>(&data)
+        .map_err(|e| ParseRequestError::InvalidRequest(Box::new(e)))
 }
 
 /// Receive a GraphQL request from a body as CBOR.

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -111,6 +111,6 @@ pub async fn receive_batch_cbor(body: impl AsyncRead) -> Result<BatchRequest, Pa
     body.read_to_end(&mut data)
         .await
         .map_err(ParseRequestError::Io)?;
-    Ok(serde_cbor::from_slice::<BatchRequest>(&data)
-        .map_err(|e| ParseRequestError::InvalidRequest(Box::new(e)))?)
+    serde_cbor::from_slice::<BatchRequest>(&data)
+        .map_err(|e| ParseRequestError::InvalidRequest(Box::new(e)))
 }

--- a/src/http/websocket.rs
+++ b/src/http/websocket.rs
@@ -365,6 +365,7 @@ impl std::str::FromStr for Protocols {
 /// A websocket message received from the client
 #[derive(Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)] //Request is at fault
 pub enum ClientMessage {
     /// A new connection
     ConnectionInit {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,3 @@
-use core::future::Future;
-use core::pin::Pin;
-use core::task;
 use std::any::Any;
 use std::collections::HashMap;
 use std::ops::Deref;
@@ -13,9 +10,7 @@ use crate::context::{Data, QueryEnvInner};
 use crate::custom_directive::CustomDirectiveFactory;
 use crate::extensions::{ExtensionFactory, Extensions};
 use crate::model::__DirectiveLocation;
-use crate::parser::types::{
-    Directive, DocumentOperations, ExecutableDocument, OperationType, Selection, SelectionSet,
-};
+use crate::parser::types::{Directive, DocumentOperations, OperationType, Selection, SelectionSet};
 use crate::parser::{parse_query, Positioned};
 use crate::registry::{MetaDirective, MetaInputValue, Registry};
 use crate::resolver_utils::{resolve_container, resolve_container_serial};
@@ -26,26 +21,6 @@ use crate::{
     BatchRequest, BatchResponse, CacheControl, ContextBase, InputType, ObjectType, OutputType,
     QueryEnv, Request, Response, ServerError, SubscriptionType, Variables, ID,
 };
-
-pub struct ParseQueryFut<'a> {
-    query: &'a str,
-    parsed: Option<ExecutableDocument>,
-}
-
-impl<'a> Future for ParseQueryFut<'a> {
-    type Output = Result<ExecutableDocument, ServerError>;
-
-    #[inline(always)]
-    fn poll(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> task::Poll<Self::Output> {
-        let this = Pin::into_inner(self);
-        let result = match this.parsed.take() {
-            Some(document) => Ok(document),
-            None => parse_query(this.query).map_err(Into::into),
-        };
-
-        task::Poll::Ready(result)
-    }
-}
 
 /// Schema builder
 pub struct SchemaBuilder<Query, Mutation, Subscription> {
@@ -455,13 +430,16 @@ where
         let mut request = extensions.prepare_request(request).await?;
         let mut document = {
             let query = &request.query;
-            let fut_parse = ParseQueryFut {
-                query,
-                parsed: request.parsed_query.take(),
+            let parsed_doc = request.parsed_query.take();
+            let fut_parse = async move {
+                match parsed_doc {
+                    Some(parsed_doc) => Ok(parsed_doc),
+                    None => parse_query(query).map_err(Into::into),
+                }
             };
             futures_util::pin_mut!(fut_parse);
             extensions
-                .parse_query(&query, &request.variables, &mut fut_parse)
+                .parse_query(query, &request.variables, &mut fut_parse)
                 .await?
         };
 


### PR DESCRIPTION
This would allow user to avoid parsing query himself in order to determine its semantics

@sunli829 This is a bit specialized use case that I found myself in need.
Right now it is difficult to determine type of operation to finalize query context (in our case it is selection of Database: whether to use replica or primary)
So I made this split which would allow to parse, check operation type and then finalize execution.

It does require our database connection to be customizable without mutable reference to `Data` which is inconvenient but can be worked around with almost zero overhead (which is better than we parse query twice 😄 )