### PR TITLE
feat(subscription): support generics in MergedSubscription types

### DIFF
--- a/derive/src/merged_subscription.rs
+++ b/derive/src/merged_subscription.rs
@@ -12,6 +12,7 @@ use crate::{
 pub fn generate(object_args: &args::MergedSubscription) -> GeneratorResult<TokenStream> {
     let crate_name = get_crate_name(object_args.internal);
     let ident = &object_args.ident;
+    let (impl_generics, ty_generics, where_clause) = object_args.generics.split_for_impl();
     let extends = object_args.extends;
     let gql_typename = if !object_args.name_type {
         let name = object_args
@@ -55,7 +56,7 @@ pub fn generate(object_args: &args::MergedSubscription) -> GeneratorResult<Token
     let visible = visible_fn(&object_args.visible);
     let expanded = quote! {
         #[allow(clippy::all, clippy::pedantic)]
-        impl #crate_name::SubscriptionType for #ident {
+        impl #impl_generics #crate_name::SubscriptionType for #ident #ty_generics #where_clause {
             fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                 #gql_typename
             }


### PR DESCRIPTION
Currently, defining a MergedSubscription that contains generics causes errors.

```rust
    #[derive(MergedSubscription)]
    struct Subscription<T1, T2>(Subscription1<T1>, Subscription2<T2>)
    where
        T1: Clone + OutputType,
        T2: Clone + OutputType;
```

```console
   --> tests/merged_object.rs:219:12
    |
219 |     struct Subscription<T1, T2>(Subscription1<T1>, Subscription2<T2>)
    |            ^^^^^^^^^^^^ expected 2 generic arguments
    |
note: struct defined here, with 2 generic parameters: `T1`, `T2`
   --> tests/merged_object.rs:219:12
    |
219 |     struct Subscription<T1, T2>(Subscription1<T1>, Subscription2<T2>)
    |            ^^^^^^^^^^^^ --  --
help: add missing generic arguments
    |
219 |     struct Subscription<T1, T2><T1, T2>(Subscription1<T1>, Subscription2<T2>)
    |            ~~~~~~~~~~~~~~~~~~~~
```