### PR TITLE
Introspection-only mode

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -13,11 +13,11 @@ use http::HeaderValue;
 use serde::ser::{SerializeSeq, Serializer};
 use serde::Serialize;
 
-use crate::extensions::Extensions;
 use crate::parser::types::{
     Directive, Field, FragmentDefinition, OperationDefinition, Selection, SelectionSet,
 };
 use crate::schema::SchemaEnv;
+use crate::{extensions::Extensions, schema::IntrospectionMode};
 use crate::{
     Error, InputType, Lookahead, Name, OneofObjectType, PathSegment, Pos, Positioned, Result,
     ServerError, ServerResult, UploadValue, Value,
@@ -244,7 +244,7 @@ pub struct QueryEnvInner {
     pub session_data: Arc<Data>,
     pub ctx_data: Arc<Data>,
     pub http_headers: Mutex<HeaderMap>,
-    pub disable_introspection: bool,
+    pub introspection_mode: IntrospectionMode,
     pub errors: Mutex<Vec<ServerError>>,
 }
 

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -9,12 +9,13 @@ use indexmap::map::IndexMap;
 use indexmap::set::IndexSet;
 
 pub use crate::model::__DirectiveLocation;
-use crate::parser::types::{
-    BaseType as ParsedBaseType, Field, Type as ParsedType, VariableDefinition,
-};
 use crate::{
     model, Any, Context, InputType, OutputType, Positioned, ServerResult, SubscriptionType, Value,
     VisitorContext,
+};
+use crate::{
+    parser::types::{BaseType as ParsedBaseType, Field, Type as ParsedType, VariableDefinition},
+    schema::IntrospectionMode,
 };
 
 pub use cache_control::CacheControl;
@@ -401,7 +402,7 @@ pub struct Registry {
     pub query_type: String,
     pub mutation_type: Option<String>,
     pub subscription_type: Option<String>,
-    pub disable_introspection: bool,
+    pub introspection_mode: IntrospectionMode,
     pub enable_federation: bool,
     pub federation_subscription: bool,
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::parser::parse_query;
 use crate::parser::types::ExecutableDocument;
+use crate::schema::IntrospectionMode;
 use crate::{Data, ParseRequestError, ServerError, UploadValue, Value, Variables};
 
 /// GraphQL request.
@@ -14,6 +15,7 @@ use crate::{Data, ParseRequestError, ServerError, UploadValue, Value, Variables}
 /// variables. The names are all in `camelCase` (e.g. `operationName`).
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Request {
     /// The query source of the request.
     #[serde(default)]
@@ -42,11 +44,17 @@ pub struct Request {
     pub extensions: HashMap<String, Value>,
 
     /// Disable introspection queries for this request.
+    /// This option has priority over `introspection_mode` when set to true.
+    /// `introspection_mode` has priority when `disable_introspection` set to `false`.
     #[serde(skip)]
     pub disable_introspection: bool,
 
     #[serde(skip)]
     pub(crate) parsed_query: Option<ExecutableDocument>,
+
+    /// Sets the introspection mode for this request (defaults to [IntrospectionMode::Enabled]).
+    #[serde(skip)]
+    pub introspection_mode: IntrospectionMode,
 }
 
 impl Request {
@@ -61,6 +69,7 @@ impl Request {
             extensions: Default::default(),
             disable_introspection: false,
             parsed_query: None,
+            introspection_mode: IntrospectionMode::Enabled,
         }
     }
 
@@ -90,6 +99,15 @@ impl Request {
     #[must_use]
     pub fn disable_introspection(mut self) -> Self {
         self.disable_introspection = true;
+        self.introspection_mode = IntrospectionMode::Disabled;
+        self
+    }
+
+    /// Only allow introspection queries for this request.
+    #[must_use]
+    pub fn only_introspection(mut self) -> Self {
+        self.disable_introspection = false;
+        self.introspection_mode = IntrospectionMode::IntrospectionOnly;
         self
     }
 
@@ -232,6 +250,17 @@ impl BatchRequest {
     pub fn disable_introspection(mut self) -> Self {
         for request in self.iter_mut() {
             request.disable_introspection = true;
+            request.introspection_mode = IntrospectionMode::Disabled;
+        }
+        self
+    }
+
+    /// Only allow introspection queries for each request.
+    #[must_use]
+    pub fn introspection_only(mut self) -> Self {
+        for request in self.iter_mut() {
+            request.disable_introspection = false;
+            request.introspection_mode = IntrospectionMode::IntrospectionOnly;
         }
         self
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use futures_util::stream::{self, Stream, StreamExt};
 use indexmap::map::IndexMap;
 
-use crate::context::{Data, QueryEnvInner};
 use crate::custom_directive::CustomDirectiveFactory;
 use crate::extensions::{ExtensionFactory, Extensions};
 use crate::model::__DirectiveLocation;
@@ -18,9 +17,27 @@ use crate::subscription::collect_subscription_streams;
 use crate::types::QueryRoot;
 use crate::validation::{check_rules, ValidationMode};
 use crate::{
+    context::{Data, QueryEnvInner},
+    EmptyMutation, EmptySubscription,
+};
+use crate::{
     BatchRequest, BatchResponse, CacheControl, ContextBase, InputType, ObjectType, OutputType,
     QueryEnv, Request, Response, ServerError, SubscriptionType, Variables, ID,
 };
+
+/// Introspection mode
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum IntrospectionMode {
+    IntrospectionOnly,
+    Enabled,
+    Disabled,
+}
+
+impl Default for IntrospectionMode {
+    fn default() -> Self {
+        IntrospectionMode::Enabled
+    }
+}
 
 /// Schema builder
 pub struct SchemaBuilder<Query, Mutation, Subscription> {
@@ -58,7 +75,14 @@ impl<Query, Mutation, Subscription> SchemaBuilder<Query, Mutation, Subscription>
     /// Disable introspection queries.
     #[must_use]
     pub fn disable_introspection(mut self) -> Self {
-        self.registry.disable_introspection = true;
+        self.registry.introspection_mode = IntrospectionMode::Disabled;
+        self
+    }
+
+    /// Only process introspection queries, everything else is processed as an error.
+    #[must_use]
+    pub fn introspection_only(mut self) -> Self {
+        self.registry.introspection_mode = IntrospectionMode::IntrospectionOnly;
         self
     }
 
@@ -303,7 +327,7 @@ where
             } else {
                 Some(Subscription::type_name().to_string())
             },
-            disable_introspection: false,
+            introspection_mode: IntrospectionMode::Enabled,
             enable_federation: false,
             federation_subscription: false,
         };
@@ -515,7 +539,11 @@ where
             session_data,
             ctx_data: query_data,
             http_headers: Default::default(),
-            disable_introspection: request.disable_introspection,
+            introspection_mode: if request.disable_introspection {
+                IntrospectionMode::Disabled
+            } else {
+                request.introspection_mode
+            },
             errors: Default::default(),
         };
         Ok((QueryEnv::new(env), validation_result.cache_control))
@@ -532,7 +560,15 @@ where
 
         let res = match &env.operation.node.ty {
             OperationType::Query => resolve_container(&ctx, &self.query).await,
-            OperationType::Mutation => resolve_container_serial(&ctx, &self.mutation).await,
+            OperationType::Mutation => {
+                if self.env.registry.introspection_mode == IntrospectionMode::IntrospectionOnly
+                    || env.introspection_mode == IntrospectionMode::IntrospectionOnly
+                {
+                    resolve_container_serial(&ctx, &EmptyMutation).await
+                } else {
+                    resolve_container_serial(&ctx, &self.mutation).await
+                }
+            }
             OperationType::Subscription => Err(ServerError::new(
                 "Subscriptions are not supported on this transport.",
                 None,
@@ -627,7 +663,15 @@ where
                 );
 
                 let mut streams = Vec::new();
-                if let Err(err) = collect_subscription_streams(&ctx, &schema.subscription, &mut streams) {
+                let collect_result = if schema.env.registry.introspection_mode
+                    == IntrospectionMode::IntrospectionOnly
+                    || env.introspection_mode == IntrospectionMode::IntrospectionOnly
+                {
+                    collect_subscription_streams(&ctx, &EmptySubscription, &mut streams)
+                } else {
+                    collect_subscription_streams(&ctx, &schema.subscription, &mut streams)
+                };
+                if let Err(err) = collect_result {
                     yield Response::from_errors(vec![err]);
                 }
 


### PR DESCRIPTION
This is useful for "proxies" (Hasura's remote schema feature) that only need access to introspection.