### PR TITLE
Keep object 'implements' order stable in SDL export

### DIFF
--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -593,7 +593,7 @@ pub struct MetaDirective {
 pub struct Registry {
     pub types: BTreeMap<String, MetaType>,
     pub directives: HashMap<String, MetaDirective>,
-    pub implements: HashMap<String, HashSet<String>>,
+    pub implements: HashMap<String, IndexSet<String>>,
     pub query_type: String,
     pub mutation_type: Option<String>,
     pub subscription_type: Option<String>,
@@ -792,7 +792,7 @@ impl Registry {
                 interfaces.insert(interface.to_string());
             })
             .or_insert({
-                let mut interfaces = HashSet::new();
+                let mut interfaces = IndexSet::new();
                 interfaces.insert(interface.to_string());
                 interfaces
             });


### PR DESCRIPTION
In a project, I have the generated schema commited in the repository to help seeing diffs in the generated schema.

Problem is, the SDL output is not stable: the interface list order in a type `implements` changes on each run, leading to diffs like that:

```diff
- type Foo implements CreationDate & Node {
+ type Foo implements Node & CreationDate {
```

This is because internally it uses a `HashSet`. This changes PR that to an `IndexSet` to keep the insertion order.
