### PR TITLE
support @specifiedBy directive in SDL export

### DIFF
--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -205,6 +205,7 @@ impl Registry {
                 description,
                 inaccessible,
                 tags,
+                specified_by_url,
                 ..
             } => {
                 let mut export_scalar = !SYSTEM_SCALARS.contains(&name.as_str());
@@ -216,6 +217,15 @@ impl Registry {
                         export_description(sdl, options, true, description);
                     }
                     write!(sdl, "scalar {}", name).ok();
+
+                    if let Some(specified_by_url) = specified_by_url {
+                        write!(
+                            sdl,
+                            " @specifiedBy(url: \"{}\")",
+                            specified_by_url.replace('"', "\\\"")
+                        )
+                        .ok();
+                    }
 
                     if options.federation {
                         if *inaccessible {


### PR DESCRIPTION
https://spec.graphql.org/draft/#sec--specifiedBy
support `@specifiedBy` directive in SDL export.

example:
```rs
pub struct MyScalar(i64);
#[Scalar(specified_by_url = "https://example.com")]
impl ScalarType for MyScalar {
  ...
}
```
```graphql
scalar MyScalar @specifiedBy(url: "https://example.com")
```
