### PR TITLE
Bump version of `uuid` to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ secrecy = { version = "0.8.0", optional = true }
 tracinglib = { version = "0.1.25", optional = true, package = "tracing" }
 tracing-futures = { version = "0.2.5", optional = true, features = ["std-future", "futures-03"] }
 opentelemetry = { version = "0.17.0", optional = true, default-features = false, features = ["trace"] }
-uuid = { version = "0.8.2", optional = true, features = ["v4", "serde"] }
+uuid = { version = "1.0.0", optional = true, features = ["v4", "serde"] }
 rust_decimal = { version = "1.14.3", optional = true }
 url = { version = "2.2.1", optional = true }
 smol_str = { version = "0.1.21", optional = true }


### PR DESCRIPTION
Closes #902 !

Doesn't look like any changes have to be made to support this after [reading the release notes](https://github.com/uuid-rs/uuid/releases/tag/1.0.0) and reviewing the code in this repository.