### PR TITLE
Fix regression on `ComplexObject` descriptions

### DIFF
--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -168,7 +168,7 @@ pub fn generate(
                     .rename(method.sig.ident.unraw().to_string(), RenameTarget::Field)
             });
             let field_desc = get_rustdoc(&method.attrs)?
-                .map(|s| quote! { ::std::option::Option::Some(#s) })
+                .map(|s| quote! { ::std::option::Option::Some(::std::string::ToString::to_string(#s)) })
                 .unwrap_or_else(|| quote! {::std::option::Option::None});
             let field_deprecation = gen_deprecation(&method_args.deprecation, &crate_name);
             let external = method_args.external;
@@ -236,7 +236,7 @@ pub fn generate(
                 });
                 let desc = desc
                     .as_ref()
-                    .map(|s| quote! {::std::option::Option::Some(#s)})
+                    .map(|s| quote! {::std::option::Option::Some(::std::string::ToString::to_string(#s))})
                     .unwrap_or_else(|| quote! {::std::option::Option::None});
                 let default = generate_default(default, default_with)?;
                 let schema_default = default

--- a/tests/complex_object.rs
+++ b/tests/complex_object.rs
@@ -43,6 +43,7 @@ async fn test_complex_object_process_with_method_field() {
 
 #[tokio::test]
 pub async fn test_complex_object() {
+    /// A complex object.
     #[derive(SimpleObject)]
     #[graphql(complex)]
     struct MyObj {
@@ -52,11 +53,13 @@ pub async fn test_complex_object() {
 
     #[ComplexObject]
     impl MyObj {
+        /// A field named `c`.
         async fn c(&self) -> i32 {
             self.a + self.b
         }
 
-        async fn d(&self, v: i32) -> i32 {
+        /// A field named `d`.
+        async fn d(&self, #[graphql(desc = "An argument named `v`.")] v: i32) -> i32 {
             self.a + self.b + v
         }
     }


### PR DESCRIPTION
Hello :wave: 

The latest changes on dynamic schema introduced a regression on the `ComplexObject` macro where having a description set on any field would cause the build to break due to the generated code missing a call to `ToString::to_string()`.