### PR TITLE
Implement Content-Encoding aware query decompression support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ string_number = []
 tokio-sync = ["tokio"]
 tracing = ["tracinglib", "tracing-futures"]
 unblock = ["blocking"]
+compression = ["brotli", "flate2", "zstd"]
 
 [dependencies]
 async-graphql-derive = { path = "derive", version = "4.0.6" }
@@ -98,6 +99,11 @@ lru = { version = "0.7.1", optional = true }
 serde_cbor = { version = "0.11.1", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 zxcvbn = { version = "2.1.2", optional = true }
+
+# compress feature
+brotli = { version = "3.3.4", optional = true }
+flate2 = { version = "1.0.24", optional = true }
+zstd = { version = "0.11.2", optional = true }
 
 [dev-dependencies]
 futures-channel = "0.3.13"

--- a/integrations/actix-web/src/request.rs
+++ b/integrations/actix-web/src/request.rs
@@ -84,6 +84,12 @@ impl FromRequest for GraphQLBatchRequest {
                 .and_then(|value| value.to_str().ok())
                 .map(|value| value.to_string());
 
+            let content_encoding = req
+                .headers()
+                .get(http::header::CONTENT_ENCODING)
+                .and_then(|value| value.to_str().ok())
+                .map(|value| value.to_string());
+
             let (tx, rx) = async_channel::bounded(16);
 
             // Payload is !Send so we create indirection with a channel
@@ -100,6 +106,7 @@ impl FromRequest for GraphQLBatchRequest {
                 Ok(GraphQLBatchRequest(
                     async_graphql::http::receive_batch_body(
                         content_type,
+                        content_encoding,
                         rx.map_err(|e| match e {
                             PayloadError::Incomplete(Some(e)) | PayloadError::Io(e) => e,
                             PayloadError::Incomplete(None) => {

--- a/integrations/axum/src/extract.rs
+++ b/integrations/axum/src/extract.rs
@@ -120,6 +120,13 @@ where
                 .get(http::header::CONTENT_TYPE)
                 .and_then(|value| value.to_str().ok())
                 .map(ToString::to_string);
+
+            let content_encoding = req
+                .headers()
+                .get(http::header::CONTENT_ENCODING)
+                .and_then(|value| value.to_str().ok())
+                .map(ToString::to_string);
+
             let body_stream = BodyStream::from_request(req)
                 .await
                 .map_err(|_| {
@@ -129,10 +136,12 @@ where
                     ))
                 })?
                 .map_err(|err| std::io::Error::new(ErrorKind::Other, err.to_string()));
+
             let body_reader = tokio_util::io::StreamReader::new(body_stream).compat();
             Ok(Self(
                 async_graphql::http::receive_batch_body(
                     content_type,
+                    content_encoding,
                     body_reader,
                     MultipartOptions::default(),
                 )

--- a/integrations/poem/src/extractor.rs
+++ b/integrations/poem/src/extractor.rs
@@ -76,9 +76,17 @@ impl<'a> FromRequest<'a> for GraphQLBatchRequest {
                 .get(header::CONTENT_TYPE)
                 .and_then(|value| value.to_str().ok())
                 .map(ToString::to_string);
+
+            let content_encoding = req
+                .headers()
+                .get(header::CONTENT_ENCODING)
+                .and_then(|value| value.to_str().ok())
+                .map(ToString::to_string);
+
             Ok(Self(
                 async_graphql::http::receive_batch_body(
                     content_type,
+                    content_encoding,
                     body.take()?.into_async_read().compat(),
                     MultipartOptions::default(),
                 )

--- a/integrations/rocket/src/lib.rs
+++ b/integrations/rocket/src/lib.rs
@@ -63,6 +63,7 @@ impl<'r> FromData<'r> for GraphQLBatchRequest {
 
         let request = async_graphql::http::receive_batch_body(
             req.headers().get_one("Content-Type"),
+            req.headers().get_one("Content-Encoding"),
             data.open(
                 req.limits()
                     .get("graphql")

--- a/integrations/tide/src/lib.rs
+++ b/integrations/tide/src/lib.rs
@@ -135,12 +135,18 @@ pub async fn receive_batch_request_opts<State: Clone + Send + Sync + 'static>(
         request.query::<async_graphql::Request>().map(Into::into)
     } else if request.method() == Method::Post {
         let body = request.take_body();
+
         let content_type = request
             .header(headers::CONTENT_TYPE)
             .and_then(|values| values.get(0))
             .map(HeaderValue::as_str);
 
-        async_graphql::http::receive_batch_body(content_type, body, opts)
+        let content_encoding = request
+            .header(headers::CONTENT_ENCODING)
+            .and_then(|values| values.get(0))
+            .map(HeaderValue::as_str);
+
+        async_graphql::http::receive_batch_body(content_type, content_encoding, body, opts)
             .await
             .map_err(|e| {
                 tide::Error::new(

--- a/integrations/warp/src/batch_request.rs
+++ b/integrations/warp/src/batch_request.rs
@@ -38,10 +38,12 @@ where
         .and(warp::get().and(warp::query()).map(BatchRequest::Single))
         .or(warp::post()
             .and(warp::header::optional::<String>("content-type"))
+            .and(warp::header::optional::<String>("content-encoding"))
             .and(warp::body::stream())
-            .and_then(move |content_type, body| async move {
+            .and_then(move |content_type, content_encoding, body| async move {
                 async_graphql::http::receive_batch_body(
                     content_type,
+                    content_encoding,
                     TryStreamExt::map_err(body, |e| io::Error::new(ErrorKind::Other, e))
                         .map_ok(|mut buf| {
                             let remaining = Buf::remaining(&buf);

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -16,13 +16,30 @@ pub use websocket::{
 
 use crate::{BatchRequest, ParseRequestError, Request};
 
+/// supported content-encoding values
+#[derive(Debug, Clone, Copy)]
+pub enum ContentEncoding {
+    /// LZ77
+    Gzip,
+
+    /// Deflate
+    Deflate,
+
+    /// Brotli
+    Br,
+
+    /// Zstd
+    Zstd,
+}
+
 /// Receive a GraphQL request from a content type and body.
 pub async fn receive_body(
     content_type: Option<impl AsRef<str>>,
+    content_encoding: Option<impl AsRef<str>>,
     body: impl AsyncRead + Send,
     opts: MultipartOptions,
 ) -> Result<Request, ParseRequestError> {
-    receive_batch_body(content_type, body, opts)
+    receive_batch_body(content_type, content_encoding, body, opts)
         .await?
         .into_single()
 }
@@ -30,6 +47,7 @@ pub async fn receive_body(
 /// Receive a GraphQL request from a content type and body.
 pub async fn receive_batch_body(
     content_type: Option<impl AsRef<str>>,
+    content_encoding: Option<impl AsRef<str>>,
     body: impl AsyncRead + Send,
     opts: MultipartOptions,
 ) -> Result<BatchRequest, ParseRequestError> {
@@ -39,13 +57,27 @@ pub async fn receive_batch_body(
         .map(AsRef::as_ref)
         .unwrap_or("application/json");
 
+    // parse the content-encoding
+    let content_encoding = match content_encoding.as_ref().map(AsRef::as_ref) {
+        Some("gzip") => Some(ContentEncoding::Gzip),
+        Some("deflate") => Some(ContentEncoding::Deflate),
+        Some("br") => Some(ContentEncoding::Br),
+        _ => None,
+    };
+
     let content_type: mime::Mime = content_type.parse()?;
 
     match (content_type.type_(), content_type.subtype()) {
         // try to use multipart
         (mime::MULTIPART, _) => {
             if let Some(boundary) = content_type.get_param("boundary") {
-                multipart::receive_batch_multipart(body, boundary.to_string(), opts).await
+                multipart::receive_batch_multipart(
+                    body,
+                    content_encoding,
+                    boundary.to_string(),
+                    opts,
+                )
+                .await
             } else {
                 Err(ParseRequestError::InvalidMultipart(
                     multer::Error::NoBoundary,
@@ -56,7 +88,7 @@ pub async fn receive_batch_body(
         // cbor is in application/octet-stream.
         // Note: cbor will only match if feature ``cbor`` is active
         // TODO: wait for mime to add application/cbor and match against that too
-        _ => receive_batch_body_no_multipart(&content_type, body).await,
+        _ => receive_batch_body_no_multipart(&content_type, content_encoding, body).await,
     }
 }
 
@@ -65,6 +97,7 @@ pub async fn receive_batch_body(
 /// and [``multipart::receive_batch_multipart``]
 pub(super) async fn receive_batch_body_no_multipart(
     content_type: &mime::Mime,
+    content_encoding: Option<ContentEncoding>,
     body: impl AsyncRead + Send,
 ) -> Result<BatchRequest, ParseRequestError> {
     assert_ne!(content_type.type_(), mime::MULTIPART, "received multipart");
@@ -73,24 +106,36 @@ pub(super) async fn receive_batch_body_no_multipart(
         // cbor is in application/octet-stream.
         // TODO: wait for mime to add application/cbor and match against that too
         (mime::OCTET_STREAM, _) | (mime::APPLICATION, mime::OCTET_STREAM) => {
-            receive_batch_cbor(body).await
+            receive_batch_cbor(body, content_encoding).await
         }
         // default to json
-        _ => receive_batch_json(body).await,
+        _ => receive_batch_json(body, content_encoding).await,
     }
 }
 /// Receive a GraphQL request from a body as JSON.
-pub async fn receive_json(body: impl AsyncRead) -> Result<Request, ParseRequestError> {
-    receive_batch_json(body).await?.into_single()
+pub async fn receive_json(
+    body: impl AsyncRead,
+    content_encoding: Option<ContentEncoding>,
+) -> Result<Request, ParseRequestError> {
+    receive_batch_json(body, content_encoding)
+        .await?
+        .into_single()
 }
 
 /// Receive a GraphQL batch request from a body as JSON.
-pub async fn receive_batch_json(body: impl AsyncRead) -> Result<BatchRequest, ParseRequestError> {
+pub async fn receive_batch_json(
+    body: impl AsyncRead,
+    content_encoding: Option<ContentEncoding>,
+) -> Result<BatchRequest, ParseRequestError> {
     let mut data = Vec::new();
     futures_util::pin_mut!(body);
+
     body.read_to_end(&mut data)
         .await
         .map_err(ParseRequestError::Io)?;
+
+    data = handle_content_encoding(data, content_encoding)?;
+
     serde_json::from_slice::<BatchRequest>(&data)
         .map_err(|e| ParseRequestError::InvalidRequest(Box::new(e)))
 }
@@ -98,19 +143,80 @@ pub async fn receive_batch_json(body: impl AsyncRead) -> Result<BatchRequest, Pa
 /// Receive a GraphQL request from a body as CBOR.
 #[cfg(feature = "cbor")]
 #[cfg_attr(docsrs, doc(cfg(feature = "cbor")))]
-pub async fn receive_cbor(body: impl AsyncRead) -> Result<Request, ParseRequestError> {
-    receive_batch_cbor(body).await?.into_single()
+pub async fn receive_cbor(
+    body: impl AsyncRead,
+    content_encoding: Option<ContentEncoding>,
+) -> Result<Request, ParseRequestError> {
+    receive_batch_cbor(body, content_encoding)
+        .await?
+        .into_single()
 }
 
 /// Receive a GraphQL batch request from a body as CBOR
 #[cfg(feature = "cbor")]
 #[cfg_attr(docsrs, doc(cfg(feature = "cbor")))]
-pub async fn receive_batch_cbor(body: impl AsyncRead) -> Result<BatchRequest, ParseRequestError> {
+pub async fn receive_batch_cbor(
+    body: impl AsyncRead,
+    content_encoding: Option<ContentEncoding>,
+) -> Result<BatchRequest, ParseRequestError> {
     let mut data = Vec::new();
     futures_util::pin_mut!(body);
     body.read_to_end(&mut data)
         .await
         .map_err(ParseRequestError::Io)?;
+
+    data = handle_content_encoding(data, content_encoding)?;
+
     serde_cbor::from_slice::<BatchRequest>(&data)
         .map_err(|e| ParseRequestError::InvalidRequest(Box::new(e)))
+}
+
+/// decompress data if needed
+#[cfg(not(feature = "compression"))]
+fn handle_content_encoding(
+    data: Vec<u8>,
+    _: Option<ContentEncoding>,
+) -> Result<Vec<u8>, ParseRequestError> {
+    Ok(data)
+}
+
+/// decompress data if needed
+#[cfg(feature = "compression")]
+fn handle_content_encoding(
+    data: Vec<u8>,
+    content_encoding: Option<ContentEncoding>,
+) -> Result<Vec<u8>, ParseRequestError> {
+    use std::io::prelude::*;
+
+    use flate2::read::{GzDecoder, ZlibDecoder};
+
+    match content_encoding {
+        Some(ContentEncoding::Gzip) => {
+            let mut buff = Vec::new();
+            GzDecoder::new(data.as_slice())
+                .read_to_end(&mut buff)
+                .map_err(ParseRequestError::Io)?;
+            Ok(buff)
+        }
+        Some(ContentEncoding::Deflate) => {
+            let mut buff = Vec::new();
+            ZlibDecoder::new(data.as_slice())
+                .read_to_end(&mut buff)
+                .map_err(ParseRequestError::Io)?;
+            Ok(buff)
+        }
+        Some(ContentEncoding::Br) => {
+            let mut buff = Vec::new();
+            brotli::Decompressor::new(data.as_slice(), 8192)
+                .read_to_end(&mut buff)
+                .map_err(ParseRequestError::Io)?;
+            Ok(buff)
+        }
+        Some(ContentEncoding::Zstd) => {
+            let mut buff = Vec::new();
+            zstd::stream::copy_decode(data.as_slice(), &mut buff).map_err(ParseRequestError::Io)?;
+            Ok(buff)
+        }
+        None => Ok(data),
+    }
 }

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -9,6 +9,7 @@ use futures_util::{io::AsyncRead, stream::Stream};
 use multer::{Constraints, Multipart, SizeLimit};
 use pin_project_lite::pin_project;
 
+use super::ContentEncoding;
 use crate::{BatchRequest, ParseRequestError, UploadValue};
 
 /// Options for `receive_multipart`.
@@ -43,6 +44,7 @@ impl MultipartOptions {
 
 pub(super) async fn receive_batch_multipart(
     body: impl AsyncRead + Send,
+    content_encoding: Option<ContentEncoding>,
     boundary: impl Into<String>,
     opts: MultipartOptions,
 ) -> Result<BatchRequest, ParseRequestError> {
@@ -79,7 +81,12 @@ pub(super) async fn receive_batch_multipart(
             Some("operations") => {
                 let body = field.bytes().await?;
                 request = Some(
-                    super::receive_batch_body_no_multipart(&content_type, body.as_ref()).await?,
+                    super::receive_batch_body_no_multipart(
+                        &content_type,
+                        content_encoding,
+                        body.as_ref(),
+                    )
+                    .await?,
                 )
             }
             Some("map") => {


### PR DESCRIPTION
Just a draft PR, this needs verification & unit testing.

This PR implements Content-Encoding aware decompression support for incoming GQL queries. This can be useful when dealing with large queries that compress well. This add supports for gzip, deflate, brotli and zstd compression algorithms under the new feature "compression".

Actix-web has similar features to allow the decompression of incoming requests based on the content-encoding header.

Fixes #879.
