### PR TITLE
Add section about redacting data from input objects

### DIFF
--- a/docs/en/src/define_input_object.md
+++ b/docs/en/src/define_input_object.md
@@ -94,3 +94,16 @@ pub struct YetAnotherInput {
 ```
 
 You can pass multiple generic types to `params()`, separated by a comma.
+
+## Redacting sensitive data
+
+If any part of your input is considered sensitive and you wish to redact it, you can mark it with `secret` directive. For example:
+
+```rust
+#[derive(InputObject)]
+pub struct CredentialsInput {
+    username: String,
+    #[graphql(secret)]
+    password: String,
+}
+```


### PR DESCRIPTION
Hey! I've spent a bit more time than necessary to find out about `secret` attribute. Throwing this into the book's InputObject section.