### PR TITLE
integrations/axum: tokio: default-features = false

### DIFF
--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -20,5 +20,5 @@ bytes = "1.0.1"
 futures-util = "0.3.0"
 http-body = "0.4.2"
 serde_json = "1.0.66"
-tokio-util = { version = "0.7.1", features = ["io", "compat"] }
+tokio-util = { version = "0.7.1", default-features = false, features = ["io", "compat"] }
 tower-service = "0.3"


### PR DESCRIPTION
for wasm, see #1184

It doesn't fix everything, since I still need to remove the "ws" feature from axum, to build, but it's a start.