### PR TITLE
Fix: `__Type.oneOf` to `__Type.isOneOf`

### DIFF
--- a/src/model/type.rs
+++ b/src/model/type.rs
@@ -238,7 +238,7 @@ impl<'a> __Type<'a> {
         }
     }
 
-    async fn one_of(&self) -> Option<bool> {
+    async fn is_one_of(&self) -> Option<bool> {
         if let TypeDetail::Named(registry::MetaType::InputObject { oneof, .. }) = &self.detail {
             Some(*oneof)
         } else {

--- a/tests/oneof_object.rs
+++ b/tests/oneof_object.rs
@@ -100,13 +100,13 @@ async fn test_oneof_object() {
 
     assert_eq!(
         schema
-            .execute(r#"{ __type(name: "MyOneofObj") { name oneOf } }"#)
+            .execute(r#"{ __type(name: "MyOneofObj") { name isOneOf } }"#)
             .await
             .into_result()
             .unwrap()
             .data,
         value!({
-            "__type": { "name": "MyOneofObj", "oneOf": true }
+            "__type": { "name": "MyOneofObj", "isOneOf": true }
         })
     );
 }


### PR DESCRIPTION
Renamed the `@oneOf` directive introspection output according to the current RFC: https://github.com/graphql/graphql-spec/pull/825#issuecomment-1138335897.

Tests seem to fail because of some generated code. I (again?) have no idea how to solve that :sweat_smile:. 