### PR TITLE
Opaque cursor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ async-graphql-value = { path = "value", version = "4.0.11" }
 
 async-stream = "0.3.0"
 async-trait = "0.1.48"
+base64 = "0.13.0"
 bytes = { version = "1.0.1", features = ["serde"] }
 fnv = "1.0.7"
 futures-util = { version = "0.3.0", default-features = false, features = [

--- a/src/types/connection/cursor.rs
+++ b/src/types/connection/cursor.rs
@@ -1,4 +1,10 @@
-use std::fmt::Display;
+use std::{
+    convert::Infallible,
+    fmt::Display,
+    num::{ParseFloatError, ParseIntError},
+};
+
+use crate::ID;
 
 /// Cursor type
 ///
@@ -15,12 +21,96 @@ pub trait CursorType: Sized {
     fn encode_cursor(&self) -> String;
 }
 
-pub enum CursorTypeError {
+impl CursorType for usize {
+    type Error = ParseIntError;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl CursorType for i32 {
+    type Error = ParseIntError;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl CursorType for i64 {
+    type Error = ParseIntError;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl CursorType for String {
+    type Error = Infallible;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        Ok(s.to_string())
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.clone()
+    }
+}
+
+impl CursorType for ID {
+    type Error = Infallible;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        Ok(s.to_string().into())
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl CursorType for f64 {
+    type Error = ParseFloatError;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl CursorType for f32 {
+    type Error = ParseFloatError;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.to_string()
+    }
+}
+
+pub enum OpaqueCursorError {
     Base64(base64::DecodeError),
     Serde(serde_json::Error),
 }
 
-impl std::fmt::Display for CursorTypeError {
+impl std::fmt::Display for OpaqueCursorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Base64(err) => err.fmt(f),
@@ -29,17 +119,20 @@ impl std::fmt::Display for CursorTypeError {
     }
 }
 
-impl<A: serde::Serialize + serde::de::DeserializeOwned> CursorType for A {
-    type Error = CursorTypeError;
+struct OpaqueCursor<A>(A);
+
+impl<A: serde::Serialize + serde::de::DeserializeOwned> CursorType for OpaqueCursor<A> {
+    type Error = OpaqueCursorError;
 
     fn decode_cursor(str: &str) -> Result<Self, Self::Error> {
         base64::decode_config(str, base64::URL_SAFE_NO_PAD)
-            .map_err(CursorTypeError::Base64)
-            .and_then(|bytes| serde_json::from_slice(&bytes).map_err(CursorTypeError::Serde))
+            .map_err(OpaqueCursorError::Base64)
+            .and_then(|bytes| serde_json::from_slice(&bytes).map_err(OpaqueCursorError::Serde))
+            .map(OpaqueCursor)
     }
 
     fn encode_cursor(&self) -> String {
-        let json = serde_json::to_string(&self).expect("Failed to serialize json cursor");
+        let json = serde_json::to_string(&self.0).expect("Failed to serialize json cursor");
 
         base64::encode_config(json, base64::URL_SAFE_NO_PAD)
     }


### PR DESCRIPTION
Change the CursorType to generate a cursor for any type that implements Serde's `Serialize` and `Deserialize`. This removes the need to define implementations for built-in types and offers support for complex types. 

This PR is in response to https://github.com/async-graphql/async-graphql/issues/1033