### PR TITLE
Make multipart a feature, and tempfile an optional dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ cbor = ["serde_cbor"]
 chrono-duration = ["chrono", "iso8601-duration"]
 dataloader = ["futures-timer", "futures-channel", "lru"]
 decimal = ["rust_decimal"]
-default = ["email-validator"]
+default = ["email-validator", "multipart"]
+multipart = ["dep:tempfile"]
 password-strength-validator = ["zxcvbn"]
 string_number = []
 tokio-sync = ["tokio"]
@@ -51,7 +52,7 @@ regex = "1.5.5"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 static_assertions = "1.1.0"
-tempfile = "3.2.0"
+tempfile = { optional = true, version = "3.2.0" }
 thiserror = "1.0.24"
 base64 = "0.13.0"
 serde_urlencoded = "0.7.0"

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -63,7 +63,7 @@ pub fn parse_query_string(input: &str) -> Result<Request, ParseRequestError> {
 pub async fn receive_body(
     content_type: Option<impl AsRef<str>>,
     body: impl AsyncRead + Send,
-    opts: MultipartOptions,
+    #[allow(unused)] opts: MultipartOptions,
 ) -> Result<Request, ParseRequestError> {
     receive_batch_body(content_type, body, opts)
         .await?
@@ -74,7 +74,7 @@ pub async fn receive_body(
 pub async fn receive_batch_body(
     content_type: Option<impl AsRef<str>>,
     body: impl AsyncRead + Send,
-    opts: MultipartOptions,
+    #[allow(unused)] opts: MultipartOptions,
 ) -> Result<BatchRequest, ParseRequestError> {
     // if no content-type header is set, we default to json
     let content_type = content_type
@@ -86,6 +86,7 @@ pub async fn receive_batch_body(
 
     match (content_type.type_(), content_type.subtype()) {
         // try to use multipart
+        #[cfg(feature = "multipart")]
         (mime::MULTIPART, _) => {
             if let Some(boundary) = content_type.get_param("boundary") {
                 multipart::receive_batch_multipart(body, boundary.to_string(), opts).await

--- a/src/http/multipart.rs
+++ b/src/http/multipart.rs
@@ -1,26 +1,30 @@
-use std::{
-    collections::HashMap,
-    io::{self, Seek, SeekFrom, Write},
-    pin::Pin,
-    task::{Context, Poll},
+#[cfg(feature = "multipart")]
+use {
+    crate::{BatchRequest, ParseRequestError, UploadValue},
+    futures_util::{io::AsyncRead, stream::Stream},
+    multer::{Constraints, Multipart, SizeLimit},
+    pin_project_lite::pin_project,
+    std::{
+        collections::HashMap,
+        io::{self, Seek, SeekFrom, Write},
+        pin::Pin,
+        task::{Context, Poll},
+    },
 };
-
-use futures_util::{io::AsyncRead, stream::Stream};
-use multer::{Constraints, Multipart, SizeLimit};
-use pin_project_lite::pin_project;
-
-use crate::{BatchRequest, ParseRequestError, UploadValue};
 
 /// Options for `receive_multipart`.
 #[derive(Default, Clone, Copy)]
 #[non_exhaustive]
 pub struct MultipartOptions {
     /// The maximum file size.
+    #[cfg(feature = "multipart")]
     pub max_file_size: Option<usize>,
     /// The maximum number of files.
+    #[cfg(feature = "multipart")]
     pub max_num_files: Option<usize>,
 }
 
+#[cfg(feature = "multipart")]
 impl MultipartOptions {
     /// Set maximum file size.
     #[must_use]
@@ -41,6 +45,7 @@ impl MultipartOptions {
     }
 }
 
+#[cfg(feature = "multipart")]
 pub(super) async fn receive_batch_multipart(
     body: impl AsyncRead + Send,
     boundary: impl Into<String>,
@@ -166,6 +171,7 @@ pub(super) async fn receive_batch_multipart(
     Ok(request)
 }
 
+#[cfg(feature = "multipart")]
 pin_project! {
     pub(crate) struct ReaderStream<T> {
         buf: [u8; 2048],
@@ -174,6 +180,7 @@ pin_project! {
     }
 }
 
+#[cfg(feature = "multipart")]
 impl<T> ReaderStream<T> {
     pub(crate) fn new(reader: T) -> Self {
         Self {
@@ -183,6 +190,7 @@ impl<T> ReaderStream<T> {
     }
 }
 
+#[cfg(feature = "multipart")]
 impl<T: AsyncRead> Stream for ReaderStream<T> {
     type Item = io::Result<Vec<u8>>;
 


### PR DESCRIPTION
tempfile needs to generate random file names, which brings in crypto dependencies.
This is not always a requirement in constrained environments like in a WASM-build.