### PR TITLE
validation: fix error message

### DIFF
--- a/src/validation/utils.rs
+++ b/src/validation/utils.rs
@@ -168,8 +168,8 @@ pub fn is_valid_input_value(
                                 return Some(valid_error(
                                     &path_node,
                                     format!(
-                                        "field \"{}\" of type \"{}\" is required but not provided",
-                                        field.name, object_name,
+                                        r#"field "{}" of type "{}" is required but not provided"#,
+                                        field.name, field.ty,
                                     ),
                                 ));
                             }


### PR DESCRIPTION
The error message was mistakenly passed the `object_name`
instead of the field type. This is fixed now.