### PR TITLE
fix: update `log` to version `0.4.16`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ chrono = { version = "0.4.19", optional = true, default-features = false, featur
 chrono-tz = { version = "0.5.3", optional = true }
 hashbrown = { version = "0.12.0", optional = true }
 iso8601-duration = { version = "0.1.0", optional = true }
-log = { version = "0.4.14", optional = true }
+log = { version = "0.4.16", optional = true }
 secrecy = { version = "0.8.0", optional = true }
 tracinglib = { version = "0.1.25", optional = true, package = "tracing" }
 tracing-futures = { version = "0.2.5", optional = true, features = ["std-future", "futures-03"] }


### PR DESCRIPTION
Updates `log` crate to version `0.4.16` to fix issue with
`ValueBag` traits.

A similar issue was reported by another user here around
7 hours ago: https://github.com/rust-lang/log/issues/507

<details>
    <summary>Error Log</summary>

```
cargo build
   Compiling log v0.4.14
   Compiling futures v0.3.21
   Compiling async-graphql-parser v3.0.30
   Compiling async-graphql-parser v3.0.38 (/Users/esteban/Repositories/src/github.com/EstebanBorai/async-graphql/parser)
error[E0277]: the trait bound `ValueBag<'_>: From<u128>` is not satisfied
   --> /Users/esteban/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.14/src/kv/value.rs:364:21
    |
364 |                       Value::from_value_bag(value)
    |                       ^^^^^^^^^^^^^^^^^^^^^ the trait `From<u128>` is not implemented for `ValueBag<'_>`
...
384 | / impl_to_value_primitive![
385 | |     usize, u8, u16, u32, u64, u128, isize, i8, i16, i32, i64, i128, f32, f64, char, bool,
386 | | ];
    | |_- in this macro invocation
    |
    = help: the following implementations were found:
              <ValueBag<'v> as From<&'a ()>>
              <ValueBag<'v> as From<&'a bool>>
              <ValueBag<'v> as From<&'a char>>
              <ValueBag<'v> as From<&'a f32>>
            and 29 others
    = note: required because of the requirements on the impl of `Into<ValueBag<'_>>` for `u128`
note: required by a bound in `value::Value::<'v>::from_value_bag`
   --> /Users/esteban/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.14/src/kv/value.rs:250:12
    |
248 |     fn from_value_bag<T>(value: T) -> Self
    |        -------------- required by a bound in this
249 |     where
250 |         T: Into<ValueBag<'v>>,
    |            ^^^^^^^^^^^^^^^^^^ required by this bound in `value::Value::<'v>::from_value_bag`
    = note: this error originates in the macro `impl_to_value_primitive` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `ValueBag<'_>: From<i128>` is not satisfied
   --> /Users/esteban/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.14/src/kv/value.rs:364:21
    |
364 |                       Value::from_value_bag(value)
    |                       ^^^^^^^^^^^^^^^^^^^^^ the trait `From<i128>` is not implemented for `ValueBag<'_>`
...
384 | / impl_to_value_primitive![
385 | |     usize, u8, u16, u32, u64, u128, isize, i8, i16, i32, i64, i128, f32, f64, char, bool,
386 | | ];
    | |_- in this macro invocation
    |
    = help: the following implementations were found:
              <ValueBag<'v> as From<&'a ()>>
              <ValueBag<'v> as From<&'a bool>>
              <ValueBag<'v> as From<&'a char>>
              <ValueBag<'v> as From<&'a f32>>
            and 29 others
    = note: required because of the requirements on the impl of `Into<ValueBag<'_>>` for `i128`
note: required by a bound in `value::Value::<'v>::from_value_bag`
   --> /Users/esteban/.cargo/registry/src/github.com-1ecc6299db9ec823/log-0.4.14/src/kv/value.rs:250:12
    |
248 |     fn from_value_bag<T>(value: T) -> Self
    |        -------------- required by a bound in this
249 |     where
250 |         T: Into<ValueBag<'v>>,
    |            ^^^^^^^^^^^^^^^^^^ required by this bound in `value::Value::<'v>::from_value_bag`
    = note: this error originates in the macro `impl_to_value_primitive` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `log` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed
```

</details>