### PR TITLE
fix #925 support BigDecimal and support parse from Number for Decimal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ opentelemetry = { version = "0.17.0", optional = true, default-features = false,
   "trace",
 ] }
 rust_decimal = { version = "1.14.3", optional = true }
+bigdecimal = { version = "0.3.0", optional = true }
 secrecy = { version = "0.8.0", optional = true }
 smol_str = { version = "0.1.21", optional = true }
 time = { version = "0.3.5", optional = true, features = [

--- a/src/types/external/big_decimal.rs
+++ b/src/types/external/big_decimal.rs
@@ -1,26 +1,26 @@
 use std::str::FromStr;
 
-use rust_decimal::Decimal;
+use bigdecimal::BigDecimal;
 
 use crate::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
 
-#[Scalar(internal, name = "Decimal")]
-impl ScalarType for Decimal {
+#[Scalar(internal, name = "BigDecimal")]
+impl ScalarType for BigDecimal {
     fn parse(value: Value) -> InputValueResult<Self> {
         match &value {
-            Value::String(s) => Ok(Decimal::from_str(s)?),
             Value::Number(n) => {
                 if let Some(f) = n.as_f64() {
-                    return Decimal::try_from(f).map_err(InputValueError::custom);
+                    return BigDecimal::try_from(f).map_err(InputValueError::custom);
                 }
 
                 if let Some(f) = n.as_i64() {
-                    return Ok(Decimal::from(f)); 
+                    return Ok(BigDecimal::from(f)); 
                 }
 
                 // unwrap safe here, because we have check the other possibility
-                Ok(Decimal::from(n.as_u64().unwrap()))
+                Ok(BigDecimal::from(n.as_u64().unwrap()))
             },
+            Value::String(s) => Ok(BigDecimal::from_str(s)?),
             _ => Err(InputValueError::expected_type(value)),
         }
     }

--- a/src/types/external/mod.rs
+++ b/src/types/external/mod.rs
@@ -23,6 +23,8 @@ mod chrono_tz;
 mod datetime;
 #[cfg(feature = "decimal")]
 mod decimal;
+#[cfg(feature = "bigdecimal")]
+mod big_decimal;
 #[cfg(feature = "chrono-duration")]
 mod duration;
 #[cfg(feature = "chrono")]


### PR DESCRIPTION
Hi, this PR supports BigDecimal and supports parse from Number for Decimal.