### PR TITLE
Mark extends as unimplemented

### DIFF
--- a/src/dynamic/macros.rs
+++ b/src/dynamic/macros.rs
@@ -30,12 +30,11 @@ macro_rules! impl_set_extends {
     () => {
         /// Indicates that an object or interface definition is an extension of another
         /// definition of that same type.
+        ///
+        /// Extend feature is not supported
         #[inline]
         pub fn extends(self) -> Self {
-            Self {
-                extends: true,
-                ..self
-            }
+            unimplemented!("Extend feature is not supported");
         }
     };
 }


### PR DESCRIPTION
add documentation about `.extends()` function. related to #1167

I think it is good to have #1167 open until `.extends()` support is added.