### PR TITLE
dynamic schema: Support WithType in field.as_value, field.as_list, field.downcast_ref

### DIFF
--- a/src/dynamic/field.rs
+++ b/src/dynamic/field.rs
@@ -177,6 +177,7 @@ impl<'a> FieldValue<'a> {
     pub fn as_value(&self) -> Option<&Value> {
         match &self.0 {
             FieldValueInner::Value(value) => Some(value),
+            FieldValueInner::WithType { value, .. } => value.as_value(),
             _ => None,
         }
     }
@@ -194,6 +195,7 @@ impl<'a> FieldValue<'a> {
     pub fn as_list(&self) -> Option<&[FieldValue]> {
         match &self.0 {
             FieldValueInner::List(values) => Some(values),
+            FieldValueInner::WithType { value, .. } => value.as_list(),
             _ => None,
         }
     }
@@ -212,6 +214,7 @@ impl<'a> FieldValue<'a> {
         match &self.0 {
             FieldValueInner::BorrowedAny(value) => value.downcast_ref::<T>(),
             FieldValueInner::OwnedAny(value) => value.downcast_ref::<T>(),
+            FieldValueInner::WithType { value, .. } => value.downcast_ref::<T>(),
             _ => None,
         }
     }


### PR DESCRIPTION
```rust
    #[test]
    fn test_downcast(){
        struct Foo;
        let f = FieldValue::owned_any(Foo).with_type("Foo");
        let _v: &Foo = f.downcast_ref().unwrap();

        let foo = Foo;
        let f = FieldValue::borrowed_any(&foo).with_type("Foo");
        let _v: &Foo = f.downcast_ref().unwrap();

    }
```