### PR TITLE
Compare to expected schema

### DIFF
--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -367,7 +367,7 @@ impl Registry {
                         write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                     }
                 }
-                writeln!(sdl, "{{").ok();
+                writeln!(sdl, " {{").ok();
 
                 let mut values = enum_values.values().collect::<Vec<_>>();
                 if options.sorted_enum_values {
@@ -418,7 +418,7 @@ impl Registry {
                         write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                     }
                 }
-                writeln!(sdl, "{{").ok();
+                writeln!(sdl, " {{").ok();
 
                 let mut fields = input_fields.values().collect::<Vec<_>>();
                 if options.sorted_fields {

--- a/tests/federation.rs
+++ b/tests/federation.rs
@@ -536,6 +536,15 @@ pub async fn test_entity_inaccessible() {
     assert!(schema_sdl.contains("inputFieldInaccessibleA: Int! @inaccessible"));
     // no trailing spaces
     assert!(!schema_sdl.contains(" \n"));
+
+    // compare to expected schema
+    let path = std::path::Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("tests/schemas/test_entity_inaccessible.schema.graphql");
+    let expected_schema = std::fs::read_to_string(&path).unwrap();
+    if schema_sdl != expected_schema {
+        std::fs::write(path, schema_sdl).unwrap();
+        panic!("schema was not up-to-date. rerun")
+    }
 }
 
 #[tokio::test]
@@ -737,4 +746,13 @@ pub async fn test_entity_tag() {
     );
     // no trailing spaces
     assert!(!schema_sdl.contains(" \n"));
+
+    // compare to expected schema
+    let path = std::path::Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("tests/schemas/test_entity_tag.schema.graphql");
+    let expected_schema = std::fs::read_to_string(&path).unwrap();
+    if schema_sdl != expected_schema {
+        std::fs::write(path, schema_sdl).unwrap();
+        panic!("schema was not up-to-date. rerun")
+    }
 }

--- a/tests/schemas/test_entity_inaccessible.schema.graphql
+++ b/tests/schemas/test_entity_inaccessible.schema.graphql
@@ -1,0 +1,67 @@
+
+
+
+
+type MyCustomObjInaccessible @inaccessible {
+	a: Int!
+	customObjectInaccessible: Int! @inaccessible
+}
+
+enum MyEnumInaccessible @inaccessible{
+	OPTION_A
+	OPTION_B
+	OPTION_C
+}
+
+enum MyEnumVariantInaccessible{
+	OPTION_A_INACCESSIBLE @inaccessible
+	OPTION_B
+	OPTION_C
+}
+
+input MyInputObjFieldInaccessible{
+	inputFieldInaccessibleA: Int! @inaccessible
+}
+
+input MyInputObjInaccessible @inaccessible{
+	a: Int!
+}
+
+interface MyInterfaceInaccessible @inaccessible {
+	inaccessibleInterfaceValue: String! @inaccessible
+}
+
+type MyInterfaceObjA implements MyInterfaceInaccessible {
+	inaccessibleInterfaceValue: String!
+}
+
+type MyInterfaceObjB implements MyInterfaceInaccessible @inaccessible {
+	inaccessibleInterfaceValue: String!
+}
+
+scalar MyNumberInaccessible @inaccessible
+
+type MyObjFieldInaccessible @key(fields: "id") {
+	objFieldInaccessibleA: Int! @inaccessible
+}
+
+type MyObjInaccessible @key(fields: "id") @inaccessible {
+	a: Int!
+}
+
+union MyUnionInaccessible @inaccessible = MyInterfaceObjA | MyInterfaceObjB
+
+extend type Query {
+	enumVariantInaccessible(id: Int!): MyEnumVariantInaccessible!
+	enumInaccessible(id: Int!): MyEnumInaccessible!
+	inaccessibleField(id: Int!): Int! @inaccessible
+	inaccessibleArgument(id: Int! @inaccessible): Int!
+	inaccessibleInterface: MyInterfaceInaccessible!
+	inaccessibleUnion: MyUnionInaccessible!
+	inaccessibleScalar: MyNumberInaccessible!
+	inaccessibleInputField(value: MyInputObjFieldInaccessible!): Int!
+	inaccessibleInput(value: MyInputObjInaccessible!): Int!
+	inaccessibleCustomObject: MyCustomObjInaccessible!
+}
+
+

--- a/tests/schemas/test_entity_inaccessible.schema.graphql
+++ b/tests/schemas/test_entity_inaccessible.schema.graphql
@@ -7,23 +7,23 @@ type MyCustomObjInaccessible @inaccessible {
 	customObjectInaccessible: Int! @inaccessible
 }
 
-enum MyEnumInaccessible @inaccessible{
+enum MyEnumInaccessible @inaccessible {
 	OPTION_A
 	OPTION_B
 	OPTION_C
 }
 
-enum MyEnumVariantInaccessible{
+enum MyEnumVariantInaccessible {
 	OPTION_A_INACCESSIBLE @inaccessible
 	OPTION_B
 	OPTION_C
 }
 
-input MyInputObjFieldInaccessible{
+input MyInputObjFieldInaccessible {
 	inputFieldInaccessibleA: Int! @inaccessible
 }
 
-input MyInputObjInaccessible @inaccessible{
+input MyInputObjInaccessible @inaccessible {
 	a: Int!
 }
 

--- a/tests/schemas/test_entity_tag.schema.graphql
+++ b/tests/schemas/test_entity_tag.schema.graphql
@@ -7,23 +7,23 @@ type MyCustomObjTagged @tag(name: "tagged") @tag(name: "object") @tag(name: "wit
 	customObjectTagged: Int! @tag(name: "tagged_custom_object_field")
 }
 
-enum MyEnumTagged @tag(name: "tagged_num"){
+enum MyEnumTagged @tag(name: "tagged_num") {
 	OPTION_A
 	OPTION_B
 	OPTION_C
 }
 
-enum MyEnumVariantTagged{
+enum MyEnumVariantTagged {
 	OPTION_A_TAGGED @tag(name: "tagged_enum_option")
 	OPTION_B
 	OPTION_C
 }
 
-input MyInputObjFieldTagged{
+input MyInputObjFieldTagged {
 	inputFieldTaggedA: Int! @tag(name: "tagged_input_object_field")
 }
 
-input MyInputObjTagged @tag(name: "input_object_tag"){
+input MyInputObjTagged @tag(name: "input_object_tag") {
 	a: Int!
 }
 

--- a/tests/schemas/test_entity_tag.schema.graphql
+++ b/tests/schemas/test_entity_tag.schema.graphql
@@ -1,0 +1,67 @@
+
+
+
+
+type MyCustomObjTagged @tag(name: "tagged") @tag(name: "object") @tag(name: "with") @tag(name: "multiple") @tag(name: "tags") {
+	a: Int!
+	customObjectTagged: Int! @tag(name: "tagged_custom_object_field")
+}
+
+enum MyEnumTagged @tag(name: "tagged_num"){
+	OPTION_A
+	OPTION_B
+	OPTION_C
+}
+
+enum MyEnumVariantTagged{
+	OPTION_A_TAGGED @tag(name: "tagged_enum_option")
+	OPTION_B
+	OPTION_C
+}
+
+input MyInputObjFieldTagged{
+	inputFieldTaggedA: Int! @tag(name: "tagged_input_object_field")
+}
+
+input MyInputObjTagged @tag(name: "input_object_tag"){
+	a: Int!
+}
+
+type MyInterfaceObjA implements MyInterfaceTagged {
+	taggedInterfaceValue: String!
+}
+
+type MyInterfaceObjB implements MyInterfaceTagged @tag(name: "interface_object") {
+	taggedInterfaceValue: String!
+}
+
+interface MyInterfaceTagged @tag(name: "tagged_interface") {
+	taggedInterfaceValue: String! @tag(name: "tagged_interface_field")
+}
+
+scalar MyNumberTagged @tag(name: "tagged_scalar")
+
+type MyObjFieldTagged @key(fields: "id") {
+	objFieldTaggedA: Int! @tag(name: "tagged_field")
+}
+
+type MyObjTagged @key(fields: "id") @tag(name: "tagged_simple_object") {
+	a: Int!
+}
+
+union MyUnionTagged @tag(name: "tagged_union") = MyInterfaceObjA | MyInterfaceObjB
+
+extend type Query {
+	enumVariantTagged(id: Int!): MyEnumVariantTagged!
+	enumTagged(id: Int!): MyEnumTagged!
+	taggedField(id: Int!): Int! @tag(name: "tagged_\"field\"")
+	taggedArgument(id: Int! @tag(name: "tagged_argument")): Int!
+	taggedInterface: MyInterfaceTagged!
+	taggedUnion: MyUnionTagged!
+	taggedScalar: MyNumberTagged!
+	taggedInputField(value: MyInputObjFieldTagged!): Int!
+	taggedInput(value: MyInputObjTagged!): Int!
+	taggedCustomObject: MyCustomObjTagged!
+}
+
+


### PR DESCRIPTION
The first commit adds logic to two unit tests where the schema
export is compared against expected output cached in two
schema files.

This is intended to help prevent bugs like the ones fixed in
https://github.com/async-graphql/async-graphql/commit/116f6e48be245097d7134407f723ef64edc2a91f or the immediately succeeding commit, as unexpected
changes to schema export will become apparent in the commit
diff, easing reviews.

When legitimately changing the export output behaviour,
the test suite just needs to be run twice, as the unit-tests
automatically overwrite the files with the new version.

This unit-test approach is inspired by

https://matklad.github.io/2022/03/26/self-modifying-code.html

The second commit fixes #1045.