### PR TITLE
Disable default-features in workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ async-stream = "0.3.0"
 async-trait.workspace = true
 bytes.workspace = true
 fnv = "1.0.7"
-futures-util = { workspace = true, default-features = false, features = [
+futures-util = { workspace = true, features = [
   "io",
   "sink",
 ] }
@@ -135,7 +135,7 @@ members = [
 ]
 
 [workspace.dependencies]
-async-graphql = { path = ".", version = "5.0.6" }
+async-graphql = { path = ".", version = "5.0.6", default-features = false }
 async-graphql-derive = { path = "derive", version = "5.0.6" }
 async-graphql-parser = { path = "parser", version = "5.0.6" }
 async-graphql-value = { path = "value", version = "5.0.6" }
@@ -146,5 +146,5 @@ indexmap = { version = "1.6.2", features = ["serde"] }
 bytes = { version = "1.0.1", features = ["serde"] }
 thiserror = "1.0.24"
 async-trait = "0.1.51"
-futures-util = "0.3.0"
-tokio-util = "0.7.1"
+futures-util = { version = "0.3.0", default-features = false }
+tokio-util = { version = "0.7.1", default-features = false }


### PR DESCRIPTION
Upgrading async-graphql to 5.0.6 caused unnecessary dependencies.

This [commit](https://github.com/async-graphql/async-graphql/commit/c63c4725241d57e013b66149a7f1b35d7ac2534b#diff-9b166170637cbe9de84c922e700832789ba40f2f316ca1d938277f78f1dafa19) enables async-graphql's default-features through integration crates (async-graphql-actix-web, async-graphql-axum, ...)
`workspace.dependencies` without `default-features = false` enables default-features even if member's Cargo.toml specifies `{ workspace = true, default-features = false }`.

So, this PR adds `default-features = false` to `workspace.dependencies`.