### PR TITLE
Fix nightly rustfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { rust: stable, os: ubuntu-latest }
+          - { rust: nightly-2022-06-29, os: ubuntu-latest }
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -78,11 +78,11 @@ jobs:
           submodules: true
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt
       - name: Check format
-        run: cargo +nightly fmt --all -- --check
+        run: cargo +${{ matrix.rust }} fmt --all -- --check
 
   clippy:
     name: Run clippy - Rust (${{ matrix.rust }}) on ${{ matrix.os }}
@@ -135,7 +135,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { rust: stable, os: ubuntu-latest }
+          - { rust: nightly-2022-06-29, os: ubuntu-latest }
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -144,11 +144,11 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ matrix.rust }}
           override: true
           components: clippy, rustfmt
       - name: Check examples format
-        run: cargo +nightly fmt --all -- --check
+        run: cargo +${{ matrix.rust }} fmt --all -- --check
         working-directory: ./examples
 
       - uses: actions-rs/toolchain@v1

--- a/integrations/actix-web/tests/graphql.rs
+++ b/integrations/actix-web/tests/graphql.rs
@@ -137,13 +137,11 @@ async fn test_hello_header() {
 async fn test_count() {
     let srv = test::init_service(
         App::new()
-            .app_data(
-                Data::new(
-                    Schema::build(CountQueryRoot, CountMutation, EmptySubscription)
-                        .data(Count::default())
-                        .finish(),
-                ),
-            )
+            .app_data(Data::new(
+                Schema::build(CountQueryRoot, CountMutation, EmptySubscription)
+                    .data(Count::default())
+                    .finish(),
+            ))
             .service(
                 web::resource("/")
                     .guard(guard::Post())

--- a/src/extensions/opentelemetry.rs
+++ b/src/extensions/opentelemetry.rs
@@ -83,14 +83,13 @@ where
         next: NextSubscribe<'_>,
     ) -> BoxStream<'s, Response> {
         Box::pin(
-            next.run(ctx, stream).with_context(
-                OpenTelemetryContext::current_with_span(
+            next.run(ctx, stream)
+                .with_context(OpenTelemetryContext::current_with_span(
                     self.tracer
                         .span_builder("subscribe")
                         .with_kind(SpanKind::Server)
                         .start(&*self.tracer),
-                ),
-            ),
+                )),
         )
     }
 


### PR DESCRIPTION
This PR sets the version of nightly to a fixed date so new versions of nightly don't mess with code formatting randomly.