### PR TITLE
Add GraphiQL v2

### DIFF
--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -66,7 +66,7 @@ impl<'a> GraphiQLSource<'a> {
         };
 
         r#"
-      <!DOCTYPE html>
+        <!DOCTYPE html>
         <html>
           <head>
             <style>
@@ -113,7 +113,7 @@ impl<'a> GraphiQLSource<'a> {
             </script>
           </body>
         </html>
-      "#
+        "#
         .replace("%GRAPHIQL_URL%", &graphiql_url)
         .replace("%GRAPHIQL_SUBSCRIPTION_URL%", &graphiql_subscription_url)
         .replace("%GRAPHIQL_HEADERS%", &graphiql_headers)
@@ -133,7 +133,7 @@ mod tests {
         assert_eq!(
             graphiql_source,
             r#"
-      <!DOCTYPE html>
+        <!DOCTYPE html>
         <html>
           <head>
             <style>
@@ -180,7 +180,7 @@ mod tests {
             </script>
           </body>
         </html>
-      "#
+        "#
         )
     }
 
@@ -194,7 +194,7 @@ mod tests {
         assert_eq!(
             graphiql_source,
             r#"
-      <!DOCTYPE html>
+        <!DOCTYPE html>
         <html>
           <head>
             <style>
@@ -241,7 +241,7 @@ mod tests {
             </script>
           </body>
         </html>
-      "#
+        "#
         )
     }
 
@@ -256,7 +256,7 @@ mod tests {
         assert_eq!(
             graphiql_source,
             r#"
-      <!DOCTYPE html>
+        <!DOCTYPE html>
         <html>
           <head>
             <style>
@@ -303,7 +303,7 @@ mod tests {
             </script>
           </body>
         </html>
-      "#
+        "#
         )
     }
 }

--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -66,54 +66,54 @@ impl<'a> GraphiQLSource<'a> {
         };
 
         r#"
-        <!DOCTYPE html>
-        <html>
-          <head>
-            <style>
-              body {
-                height: 100%;
-                margin: 0;
-                width: 100%;
-                overflow: hidden;
-              }
-  
-              #graphiql {
-                height: 100vh;
-              }
-            </style>
-            <script
-              crossorigin
-              src="https://unpkg.com/react@17/umd/react.development.js"
-            ></script>
-            <script
-              crossorigin
-              src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
-            ></script>
-            <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
-          </head>
-  
-          <body>
-            <div id="graphiql">Loading...</div>
-            <script
-              src="https://unpkg.com/graphiql/graphiql.min.js"
-              type="application/javascript"
-            ></script>
-            <script>
-              ReactDOM.render(
-                React.createElement(GraphiQL, {
-                  fetcher: GraphiQL.createFetcher({
-                    url: %GRAPHIQL_URL%,
-                    subscriptionUrl: %GRAPHIQL_SUBSCRIPTION_URL%,
-                    headers: %GRAPHIQL_HEADERS%,
-                  }),
-                  defaultEditorToolsVisibility: true,
-                }),
-                document.getElementById("graphiql")
-              );
-            </script>
-          </body>
-        </html>
-        "#
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
+    <script
+      crossorigin
+      src="https://unpkg.com/react@17/umd/react.development.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
+    ></script>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+  </head>
+
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script
+      src="https://unpkg.com/graphiql/graphiql.min.js"
+      type="application/javascript"
+    ></script>
+    <script>
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: GraphiQL.createFetcher({
+            url: %GRAPHIQL_URL%,
+            subscriptionUrl: %GRAPHIQL_SUBSCRIPTION_URL%,
+            headers: %GRAPHIQL_HEADERS%,
+          }),
+          defaultEditorToolsVisibility: true,
+        }),
+        document.getElementById("graphiql")
+      );
+    </script>
+  </body>
+</html>
+"#
         .replace("%GRAPHIQL_URL%", &graphiql_url)
         .replace("%GRAPHIQL_SUBSCRIPTION_URL%", &graphiql_subscription_url)
         .replace("%GRAPHIQL_HEADERS%", &graphiql_headers)
@@ -133,54 +133,54 @@ mod tests {
         assert_eq!(
             graphiql_source,
             r#"
-        <!DOCTYPE html>
-        <html>
-          <head>
-            <style>
-              body {
-                height: 100%;
-                margin: 0;
-                width: 100%;
-                overflow: hidden;
-              }
-  
-              #graphiql {
-                height: 100vh;
-              }
-            </style>
-            <script
-              crossorigin
-              src="https://unpkg.com/react@17/umd/react.development.js"
-            ></script>
-            <script
-              crossorigin
-              src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
-            ></script>
-            <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
-          </head>
-  
-          <body>
-            <div id="graphiql">Loading...</div>
-            <script
-              src="https://unpkg.com/graphiql/graphiql.min.js"
-              type="application/javascript"
-            ></script>
-            <script>
-              ReactDOM.render(
-                React.createElement(GraphiQL, {
-                  fetcher: GraphiQL.createFetcher({
-                    url: 'http://localhost:8000',
-                    subscriptionUrl: undefined,
-                    headers: undefined,
-                  }),
-                  defaultEditorToolsVisibility: true,
-                }),
-                document.getElementById("graphiql")
-              );
-            </script>
-          </body>
-        </html>
-        "#
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
+    <script
+      crossorigin
+      src="https://unpkg.com/react@17/umd/react.development.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
+    ></script>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+  </head>
+
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script
+      src="https://unpkg.com/graphiql/graphiql.min.js"
+      type="application/javascript"
+    ></script>
+    <script>
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: GraphiQL.createFetcher({
+            url: 'http://localhost:8000',
+            subscriptionUrl: undefined,
+            headers: undefined,
+          }),
+          defaultEditorToolsVisibility: true,
+        }),
+        document.getElementById("graphiql")
+      );
+    </script>
+  </body>
+</html>
+"#
         )
     }
 
@@ -194,54 +194,54 @@ mod tests {
         assert_eq!(
             graphiql_source,
             r#"
-        <!DOCTYPE html>
-        <html>
-          <head>
-            <style>
-              body {
-                height: 100%;
-                margin: 0;
-                width: 100%;
-                overflow: hidden;
-              }
-  
-              #graphiql {
-                height: 100vh;
-              }
-            </style>
-            <script
-              crossorigin
-              src="https://unpkg.com/react@17/umd/react.development.js"
-            ></script>
-            <script
-              crossorigin
-              src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
-            ></script>
-            <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
-          </head>
-  
-          <body>
-            <div id="graphiql">Loading...</div>
-            <script
-              src="https://unpkg.com/graphiql/graphiql.min.js"
-              type="application/javascript"
-            ></script>
-            <script>
-              ReactDOM.render(
-                React.createElement(GraphiQL, {
-                  fetcher: GraphiQL.createFetcher({
-                    url: 'http://localhost:8000',
-                    subscriptionUrl: 'ws://localhost:8000/ws',
-                    headers: undefined,
-                  }),
-                  defaultEditorToolsVisibility: true,
-                }),
-                document.getElementById("graphiql")
-              );
-            </script>
-          </body>
-        </html>
-        "#
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
+    <script
+      crossorigin
+      src="https://unpkg.com/react@17/umd/react.development.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
+    ></script>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+  </head>
+
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script
+      src="https://unpkg.com/graphiql/graphiql.min.js"
+      type="application/javascript"
+    ></script>
+    <script>
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: GraphiQL.createFetcher({
+            url: 'http://localhost:8000',
+            subscriptionUrl: 'ws://localhost:8000/ws',
+            headers: undefined,
+          }),
+          defaultEditorToolsVisibility: true,
+        }),
+        document.getElementById("graphiql")
+      );
+    </script>
+  </body>
+</html>
+"#
         )
     }
 
@@ -256,54 +256,54 @@ mod tests {
         assert_eq!(
             graphiql_source,
             r#"
-        <!DOCTYPE html>
-        <html>
-          <head>
-            <style>
-              body {
-                height: 100%;
-                margin: 0;
-                width: 100%;
-                overflow: hidden;
-              }
-  
-              #graphiql {
-                height: 100vh;
-              }
-            </style>
-            <script
-              crossorigin
-              src="https://unpkg.com/react@17/umd/react.development.js"
-            ></script>
-            <script
-              crossorigin
-              src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
-            ></script>
-            <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
-          </head>
-  
-          <body>
-            <div id="graphiql">Loading...</div>
-            <script
-              src="https://unpkg.com/graphiql/graphiql.min.js"
-              type="application/javascript"
-            ></script>
-            <script>
-              ReactDOM.render(
-                React.createElement(GraphiQL, {
-                  fetcher: GraphiQL.createFetcher({
-                    url: 'http://localhost:8000',
-                    subscriptionUrl: 'ws://localhost:8000/ws',
-                    headers: {"Authorization":"Bearer <token>"},
-                  }),
-                  defaultEditorToolsVisibility: true,
-                }),
-                document.getElementById("graphiql")
-              );
-            </script>
-          </body>
-        </html>
-        "#
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
+    <script
+      crossorigin
+      src="https://unpkg.com/react@17/umd/react.development.js"
+    ></script>
+    <script
+      crossorigin
+      src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
+    ></script>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+  </head>
+
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script
+      src="https://unpkg.com/graphiql/graphiql.min.js"
+      type="application/javascript"
+    ></script>
+    <script>
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: GraphiQL.createFetcher({
+            url: 'http://localhost:8000',
+            subscriptionUrl: 'ws://localhost:8000/ws',
+            headers: {"Authorization":"Bearer <token>"},
+          }),
+          defaultEditorToolsVisibility: true,
+        }),
+        document.getElementById("graphiql")
+      );
+    </script>
+  </body>
+</html>
+"#
         )
     }
 }

--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -69,6 +69,13 @@ impl<'a> GraphiQLSource<'a> {
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="referrer" content="origin">
+
+    <title>GraphiQL IDE</title>
+
     <style>
       body {
         height: 100%;
@@ -89,6 +96,7 @@ impl<'a> GraphiQLSource<'a> {
       crossorigin
       src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
     ></script>
+    <link rel="icon" href="https://graphql.org/favicon.ico">
     <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
   </head>
 
@@ -136,6 +144,13 @@ mod tests {
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="referrer" content="origin">
+
+    <title>GraphiQL IDE</title>
+
     <style>
       body {
         height: 100%;
@@ -156,6 +171,7 @@ mod tests {
       crossorigin
       src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
     ></script>
+    <link rel="icon" href="https://graphql.org/favicon.ico">
     <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
   </head>
 
@@ -197,6 +213,13 @@ mod tests {
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="referrer" content="origin">
+
+    <title>GraphiQL IDE</title>
+
     <style>
       body {
         height: 100%;
@@ -217,6 +240,7 @@ mod tests {
       crossorigin
       src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
     ></script>
+    <link rel="icon" href="https://graphql.org/favicon.ico">
     <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
   </head>
 
@@ -259,6 +283,13 @@ mod tests {
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="referrer" content="origin">
+
+    <title>GraphiQL IDE</title>
+
     <style>
       body {
         height: 100%;
@@ -279,6 +310,7 @@ mod tests {
       crossorigin
       src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
     ></script>
+    <link rel="icon" href="https://graphql.org/favicon.ico">
     <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
   </head>
 

--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -59,7 +59,7 @@ impl<'a> GraphiQLSource<'a> {
         let graphiql_subscription_url = self
             .subscription_endpoint
             .map(|endpoint| format!("'{}'", endpoint))
-            .unwrap_or("undefined".into());
+            .unwrap_or_else(|| "undefined".into());
         let graphiql_headers = match self.headers {
             Some(headers) => serde_json::to_string(&headers).unwrap(),
             None => "undefined".into(),

--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -1,0 +1,309 @@
+use std::collections::HashMap;
+
+/// A builder for constructing a GraphiQL (v2) HTML page.
+///
+/// # Example
+///
+/// ```rust
+/// use async_graphql::http::*;
+///
+/// GraphiQLSource::build()
+///     .endpoint("http://localhost:8000")
+///     .subscription_endpoint("ws://localhost:8000/ws")
+///     .header("Authorization", "Bearer <token>")
+///     .finish();
+/// ```
+#[derive(Default)]
+pub struct GraphiQLSource<'a> {
+    endpoint: &'a str,
+    subscription_endpoint: Option<&'a str>,
+    headers: Option<HashMap<&'a str, &'a str>>,
+}
+
+impl<'a> GraphiQLSource<'a> {
+    /// Creates a builder for constructing a GraphiQL (v2) HTML page.
+    pub fn build() -> GraphiQLSource<'a> {
+        Default::default()
+    }
+
+    /// Sets the endpoint of the server GraphiQL will connect to.
+    #[must_use]
+    pub fn endpoint(self, endpoint: &'a str) -> GraphiQLSource<'a> {
+        GraphiQLSource { endpoint, ..self }
+    }
+
+    /// Sets the subscription endpoint of the server GraphiQL will connect to.
+    pub fn subscription_endpoint(self, endpoint: &'a str) -> GraphiQLSource<'a> {
+        GraphiQLSource {
+            subscription_endpoint: Some(endpoint),
+            ..self
+        }
+    }
+
+    /// Sets a header to be sent with requests GraphiQL will send.
+    pub fn header(self, name: &'a str, value: &'a str) -> GraphiQLSource<'a> {
+        let mut headers = match self.headers {
+            Some(headers) => headers,
+            None => HashMap::new(),
+        };
+        headers.insert(name, value);
+        GraphiQLSource {
+            headers: Some(headers),
+            ..self
+        }
+    }
+
+    /// Returns a GraphiQL (v2) HTML page.
+    pub fn finish(self) -> String {
+        let graphiql_url = format!("'{}'", self.endpoint);
+        let graphiql_subscription_url = self
+            .subscription_endpoint
+            .map(|endpoint| format!("'{}'", endpoint))
+            .unwrap_or("undefined".into());
+        let graphiql_headers = match self.headers {
+            Some(headers) => serde_json::to_string(&headers).unwrap(),
+            None => "undefined".into(),
+        };
+
+        r#"
+      <!DOCTYPE html>
+        <html>
+          <head>
+            <style>
+              body {
+                height: 100%;
+                margin: 0;
+                width: 100%;
+                overflow: hidden;
+              }
+  
+              #graphiql {
+                height: 100vh;
+              }
+            </style>
+            <script
+              crossorigin
+              src="https://unpkg.com/react@17/umd/react.development.js"
+            ></script>
+            <script
+              crossorigin
+              src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
+            ></script>
+            <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+          </head>
+  
+          <body>
+            <div id="graphiql">Loading...</div>
+            <script
+              src="https://unpkg.com/graphiql/graphiql.min.js"
+              type="application/javascript"
+            ></script>
+            <script>
+              ReactDOM.render(
+                React.createElement(GraphiQL, {
+                  fetcher: GraphiQL.createFetcher({
+                    url: %GRAPHIQL_URL%,
+                    subscriptionUrl: %GRAPHIQL_SUBSCRIPTION_URL%,
+                    headers: %GRAPHIQL_HEADERS%,
+                  }),
+                  defaultEditorToolsVisibility: true,
+                }),
+                document.getElementById("graphiql")
+              );
+            </script>
+          </body>
+        </html>
+      "#
+        .replace("%GRAPHIQL_URL%", &graphiql_url)
+        .replace("%GRAPHIQL_SUBSCRIPTION_URL%", &graphiql_subscription_url)
+        .replace("%GRAPHIQL_HEADERS%", &graphiql_headers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_with_only_url() {
+        let graphiql_source = GraphiQLSource::build()
+            .endpoint("http://localhost:8000")
+            .finish();
+
+        assert_eq!(
+            graphiql_source,
+            r#"
+      <!DOCTYPE html>
+        <html>
+          <head>
+            <style>
+              body {
+                height: 100%;
+                margin: 0;
+                width: 100%;
+                overflow: hidden;
+              }
+  
+              #graphiql {
+                height: 100vh;
+              }
+            </style>
+            <script
+              crossorigin
+              src="https://unpkg.com/react@17/umd/react.development.js"
+            ></script>
+            <script
+              crossorigin
+              src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
+            ></script>
+            <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+          </head>
+  
+          <body>
+            <div id="graphiql">Loading...</div>
+            <script
+              src="https://unpkg.com/graphiql/graphiql.min.js"
+              type="application/javascript"
+            ></script>
+            <script>
+              ReactDOM.render(
+                React.createElement(GraphiQL, {
+                  fetcher: GraphiQL.createFetcher({
+                    url: 'http://localhost:8000',
+                    subscriptionUrl: undefined,
+                    headers: undefined,
+                  }),
+                  defaultEditorToolsVisibility: true,
+                }),
+                document.getElementById("graphiql")
+              );
+            </script>
+          </body>
+        </html>
+      "#
+        )
+    }
+
+    #[test]
+    fn test_with_both_urls() {
+        let graphiql_source = GraphiQLSource::build()
+            .endpoint("http://localhost:8000")
+            .subscription_endpoint("ws://localhost:8000/ws")
+            .finish();
+
+        assert_eq!(
+            graphiql_source,
+            r#"
+      <!DOCTYPE html>
+        <html>
+          <head>
+            <style>
+              body {
+                height: 100%;
+                margin: 0;
+                width: 100%;
+                overflow: hidden;
+              }
+  
+              #graphiql {
+                height: 100vh;
+              }
+            </style>
+            <script
+              crossorigin
+              src="https://unpkg.com/react@17/umd/react.development.js"
+            ></script>
+            <script
+              crossorigin
+              src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
+            ></script>
+            <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+          </head>
+  
+          <body>
+            <div id="graphiql">Loading...</div>
+            <script
+              src="https://unpkg.com/graphiql/graphiql.min.js"
+              type="application/javascript"
+            ></script>
+            <script>
+              ReactDOM.render(
+                React.createElement(GraphiQL, {
+                  fetcher: GraphiQL.createFetcher({
+                    url: 'http://localhost:8000',
+                    subscriptionUrl: 'ws://localhost:8000/ws',
+                    headers: undefined,
+                  }),
+                  defaultEditorToolsVisibility: true,
+                }),
+                document.getElementById("graphiql")
+              );
+            </script>
+          </body>
+        </html>
+      "#
+        )
+    }
+
+    #[test]
+    fn test_with_all_options() {
+        let graphiql_source = GraphiQLSource::build()
+            .endpoint("http://localhost:8000")
+            .subscription_endpoint("ws://localhost:8000/ws")
+            .header("Authorization", "Bearer <token>")
+            .finish();
+
+        assert_eq!(
+            graphiql_source,
+            r#"
+      <!DOCTYPE html>
+        <html>
+          <head>
+            <style>
+              body {
+                height: 100%;
+                margin: 0;
+                width: 100%;
+                overflow: hidden;
+              }
+  
+              #graphiql {
+                height: 100vh;
+              }
+            </style>
+            <script
+              crossorigin
+              src="https://unpkg.com/react@17/umd/react.development.js"
+            ></script>
+            <script
+              crossorigin
+              src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
+            ></script>
+            <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+          </head>
+  
+          <body>
+            <div id="graphiql">Loading...</div>
+            <script
+              src="https://unpkg.com/graphiql/graphiql.min.js"
+              type="application/javascript"
+            ></script>
+            <script>
+              ReactDOM.render(
+                React.createElement(GraphiQL, {
+                  fetcher: GraphiQL.createFetcher({
+                    url: 'http://localhost:8000',
+                    subscriptionUrl: 'ws://localhost:8000/ws',
+                    headers: {"Authorization":"Bearer <token>"},
+                  }),
+                  defaultEditorToolsVisibility: true,
+                }),
+                document.getElementById("graphiql")
+              );
+            </script>
+          </body>
+        </html>
+      "#
+        )
+    }
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,12 +1,14 @@
 //! A helper module that supports HTTP
 
 mod graphiql_source;
+mod graphiql_v2_source;
 mod multipart;
 mod playground_source;
 mod websocket;
 
 use futures_util::io::{AsyncRead, AsyncReadExt};
 pub use graphiql_source::graphiql_source;
+pub use graphiql_v2_source::GraphiQLSource;
 use mime;
 pub use multipart::MultipartOptions;
 pub use playground_source::{playground_source, GraphQLPlaygroundConfig};


### PR DESCRIPTION
GraphiQL version 2 was [released](https://github.com/graphql/graphiql/releases) this week! 🎉 
It is the successor to both GraphiQL v1 and the GraphQL Playground (see https://github.com/graphql/graphql-playground/issues/1143 for more info).

I therefore propose to add the GraphiQL version 2 source to the repo and created this PR for it.
I created a separate module for this source, since that ensures nothing breaks 🙃.

Since this officially replaces the earlier versions of GraphiQL and GraphQL Playground it might be good to add the `#[deprecated]` attribute to `http::graphiql_source::graphiql_source` and `http::playground_source::playground_source` since these packages likely won't receive any further updates, but I want to leave that decision to you.

When this gets merged, I will also create a PR to update the examples in the other repo.