### PR TITLE
export_sdl: avoid trailing space for scalar definitions

### DIFF
--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -215,14 +215,14 @@ impl Registry {
                     if let Some(description) = description {
                         export_description(sdl, options, true, description);
                     }
-                    write!(sdl, "scalar {} ", name).ok();
+                    write!(sdl, "scalar {}", name).ok();
 
                     if options.federation {
                         if *inaccessible {
-                            write!(sdl, "@inaccessible ").ok();
+                            write!(sdl, " @inaccessible").ok();
                         }
                         for tag in *tags {
-                            write!(sdl, "@tag(name: \"{}\") ", tag.replace('"', "\\\"")).ok();
+                            write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                         }
                     }
                     writeln!(sdl).ok();


### PR DESCRIPTION
This has been introduced in 619013d.

The problem can easily be avoided by modifying the `write!`
directives inside the federation if-clause to write space
prefixes instead of suffixes.