### PR TITLE
export_sdl: consistently avoid trailing spaces

### DIFF
--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -271,29 +271,29 @@ impl Registry {
                     write!(sdl, "extend ").ok();
                 }
 
-                write!(sdl, "type {} ", name).ok();
+                write!(sdl, "type {}", name).ok();
                 self.write_implements(sdl, name);
 
                 if options.federation {
                     if let Some(keys) = keys {
                         for key in keys {
-                            write!(sdl, "@key(fields: \"{}\") ", key).ok();
+                            write!(sdl, " @key(fields: \"{}\")", key).ok();
                         }
                     }
                     if *shareable {
-                        write!(sdl, "@shareable ").ok();
+                        write!(sdl, " @shareable").ok();
                     }
 
                     if *inaccessible {
-                        write!(sdl, "@inaccessible ").ok();
+                        write!(sdl, " @inaccessible").ok();
                     }
 
                     for tag in *tags {
-                        write!(sdl, "@tag(name: \"{}\") ", tag.replace('"', "\\\"")).ok();
+                        write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                     }
                 }
 
-                writeln!(sdl, "{{").ok();
+                writeln!(sdl, " {{").ok();
                 Self::export_fields(sdl, fields.values(), options);
                 writeln!(sdl, "}}").ok();
             }
@@ -314,25 +314,25 @@ impl Registry {
                 if options.federation && *extends {
                     write!(sdl, "extend ").ok();
                 }
-                write!(sdl, "interface {} ", name).ok();
+                write!(sdl, "interface {}", name).ok();
 
                 if options.federation {
                     if let Some(keys) = keys {
                         for key in keys {
-                            write!(sdl, "@key(fields: \"{}\") ", key).ok();
+                            write!(sdl, " @key(fields: \"{}\")", key).ok();
                         }
                     }
                     if *inaccessible {
-                        write!(sdl, "@inaccessible ").ok();
+                        write!(sdl, " @inaccessible").ok();
                     }
 
                     for tag in *tags {
-                        write!(sdl, "@tag(name: \"{}\") ", tag.replace('"', "\\\"")).ok();
+                        write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                     }
                 }
                 self.write_implements(sdl, name);
 
-                writeln!(sdl, "{{").ok();
+                writeln!(sdl, " {{").ok();
                 Self::export_fields(sdl, fields.values(), options);
                 writeln!(sdl, "}}").ok();
             }
@@ -348,13 +348,13 @@ impl Registry {
                     export_description(sdl, options, true, description);
                 }
 
-                write!(sdl, "enum {} ", name).ok();
+                write!(sdl, "enum {}", name).ok();
                 if options.federation {
                     if *inaccessible {
-                        write!(sdl, "@inaccessible ").ok();
+                        write!(sdl, " @inaccessible").ok();
                     }
                     for tag in *tags {
-                        write!(sdl, "@tag(name: \"{}\") ", tag.replace('"', "\\\"")).ok();
+                        write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                     }
                 }
                 writeln!(sdl, "{{").ok();
@@ -395,17 +395,17 @@ impl Registry {
                     export_description(sdl, options, true, description);
                 }
 
-                write!(sdl, "input {} ", name).ok();
+                write!(sdl, "input {}", name).ok();
 
                 if *oneof {
-                    write!(sdl, "@oneof ").ok();
+                    write!(sdl, " @oneof").ok();
                 }
                 if options.federation {
                     if *inaccessible {
-                        write!(sdl, "@inaccessible ").ok();
+                        write!(sdl, " @inaccessible").ok();
                     }
                     for tag in *tags {
-                        write!(sdl, "@tag(name: \"{}\") ", tag.replace('"', "\\\"")).ok();
+                        write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                     }
                 }
                 writeln!(sdl, "{{").ok();
@@ -419,13 +419,13 @@ impl Registry {
                     if let Some(description) = field.description {
                         export_description(sdl, options, false, description);
                     }
-                    write!(sdl, "\t{} ", export_input_value(&field)).ok();
+                    write!(sdl, "\t{}", export_input_value(&field)).ok();
                     if options.federation {
                         if field.inaccessible {
-                            write!(sdl, "@inaccessible ").ok();
+                            write!(sdl, " @inaccessible").ok();
                         }
                         for tag in field.tags {
-                            write!(sdl, "@tag(name: \"{}\") ", tag.replace('"', "\\\"")).ok();
+                            write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                         }
                     }
                     writeln!(sdl).ok();
@@ -445,16 +445,16 @@ impl Registry {
                     export_description(sdl, options, true, description);
                 }
 
-                write!(sdl, "union {} ", name).ok();
+                write!(sdl, "union {}", name).ok();
                 if options.federation {
                     if *inaccessible {
-                        write!(sdl, "@inaccessible ").ok();
+                        write!(sdl, " @inaccessible").ok();
                     }
                     for tag in *tags {
-                        write!(sdl, "@tag(name: \"{}\") ", tag.replace('"', "\\\"")).ok();
+                        write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                     }
                 }
-                write!(sdl, "=").ok();
+                write!(sdl, " =").ok();
 
                 for (idx, ty) in possible_types.iter().enumerate() {
                     if idx == 0 {
@@ -473,7 +473,7 @@ impl Registry {
             if !implements.is_empty() {
                 write!(
                     sdl,
-                    "implements {} ",
+                    " implements {}",
                     implements
                         .iter()
                         .map(AsRef::as_ref)

--- a/tests/federation.rs
+++ b/tests/federation.rs
@@ -534,6 +534,8 @@ pub async fn test_entity_inaccessible() {
     assert!(schema_sdl.contains("input MyInputObjInaccessible @inaccessible"));
     // INPUT_FIELD_DEFINITION
     assert!(schema_sdl.contains("inputFieldInaccessibleA: Int! @inaccessible"));
+    // no trailing spaces
+    assert!(!schema_sdl.contains(" \n"));
 }
 
 #[tokio::test]
@@ -733,4 +735,6 @@ pub async fn test_entity_tag() {
     assert!(
         schema_sdl.contains(r#"inputFieldTaggedA: Int! @tag(name: "tagged_input_object_field")"#)
     );
+    // no trailing spaces
+    assert!(!schema_sdl.contains(" \n"));
 }


### PR DESCRIPTION
116f6e48 modified the SDL export for scalars not to
incur trailing spaces. Unfortunately this occurs for
other types as well. This commit takes care of the
remaining occurrences and adds assertions to unit-tests
where an SDL is already available.

Closes #1037.