### PR TITLE
Implemente From<ID> for ConstValue

### DIFF
--- a/src/types/id.rs
+++ b/src/types/id.rs
@@ -3,6 +3,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+use async_graphql_value::ConstValue;
 #[cfg(feature = "bson")]
 use bson::oid::{self, ObjectId};
 use serde::{Deserialize, Serialize};
@@ -40,6 +41,12 @@ impl<T: std::fmt::Display> From<T> for ID {
 impl From<ID> for String {
     fn from(id: ID) -> Self {
         id.0
+    }
+}
+
+impl From<ID> for ConstValue {
+    fn from(id: ID) -> Self {
+        ConstValue::String(id.0)
     }
 }
 


### PR DESCRIPTION
## Code example 

```rust
        let id: ID = ID("some-value".to_string());
        let field_value = FieldValue::value(id);
```

error before this pr:
```
    |
    |         let field_value = FieldValue::value(id);
    |                           ----------------- ^^ the trait `std::convert::From<async_graphql::ID>` is not implemented for `async_graphql::Value`
    |                           |
    |                           required by a bound introduced by this call

```