### PR TITLE
Palliative workaround for #900

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ async-graphql-value = { path = "value", version = "4.0.4" }
 async-stream = "0.3.0"
 async-trait = "0.1.48"
 bytes = { version = "1.0.1", features = ["serde"] }
+fix-hidden-lifetime-bug = "0.2.5"  # See #900
 fnv = "1.0.7"
 futures-util = { version = "0.3.0", default-features = false, features = [
   "io",

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -250,6 +250,9 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
         let schema_ty = oty.value_type();
 
         methods.push(quote! {
+            #[#crate_name::fix_hidden_lifetime_bug::fix_hidden_lifetime_bug(
+                crate = #crate_name::fix_hidden_lifetime_bug,
+            )] // See #900
             #[inline]
             pub async fn #method_name<'ctx>(&self, #(#decl_params),*) -> #crate_name::Result<#ty> {
                 match self {

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -226,6 +226,9 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
             getters.push(quote! {
                  #[inline]
                  #[allow(missing_docs)]
+                 #[#crate_name::fix_hidden_lifetime_bug::fix_hidden_lifetime_bug(
+                     crate = #crate_name::fix_hidden_lifetime_bug,
+                 )] // See #900
                  #vis async fn #ident(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::Result<#ty> {
                      ::std::result::Result::Ok(#block)
                  }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,6 +214,8 @@ pub use async_graphql_value::{
 pub use async_stream;
 #[doc(hidden)]
 pub use async_trait;
+#[doc(hidden)]
+pub use ::fix_hidden_lifetime_bug;
 pub use base::{
     ComplexObject, Description, InputObjectType, InputType, InterfaceType, ObjectType,
     OneofObjectType, OutputType, TypeName, UnionType,


### PR DESCRIPTION
This uses <https://docs.rs/fix-hidden-lifetime-bug> to replace the compiler's heuristic with lifetimes with a simpler and more straight-forward one, which **does dodge the regression from https://github.com/rust-lang/rust/issues/98890**.

# How to use

Add the following to your workspace[^1]'s `Cargo.toml` file:

```toml
[patch.crates-io.async-graphql]
git = "https://github.com/danielhenrymantilla/async-graphql.git"
branch = "workaround-for-1-62-bug"
# or, instead of branch, you may pin-point its `HEAD` commit, if you are scared of a sneaky branch update
# rev = "6dae5c864c009de9dda03fc0b7796ced02e895bd"
```

[^1]: the directory where the `Cargo.lock` file is generated.