### PR TITLE
Fix serializing of JSON default values

### DIFF
--- a/integrations/actix-web/tests/graphql.rs
+++ b/integrations/actix-web/tests/graphql.rs
@@ -137,13 +137,11 @@ async fn test_hello_header() {
 async fn test_count() {
     let srv = test::init_service(
         App::new()
-            .app_data(
-                Data::new(
-                    Schema::build(CountQueryRoot, CountMutation, EmptySubscription)
-                        .data(Count::default())
-                        .finish(),
-                ),
-            )
+            .app_data(Data::new(
+                Schema::build(CountQueryRoot, CountMutation, EmptySubscription)
+                    .data(Count::default())
+                    .finish(),
+            ))
             .service(
                 web::resource("/")
                     .guard(guard::Post())

--- a/src/extensions/opentelemetry.rs
+++ b/src/extensions/opentelemetry.rs
@@ -83,14 +83,13 @@ where
         next: NextSubscribe<'_>,
     ) -> BoxStream<'s, Response> {
         Box::pin(
-            next.run(ctx, stream).with_context(
-                OpenTelemetryContext::current_with_span(
+            next.run(ctx, stream)
+                .with_context(OpenTelemetryContext::current_with_span(
                     self.tracer
                         .span_builder("subscribe")
                         .with_kind(SpanKind::Server)
                         .start(&*self.tracer),
-                ),
-            ),
+                )),
         )
     }
 

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -63,7 +63,7 @@ impl<T: DeserializeOwned + Serialize + Send + Sync> InputType for Json<T> {
     }
 
     fn to_value(&self) -> Value {
-        to_value(&self.0).unwrap_or_default()
+        Value::String(serde_json::to_string(&self.0).unwrap_or_default())
     }
 
     fn as_raw_value(&self) -> Option<&Self::RawValueType> {
@@ -120,7 +120,7 @@ impl InputType for serde_json::Value {
     }
 
     fn to_value(&self) -> Value {
-        to_value(&self).unwrap_or_default()
+        Value::String(self.to_string())
     }
 
     fn as_raw_value(&self) -> Option<&Self::RawValueType> {


### PR DESCRIPTION
This changes the InputType::to_value implementations to serialize the JSON values to strings. (since these are scalar types GraphQL requires it to be a string for the default)