### PR TITLE
Make email-validator optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,12 @@ version = "4.0.2"
 [features]
 apollo_persisted_queries = ["lru", "sha2"]
 apollo_tracing = ["chrono"]
+email-validator = ["fast_chemail"]
 cbor = ["serde_cbor"]
 chrono-duration = ["chrono", "iso8601-duration"]
 dataloader = ["futures-timer", "futures-channel", "lru"]
 decimal = ["rust_decimal"]
-default = []
+default = ["email-validator"]
 password-strength-validator = ["zxcvbn"]
 string_number = []
 tokio-sync = ["tokio"]
@@ -34,7 +35,6 @@ async-graphql-value = { path = "value", version = "4.0.2" }
 async-stream = "0.3.0"
 async-trait = "0.1.48"
 bytes = { version = "1.0.1", features = ["serde"] }
-fast_chemail = "0.9.6"
 fnv = "1.0.7"
 futures-util = { version = "0.3.0", default-features = false, features = [
   "io",
@@ -61,6 +61,7 @@ chrono = { version = "0.4.19", optional = true, default-features = false, featur
   "std",
 ] }
 chrono-tz = { version = "0.6.1", optional = true }
+fast_chemail = { version = "0.9.6", optional = true }
 hashbrown = { version = "0.12.0", optional = true }
 iso8601-duration = { version = "0.1.0", optional = true }
 log = { version = "0.4.16", optional = true }

--- a/integrations/actix-web/Cargo.toml
+++ b/integrations/actix-web/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "4.0.2"
 
 [dependencies]
-async-graphql = { path = "../..", version = "4.0.2" }
+async-graphql = { path = "../..", version = "4.0.2", default-features = false }
 
 actix = "0.13.0"
 actix-http = "3.0.1"

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "4.0.2"
 
 [dependencies]
-async-graphql = { path = "../..", version = "4.0.2" }
+async-graphql = { path = "../..", version = "4.0.2", default-features = false }
 
 async-trait = "0.1.51"
 axum = { version = "0.5.1", features = ["ws", "headers"] }

--- a/integrations/poem/Cargo.toml
+++ b/integrations/poem/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "4.0.2"
 
 [dependencies]
-async-graphql = { path = "../..", version = "4.0.2" }
+async-graphql = { path = "../..", version = "4.0.2", default-features = false }
 
 futures-util = { version = "0.3.0", default-features = false }
 poem = { version = "1.3.0", features = ["websocket"] }

--- a/integrations/rocket/Cargo.toml
+++ b/integrations/rocket/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "4.0.2"
 
 [dependencies]
-async-graphql = { path = "../..", version = "4.0.2" }
+async-graphql = { path = "../..", version = "4.0.2", default-features = false }
 
 rocket = { version = "0.5.0-rc.1", default-features = false }
 serde = "1.0.126"

--- a/integrations/tide/Cargo.toml
+++ b/integrations/tide/Cargo.toml
@@ -16,7 +16,7 @@ default = ["websocket"]
 websocket = ["tide-websockets"]
 
 [dependencies]
-async-graphql = { path = "../..", version = "4.0.2" }
+async-graphql = { path = "../..", version = "4.0.2", default-features = false }
 
 async-trait = "0.1.48"
 futures-util = "0.3.0"

--- a/integrations/warp/Cargo.toml
+++ b/integrations/warp/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "4.0.2"
 
 [dependencies]
-async-graphql = { path = "../..", version = "4.0.2" }
+async-graphql = { path = "../..", version = "4.0.2", default-features = false }
 
 futures-util = { version = "0.3.0", default-features = false, features = [
   "sink",

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -1,5 +1,6 @@
 mod chars_max_length;
 mod chars_min_length;
+#[cfg(feature = "email-validator")]
 mod email;
 mod ip;
 mod max_items;
@@ -16,6 +17,7 @@ mod url;
 
 pub use chars_max_length::chars_max_length;
 pub use chars_min_length::chars_min_length;
+#[cfg(feature = "email-validator")]
 pub use email::email;
 pub use ip::ip;
 pub use max_items::max_items;


### PR DESCRIPTION
This change makes it possible to opt out of the email validator
which brings in the `fast_chemail` crate. Since it won't be
ideal to break existing usages, by default the dependency is
still included.

Fixes #949