### PR TITLE
Expose SubscriptionType

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,6 @@ pub use response::{BatchResponse, Response};
 pub use schema::{Schema, SchemaBuilder, SchemaEnv};
 #[doc(hidden)]
 pub use static_assertions;
-#[doc(hidden)]
 pub use subscription::SubscriptionType;
 pub use types::*;
 pub use validation::{ValidationMode, ValidationResult, VisitorContext};


### PR DESCRIPTION
I know user is not supposed to implement this trait, but unfortunately it makes it difficult to figure out how to create Schema in a generic way.
So I think it would be best to open this trait while retaining hidden method of it to make it difficult to implement.

P.s. I know I can use it as it is since this trait is just hidden, but I think it would be better not to have people like me to look into source code to find it out 😄 