### PR TITLE
Expose Edge::node to allow better testing

### DIFF
--- a/src/types/connection/edge.rs
+++ b/src/types/connection/edge.rs
@@ -44,7 +44,7 @@ where
     /// A cursor for use in pagination
     pub(crate) cursor: CursorScalar<Cursor>,
     /// "The item at the end of the edge
-    pub(crate) node: Node,
+    pub node: Node,
     #[graphql(flatten)]
     pub(crate) additional_fields: EdgeFields,
 }


### PR DESCRIPTION
This helps when testing API as otherwise there is no way to check content of connection