### PR TITLE
dynamic schema: add boxed_any function

### DIFF
--- a/src/dynamic/field.rs
+++ b/src/dynamic/field.rs
@@ -102,7 +102,7 @@ impl<'a> FieldValue<'a> {
 
     /// Create a FieldValue from owned any value
     #[inline]
-    pub fn borrowed_any(obj: &'a (impl Any + Send + Sync)) -> Self {
+    pub fn borrowed_any(obj: &'a (dyn Any + Send + Sync)) -> Self {
         Self(FieldValueInner::BorrowedAny(obj))
     }
 

--- a/src/dynamic/field.rs
+++ b/src/dynamic/field.rs
@@ -94,6 +94,12 @@ impl<'a> FieldValue<'a> {
         Self(FieldValueInner::OwnedAny(Box::new(obj)))
     }
 
+    /// Create a FieldValue from unsized any value
+    #[inline]
+    pub fn boxed_any(obj: Box<dyn Any + Send + Sync>) -> Self {
+        Self(FieldValueInner::OwnedAny(obj))
+    }
+
     /// Create a FieldValue from owned any value
     #[inline]
     pub fn borrowed_any(obj: &'a (impl Any + Send + Sync)) -> Self {


### PR DESCRIPTION
Sometimes we have `Box<dyn Any + Send + Sync>`. in these cases the `boxed_any` function can help.

also `borrowed_any` changed from `borrowed_any(obj: &'a (impl Any + Send + Sync))` to `borrowed_any(obj: &'a (dyn Any + Send + Sync))` to remove sized constraint.

my use case:

```rust

pub enum AnyBox<'a> {
    Owned(Box<dyn Any + Send + Sync>, String),
    Borrowed(&'a (dyn Any + Send + Sync), String),
}

impl<'a> AnyBox<'a> {
    pub fn new_owned<T: Any + Send + Sync>(value: T, ty: String) -> Self {
        Self::Owned(Box::new(value), ty)
    }
    pub fn new_borrowed<T: Any + Send + Sync + Sized>(value: &'a T, ty: String) -> Self {
        Self::Borrowed(value, ty)
    }
}

impl<'a> ResolveOwned<'a> for AnyBox<'a> {
    fn resolve_owned(self, _ctx: &Context) -> async_graphql::Result<Option<FieldValue<'a>>> {
        match self {
            AnyBox::Owned(obj, name) => Ok(Some(FieldValue::boxed_any(obj).with_type(name))),
            AnyBox::Borrowed(obj, name) => Ok(Some(FieldValue::borrowed_any(obj).with_type(name))),
        }
    }
}

```

you can see example in [here][1] and [here][2]

[1]: https://github.com/smmoosavi/async-graphql-dynamic-extend/blob/770eb1373ac3be620fdbb05aee53e550483a7134/src/schema/interface/utils.rs
[2]: https://github.com/smmoosavi/async-graphql-dynamic-extend/blob/770eb1373ac3be620fdbb05aee53e550483a7134/src/schema/interface/output.rs#L55