### PR TITLE
add nodes exposure on ConectionType so nesting through edges isn't always needed.

### DIFF
--- a/integrations/actix-web/tests/graphql.rs
+++ b/integrations/actix-web/tests/graphql.rs
@@ -137,11 +137,13 @@ async fn test_hello_header() {
 async fn test_count() {
     let srv = test::init_service(
         App::new()
-            .app_data(Data::new(
-                Schema::build(CountQueryRoot, CountMutation, EmptySubscription)
-                    .data(Count::default())
-                    .finish(),
-            ))
+            .app_data(
+                Data::new(
+                    Schema::build(CountQueryRoot, CountMutation, EmptySubscription)
+                        .data(Count::default())
+                        .finish(),
+                ),
+            )
             .service(
                 web::resource("/")
                     .guard(guard::Post())

--- a/src/extensions/opentelemetry.rs
+++ b/src/extensions/opentelemetry.rs
@@ -83,13 +83,14 @@ where
         next: NextSubscribe<'_>,
     ) -> BoxStream<'s, Response> {
         Box::pin(
-            next.run(ctx, stream)
-                .with_context(OpenTelemetryContext::current_with_span(
+            next.run(ctx, stream).with_context(
+                OpenTelemetryContext::current_with_span(
                     self.tracer
                         .span_builder("subscribe")
                         .with_kind(SpanKind::Server)
                         .start(&*self.tracer),
-                )),
+                ),
+            ),
         )
     }
 

--- a/src/types/connection/connection_type.rs
+++ b/src/types/connection/connection_type.rs
@@ -117,6 +117,11 @@ where
         &self.edges
     }
 
+    /// A list of nodes.
+    async fn nodes(&self) -> Vec<&Node> {
+        self.edges.iter().map(|e| &e.node).collect()
+    }
+
     #[graphql(flatten)]
     #[inline]
     async fn additional_fields(&self) -> &ConnectionFields {

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -94,3 +94,76 @@ pub async fn test_connection_additional_fields() {
         })
     );
 }
+
+#[tokio::test]
+pub async fn test_connection_nodes() {
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn numbers(
+            &self,
+            after: Option<String>,
+            before: Option<String>,
+            first: Option<i32>,
+            last: Option<i32>,
+        ) -> Result<Connection<usize, i32>> {
+            connection::query(
+                after,
+                before,
+                first,
+                last,
+                |after, before, first, last| async move {
+                    let mut start = after.map(|after| after + 1).unwrap_or(0);
+                    let mut end = before.unwrap_or(10000);
+                    if let Some(first) = first {
+                        end = (start + first).min(end);
+                    }
+                    if let Some(last) = last {
+                        start = if last > end - start { end } else { end - last };
+                    }
+                    let mut connection = Connection::new(start > 0, end < 10000);
+                    connection
+                        .edges
+                        .extend((start..end).map(|n| Edge::new(n, n as i32)));
+                    Ok::<_, Error>(connection)
+                },
+            )
+            .await
+        }
+    }
+
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+
+    assert_eq!(
+        schema
+            .execute("{ numbers(first: 2) { __typename edges { __typename node } nodes } }")
+            .await
+            .data,
+        value!({
+            "numbers": {
+                "__typename": "IntConnection",
+                "edges": [
+                    {"__typename": "IntEdge", "node": 0},
+                    {"__typename": "IntEdge", "node": 1},
+                ],
+                "nodes": [
+                    0,
+                    1,
+                ],
+            },
+        })
+    );
+
+    assert_eq!(
+        schema.execute("{ numbers(last: 2) { nodes } }").await.data,
+        value!({
+            "numbers": {
+                "nodes": [
+                    9998,
+                    9999,
+                ],
+            },
+        })
+    );
+}


### PR DESCRIPTION
When there are no extra edge fields, we can short-cut and just access nodes to get all the entries (since pageInfo still provides the endCursor)

See Github's GraphQL API for an example of this usage. And this alluded to on the GraphQL pagination page ( https://graphql.org/learn/pagination/#end-of-list-counts-and-connections )