### PR TITLE
Add generics support for Interface and Union static assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ pin-project-lite = "0.2.6"
 regex = "1.5.5"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
-static_assertions = "1.1.0"
+static_assertions = { git = "https://github.com/nvzqz/static-assertions-rs", rev = "a867e97a1b3c2e0c76b7a154abdf4e422b78e5f2" }
 tempfile = "3.2.0"
 thiserror = "1.0.24"
 

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -18,6 +18,7 @@ use crate::{
 pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream> {
     let crate_name = get_crate_name(interface_args.internal);
     let ident = &interface_args.ident;
+    let type_params = interface_args.generics.type_params().collect::<Vec<_>>();
     let (impl_generics, ty_generics, where_clause) = interface_args.generics.split_for_impl();
     let s = match &interface_args.data {
         Data::Enum(s) => s,
@@ -82,7 +83,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
             RemoveLifetime.visit_type_path_mut(&mut assert_ty);
 
             type_into_impls.push(quote! {
-                #crate_name::static_assertions::assert_impl_any!(#assert_ty: #crate_name::ObjectType, #crate_name::InterfaceType);
+                #crate_name::static_assertions::assert_impl!(for(#(#type_params),*) #assert_ty: (#crate_name::ObjectType) | (#crate_name::InterfaceType));
 
                 #[allow(clippy::all, clippy::pedantic)]
                 impl #impl_generics ::std::convert::From<#p> for #ident #ty_generics #where_clause {

--- a/derive/src/union.rs
+++ b/derive/src/union.rs
@@ -13,6 +13,7 @@ use crate::{
 pub fn generate(union_args: &args::Union) -> GeneratorResult<TokenStream> {
     let crate_name = get_crate_name(union_args.internal);
     let ident = &union_args.ident;
+    let type_params = union_args.generics.type_params().collect::<Vec<_>>();
     let (impl_generics, ty_generics, where_clause) = union_args.generics.split_for_impl();
     let s = match &union_args.data {
         Data::Enum(s) => s,
@@ -84,7 +85,7 @@ pub fn generate(union_args: &args::Union) -> GeneratorResult<TokenStream> {
 
             if !variant.flatten {
                 type_into_impls.push(quote! {
-                    #crate_name::static_assertions::assert_impl_one!(#assert_ty: #crate_name::ObjectType);
+                    #crate_name::static_assertions::assert_impl!(for(#(#type_params),*) #assert_ty: #crate_name::ObjectType);
 
                     #[allow(clippy::all, clippy::pedantic)]
                     impl #impl_generics ::std::convert::From<#ty> for #ident #ty_generics #where_clause {
@@ -95,7 +96,7 @@ pub fn generate(union_args: &args::Union) -> GeneratorResult<TokenStream> {
                 });
             } else {
                 type_into_impls.push(quote! {
-                    #crate_name::static_assertions::assert_impl_one!(#assert_ty: #crate_name::UnionType);
+                    #crate_name::static_assertions::assert_impl!(for(#(#type_params),*) #assert_ty: #crate_name::UnionType);
 
                     #[allow(clippy::all, clippy::pedantic)]
                     impl #impl_generics ::std::convert::From<#ty> for #ident #ty_generics #where_clause {


### PR DESCRIPTION
This is an attempt to fix #978. This unfortunately relies on an unreleased version of `static_assertions` crate