### PR TITLE
fix: Export directives to federation SDL so they can be composed.

### DIFF
--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -113,9 +113,12 @@ impl Registry {
 
         if options.federation {
             writeln!(sdl, "extend schema @link(").ok();
-            writeln!(sdl, "\turl: \"https://specs.apollo.dev/federation/v2.0\",").ok();
+            writeln!(sdl, "\turl: \"https://specs.apollo.dev/federation/v2.1\",").ok();
             writeln!(sdl, "\timport: [\"@key\", \"@tag\", \"@shareable\", \"@inaccessible\", \"@override\", \"@external\", \"@provides\", \"@requires\"]").ok();
             writeln!(sdl, ")").ok();
+            self.directives.values().for_each(|directive| {
+                writeln!(sdl, "{}", directive.sdl()).ok();
+            });
         } else {
             writeln!(sdl, "schema {{").ok();
             writeln!(sdl, "\tquery: {}", self.query_type).ok();

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -4,7 +4,7 @@ mod stringify_exec_doc;
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    fmt::{self, Display, Formatter},
+    fmt::{self, Display, Formatter, Write},
     sync::Arc,
 };
 
@@ -594,6 +594,29 @@ pub struct MetaDirective {
     pub args: IndexMap<String, MetaInputValue>,
     pub is_repeatable: bool,
     pub visible: Option<MetaVisibleFn>,
+}
+
+impl MetaDirective {
+    pub(crate) fn sdl(&self) -> String {
+        let mut sdl = format!("directive @{}", self.name);
+        if !self.args.is_empty() {
+            let args = self
+                .args
+                .values()
+                .map(|value| format!("{}: {}", value.name, value.ty))
+                .collect::<Vec<_>>()
+                .join(", ");
+            write!(sdl, "({})", args).ok();
+        }
+        let locations = self
+            .locations
+            .iter()
+            .map(|location| location.to_value().to_string())
+            .collect::<Vec<_>>()
+            .join(" | ");
+        write!(sdl, " on {}", locations).ok();
+        sdl
+    }
 }
 
 /// A type registry for build schemas


### PR DESCRIPTION
Also added example of this feature in https://github.com/async-graphql/examples/pull/66

Also also updated the reported federation version to 2.1 so that `@defer` is available by default with Apollo tooling. The only change to 2.1 is `@composeDirective` which isn't applicable to this project since it isn't used with executable directives, only custom schema ones.