### PR TITLE
Include enum value descriptions in sdl 

### DIFF
--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -391,6 +391,9 @@ impl Registry {
                 }
 
                 for value in values {
+                    if let Some(description) = value.description {
+                        export_description(sdl, options, false, description);
+                    }
                     write!(sdl, "\t{}", value.name).ok();
                     write_deprecated(sdl, &value.deprecation);
 


### PR DESCRIPTION
Hello and thanks for the great package!

I noticed that the generated sdl did not contain descriptions of enum values. This PR should fix this.