### PR TITLE
Support for primitive type in CursorType

### DIFF
--- a/src/types/connection/cursor.rs
+++ b/src/types/connection/cursor.rs
@@ -1,7 +1,9 @@
 use std::{
+    char::ParseCharError,
     convert::Infallible,
     fmt::Display,
     num::{ParseFloatError, ParseIntError},
+    str::ParseBoolError,
 };
 
 use serde::{de::DeserializeOwned, Serialize};
@@ -23,8 +25,26 @@ pub trait CursorType: Sized {
     fn encode_cursor(&self) -> String;
 }
 
-impl CursorType for usize {
-    type Error = ParseIntError;
+macro_rules! cursor_type_int_impl {
+    ($($t:ty)*) => {$(
+        impl CursorType for $t {
+            type Error = ParseIntError;
+
+            fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+                s.parse()
+            }
+
+            fn encode_cursor(&self) -> String {
+                self.to_string()
+            }
+        }
+    )*}
+}
+
+cursor_type_int_impl! { isize i8 i16 i32 i64 i128 usize u8 u16 u32 u64 u128 }
+
+impl CursorType for f32 {
+    type Error = ParseFloatError;
 
     fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
         s.parse()
@@ -35,8 +55,8 @@ impl CursorType for usize {
     }
 }
 
-impl CursorType for i32 {
-    type Error = ParseIntError;
+impl CursorType for f64 {
+    type Error = ParseFloatError;
 
     fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
         s.parse()
@@ -47,8 +67,20 @@ impl CursorType for i32 {
     }
 }
 
-impl CursorType for i64 {
-    type Error = ParseIntError;
+impl CursorType for char {
+    type Error = ParseCharError;
+
+    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+
+    fn encode_cursor(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl CursorType for bool {
+    type Error = ParseBoolError;
 
     fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
         s.parse()
@@ -76,30 +108,6 @@ impl CursorType for ID {
 
     fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
         Ok(s.to_string().into())
-    }
-
-    fn encode_cursor(&self) -> String {
-        self.to_string()
-    }
-}
-
-impl CursorType for f64 {
-    type Error = ParseFloatError;
-
-    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
-        s.parse()
-    }
-
-    fn encode_cursor(&self) -> String {
-        self.to_string()
-    }
-}
-
-impl CursorType for f32 {
-    type Error = ParseFloatError;
-
-    fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
-        s.parse()
     }
 
     fn encode_cursor(&self) -> String {


### PR DESCRIPTION
Changed `CursorType` to support primitive types.
This is useful if the use case is to decode recursively.