### PR TITLE
Allow to add fetch `credentials` option to graphiql 2

### DIFF
--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -128,7 +128,10 @@ impl<'a> GraphiQLSource<'a> {
       type="application/javascript"
     ></script>
     <script>
-    customFetch = (...args) => fetch({ ...args, credentials: "%CREDENTIALS%" })
+    customFetch = (...args) => {
+      console.log(args);
+      fetch({ ...args, credentials: "%CREDENTIALS%" })
+    }
 
       ReactDOM.render(
         React.createElement(GraphiQL, {

--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -128,7 +128,7 @@ impl<'a> GraphiQLSource<'a> {
       type="application/javascript"
     ></script>
     <script>
-    customFetch = () => fetch({ ...arguments, credentials: %CREDENTIALS% })
+    customFetch = (...args) => fetch({ ...args, credentials: %CREDENTIALS% })
 
       ReactDOM.render(
         React.createElement(GraphiQL, {

--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -128,17 +128,17 @@ impl<'a> GraphiQLSource<'a> {
       type="application/javascript"
     ></script>
     <script>
-    customFetch = (url, opts = {}) => {
-      return fetch(url, {...opts, credentials: '%GRAPHIQL_CREDENTIALS%'})
-    }
+      customFetch = (url, opts = {}) => {
+        return fetch(url, {...opts, credentials: '%GRAPHIQL_CREDENTIALS%'})
+      }
 
       ReactDOM.render(
         React.createElement(GraphiQL, {
           fetcher: GraphiQL.createFetcher({
             url: %GRAPHIQL_URL%,
+            fetch: customFetch,
             subscriptionUrl: %GRAPHIQL_SUBSCRIPTION_URL%,
             headers: %GRAPHIQL_HEADERS%,
-            fetch: customFetch,
           }),
           defaultEditorToolsVisibility: true,
         }),
@@ -210,10 +210,15 @@ mod tests {
       type="application/javascript"
     ></script>
     <script>
+      customFetch = (url, opts = {}) => {
+        return fetch(url, {...opts, credentials: 'same-origin'})
+      }
+
       ReactDOM.render(
         React.createElement(GraphiQL, {
           fetcher: GraphiQL.createFetcher({
             url: 'http://localhost:8000',
+            fetch: customFetch,
             subscriptionUrl: undefined,
             headers: undefined,
           }),
@@ -279,10 +284,15 @@ mod tests {
       type="application/javascript"
     ></script>
     <script>
+      customFetch = (url, opts = {}) => {
+        return fetch(url, {...opts, credentials: 'same-origin'})
+      }
+
       ReactDOM.render(
         React.createElement(GraphiQL, {
           fetcher: GraphiQL.createFetcher({
             url: 'http://localhost:8000',
+            fetch: customFetch,
             subscriptionUrl: 'ws://localhost:8000/ws',
             headers: undefined,
           }),
@@ -304,6 +314,7 @@ mod tests {
             .subscription_endpoint("ws://localhost:8000/ws")
             .header("Authorization", "Bearer <token>")
             .title("Awesome GraphiQL IDE Test")
+            .credentials("include")
             .finish();
 
         assert_eq!(
@@ -350,10 +361,15 @@ mod tests {
       type="application/javascript"
     ></script>
     <script>
+      customFetch = (url, opts = {}) => {
+        return fetch(url, {...opts, credentials: 'include'})
+      }
+
       ReactDOM.render(
         React.createElement(GraphiQL, {
           fetcher: GraphiQL.createFetcher({
             url: 'http://localhost:8000',
+            fetch: customFetch,
             subscriptionUrl: 'ws://localhost:8000/ws',
             headers: {"Authorization":"Bearer <token>"},
           }),

--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -128,7 +128,7 @@ impl<'a> GraphiQLSource<'a> {
       type="application/javascript"
     ></script>
     <script>
-    customFetch = (...args) => fetch({ ...args, credentials: %CREDENTIALS% })
+    customFetch = (...args) => fetch({ ...args, credentials: "%CREDENTIALS%" })
 
       ReactDOM.render(
         React.createElement(GraphiQL, {

--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -128,9 +128,8 @@ impl<'a> GraphiQLSource<'a> {
       type="application/javascript"
     ></script>
     <script>
-    customFetch = (...args) => {
-      console.log(args);
-      return fetch(...args)
+    customFetch = (url, opts = {}) => {
+      return fetch(url, {...opts, credentials: '%GRAPHIQL_CREDENTIALS%'})
     }
 
       ReactDOM.render(

--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -152,7 +152,7 @@ impl<'a> GraphiQLSource<'a> {
         .replace("%GRAPHIQL_SUBSCRIPTION_URL%", &graphiql_subscription_url)
         .replace("%GRAPHIQL_HEADERS%", &graphiql_headers)
         .replace("%GRAPHIQL_TITLE%", &graphiql_title)
-        .replace("%CREDENTIALS%", &graphiql_credentials)
+        .replace("%GRAPHIQL_CREDENTIALS%", &graphiql_credentials)
     }
 }
 

--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -136,6 +136,7 @@ impl<'a> GraphiQLSource<'a> {
             url: %GRAPHIQL_URL%,
             subscriptionUrl: %GRAPHIQL_SUBSCRIPTION_URL%,
             headers: %GRAPHIQL_HEADERS%,
+            fetch: customFetch,
           }),
           defaultEditorToolsVisibility: true,
         }),

--- a/src/http/graphiql_v2_source.rs
+++ b/src/http/graphiql_v2_source.rs
@@ -130,7 +130,7 @@ impl<'a> GraphiQLSource<'a> {
     <script>
     customFetch = (...args) => {
       console.log(args);
-      fetch({ ...args, credentials: "%CREDENTIALS%" })
+      return fetch(...args)
     }
 
       ReactDOM.render(


### PR DESCRIPTION
Added the fetch `credentials` option to the `GraphiQLSource` builder.

Example usage:
```rust
GraphiQLSource::build()
  .endpoint("http://localhost:8000")
  .credentials("omit")
  .finish();
```

