### PR TITLE
Make `PageInfo` type shareable

### DIFF
--- a/src/types/connection/page_info.rs
+++ b/src/types/connection/page_info.rs
@@ -2,7 +2,7 @@ use crate::SimpleObject;
 
 /// Information about pagination in a connection
 #[derive(SimpleObject)]
-#[graphql(internal)]
+#[graphql(internal, shareable)]
 pub struct PageInfo {
     /// When paginating backwards, are there more items?
     pub has_previous_page: bool,


### PR DESCRIPTION
Hello :wave:

This PR marks the `PageInfo` type for Relay-style connections as `@shareable`.

The reason behind this change is that if we compose with Federation two subgraphs using Relay-style pagination, while all the `*Connection` and `*Edge` types compose successfully because they have different names, the `PageInfo` types clash because they can't have any suffix of prefix according to the spec. The solution to this would be to add the `@shareable` directive to the `PageInfo` type so that it can be shared by multiple subgraphs without issues.

I'm not 100% sure of the implications of adding this directive to the library (e.g., is it a breaking change?), so this PR is more for discussion than anything else.