### PR TITLE
Use `tracinglib::error! instead of `tracinglib::info!`

### DIFF
--- a/src/extensions/tracing.rs
+++ b/src/extensions/tracing.rs
@@ -144,7 +144,7 @@ impl Extension for TracingExtension {
         next.run(ctx, info)
             .map_err(|err| {
                 tracinglib::error!(target: "async_graphql::graphql",
-                                  error = %err.message,
+                                  error = tracinglib::field::display(&err.message),
                                   "error");
                 err
             })

--- a/src/extensions/tracing.rs
+++ b/src/extensions/tracing.rs
@@ -147,9 +147,9 @@ impl Extension for TracingExtension {
         };
 
         let fut = next.run(ctx, info).inspect_err(|err| {
-            tracinglib::info!(
+            tracinglib::error!(
                 target: "async_graphql::graphql",
-                error = %err.message,
+                error = tracinglib::field::display(&err.message),
                 "error",
             );
         });

--- a/src/extensions/tracing.rs
+++ b/src/extensions/tracing.rs
@@ -143,7 +143,7 @@ impl Extension for TracingExtension {
         );
         next.run(ctx, info)
             .map_err(|err| {
-                tracinglib::info!(target: "async_graphql::graphql",
+                tracinglib::error!(target: "async_graphql::graphql",
                                   error = %err.message,
                                   "error");
                 err


### PR DESCRIPTION
On [Rust forum](https://users.rust-lang.org/t/is-tracing-intended-to-be-used-as-i-am-using-it-how-can-i-trace-errors-chain/81988/2) they're helping me better understand https://github.com/async-graphql/async-graphql/discussions/1089 and found that we're calling

```rust
tracinglib::info!
```

instead of

```rust
tracinglib::error!
```

here: https://github.com/async-graphql/async-graphql/blob/974f8ff21d9019bde138f11c4eb5b1aeae554aa0/src/extensions/tracing.rs#L146

Is this wrong, right?