### PR TITLE
docs: Update federation docs with examples of each directive

### DIFF
--- a/docs/en/src/apollo_federation.md
+++ b/docs/en/src/apollo_federation.md
@@ -10,10 +10,8 @@ Apollo Federation is a GraphQL architecture for combining multiple GraphQL servi
 
 ```rust
 # extern crate async_graphql;
-# extern crate tokio;
 # use async_graphql::*;
-#[tokio::main]
-async fn main() {
+fn main() {
   let schema = Schema::build(EmptyQuery, EmptyMutation, EmptySubscription)
     .enable_federation()
     .finish();

--- a/docs/en/src/apollo_federation.md
+++ b/docs/en/src/apollo_federation.md
@@ -11,8 +11,11 @@ Apollo Federation is a GraphQL architecture for combining multiple GraphQL servi
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
+# struct Query;
+# #[Object]
+# impl Query {}
 fn main() {
-  let schema = Schema::build(EmptyQuery, EmptyMutation, EmptySubscription)
+  let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
     .enable_federation()
     .finish();
   // ... Start your server of choice

--- a/docs/en/src/apollo_federation.md
+++ b/docs/en/src/apollo_federation.md
@@ -288,14 +288,14 @@ impl Query {
     #[graphql(provides = "humanName")]
     async fn out_of_stock_products(&self) -> Vec<Product> {
       vec![Product {
-        id: "1".to_string(),
+        id: "1".into(),
         human_name: "My Product".to_string(),
         in_stock: false,
       }]
     }
     async fn discontinued_products(&self) -> Vec<Product> {
         vec![Product {
-            id: "2".to_string(),
+            id: "2".into(),
             human_name: String::new(),  // This is ignored by the router
             in_stock: false,
         }]

--- a/docs/en/src/apollo_federation.md
+++ b/docs/en/src/apollo_federation.md
@@ -133,7 +133,7 @@ Apply the [`@shareable` directive](https://www.apollographql.com/docs/federation
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
-#[SimpleObject]
+#[derive(SimpleObject)]
 #[graphql(complex)]
 struct Position {
   #[graphql(shareable)]
@@ -164,7 +164,7 @@ type Position {
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
-#[SimpleObject]
+#[derive(SimpleObject)]
 #[graphql(shareable)]
 struct Position {
   x: u64,
@@ -188,7 +188,7 @@ The [`@inaccessible` directive](https://www.apollographql.com/docs/federation/fe
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
-#[SimpleObject]
+#[derive(SimpleObject)]
 #[graphql(shareable)]
 struct Position {
   x: u32,
@@ -217,7 +217,7 @@ For example, if you add a new "Inventory" subgraph which should take over respon
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
-#[SimpleObject]
+#[derive(SimpleObject)]
 struct Product {
   id: ID,
   #[graphql(override_from = "Products")]
@@ -241,7 +241,7 @@ The [`@external` directive](https://www.apollographql.com/docs/federation/federa
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
-#[SimpleObject]
+#[derive(SimpleObject)]
 struct Product {
   id: ID,
   #[graphql(external)]
@@ -267,7 +267,7 @@ The [`@provides` directive](https://www.apollographql.com/docs/federation/federa
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
-#[SimpleObject]
+#[derive(SimpleObject)]
 struct Product {
     id: ID,
     #[graphql(external)]
@@ -341,7 +341,7 @@ In order to implement this in Rust, we can use the `#[graphql(requires)]` attrib
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
-#[SimpleObject]
+#[derive(SimpleObject)]
 #[graphql(complex)]
 struct Product {
   id: ID,
@@ -366,7 +366,7 @@ Note that we use the GraphQL field name `weightInPounds`, not the Rust field nam
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
-# #[SimpleObject]
+# #[derive(SimpleObject)]
 # #[graphql(complex)]
 # struct Product {
 #     id: ID,
@@ -435,7 +435,7 @@ You can write code like this:
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
-#[SimpleObject]
+#[derive(SimpleObject)]
 #[graphql(tag = "team-accounts")]
 struct User {
   id: ID,

--- a/docs/en/src/apollo_federation.md
+++ b/docs/en/src/apollo_federation.md
@@ -13,7 +13,9 @@ Apollo Federation is a GraphQL architecture for combining multiple GraphQL servi
 # use async_graphql::*;
 # struct Query;
 # #[Object]
-# impl Query {}
+# impl Query {
+#    async fn hello(&self) -> String { "Hello".to_string() }
+# }
 fn main() {
   let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
     .enable_federation()
@@ -283,7 +285,7 @@ struct Query;
 #[Object]
 impl Query {
     /// This operation will provide the `humanName` field on `Product
-    #[graphql(provides(fields: "humanName"))]
+    #[graphql(provides = "humanName")]
     async fn out_of_stock_products(&self) -> Vec<Product> {
       vec![Product {
         id: "1".to_string(),
@@ -359,7 +361,7 @@ impl Product {
   #[graphql(requires = "size weightInPounds")]
   async fn shipping_estimate(&self) -> String {
     let price = self.size * self.weight_in_pounds;
-    format!(${}, price)
+    format!("${}", price)
   }
 }
 ```
@@ -370,7 +372,6 @@ Note that we use the GraphQL field name `weightInPounds`, not the Rust field nam
 # extern crate async_graphql;
 # use async_graphql::*;
 # #[derive(SimpleObject)]
-# #[graphql(complex)]
 # struct Product {
 #     id: ID,
 #     #[graphql(external)]


### PR DESCRIPTION
This greatly expands the federation docs by adding examples of all the directives as well as links out to the Apollo docs for each of them.

I may have gone a little overboard with the amount of examples 😅 but I wanted it to be very easy for folks to find and add a federated directive when they need one 😁.

I didn't add all of the `# ...` lines to make the code compilable, so I'm guessing CI will fail. If it does, I'll go back and add those soon!