### PR TITLE
Fixes extension request.data(X) being lost in the resolver

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -254,6 +254,7 @@ pub struct QueryEnvInner {
     pub uploads: Vec<UploadValue>,
     pub session_data: Arc<Data>,
     pub ctx_data: Arc<Data>,
+    pub extension_data: Arc<Data>,
     pub http_headers: Mutex<HeaderMap>,
     pub introspection_mode: IntrospectionMode,
     pub errors: Mutex<Vec<ServerError>>,
@@ -392,9 +393,10 @@ impl<'a, T> ContextBase<'a, T> {
     /// the specified type data does not exist.
     pub fn data_opt<D: Any + Send + Sync>(&self) -> Option<&'a D> {
         self.query_env
-            .ctx_data
+            .extension_data
             .0
             .get(&TypeId::of::<D>())
+            .or_else(|| self.query_env.ctx_data.0.get(&TypeId::of::<D>()))
             .or_else(|| self.query_env.session_data.0.get(&TypeId::of::<D>()))
             .or_else(|| self.schema_env.data.0.get(&TypeId::of::<D>()))
             .and_then(|d| d.downcast_ref::<D>())

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -593,6 +593,7 @@ where
             uploads: request.uploads,
             session_data,
             ctx_data: query_data,
+            extension_data: Arc::new(request.data),
             http_headers: Default::default(),
             introspection_mode: request.introspection_mode,
             errors: Default::default(),


### PR DESCRIPTION
The extension request.data(X) is lost in the resolver.
```rust
async fn prepare_request(
    &self,
    ctx: &ExtensionContext<'_>,
    request: Request,
    next: NextPrepareRequest<'_>,
) -> ServerResult<Request> {
    request.data("foo".to_string())
    next.run(ctx, request).await
}
```
```rust
#[Object]
impl Query {
    async fn resolve(&self, ctx: &Context<'_>) -> Result<Vec<Account>> {
        ctx.data_unchecked::<String>(); // panic occurs
}
```

I fixed it because I want to do JWT authentication in extension.