### PR TITLE
feat: allow optionally enable nodes field on Connection strucutre with feature. Make this default because of sem ver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,17 @@ apollo_persisted_queries = ["lru", "sha2"]
 apollo_tracing = ["chrono"]
 email-validator = ["fast_chemail"]
 cbor = ["serde_cbor"]
+connection-type-with-nodes-field = [] # modify types::connection::Connection
 chrono-duration = ["chrono", "iso8601-duration"]
 dataloader = ["futures-timer", "futures-channel", "lru"]
 decimal = ["rust_decimal"]
-default = ["email-validator", "tempfile", "playground", "graphiql"]
+default = [
+  "email-validator",
+  "tempfile",
+  "playground",
+  "graphiql",
+  "connection-type-with-nodes-field",
+]
 password-strength-validator = ["zxcvbn"]
 string_number = []
 tokio-sync = ["tokio"]

--- a/src/types/connection/connection_type.rs
+++ b/src/types/connection/connection_type.rs
@@ -117,6 +117,7 @@ where
         &self.edges
     }
 
+    #[cfg(feature = "connection-type-with-nodes-field")]
     /// A list of nodes.
     async fn nodes(&self) -> Vec<&Node> {
         self.edges.iter().map(|e| &e.node).collect()


### PR DESCRIPTION
I am not sure if this is correct solution in case of feature unification: https://doc.rust-lang.org/cargo/reference/features.html#feature-unification

This is related to #1001 