### PR TITLE
disable default features for async-graphql in workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ members = [
 ]
 
 [workspace.dependencies]
-async-graphql = { path = ".", version = "5.0.6" }
+async-graphql = { path = ".", version = "5.0.6", default-features = false }
 async-graphql-derive = { path = "derive", version = "5.0.6" }
 async-graphql-parser = { path = "parser", version = "5.0.6" }
 async-graphql-value = { path = "value", version = "5.0.6" }

--- a/integrations/actix-web/Cargo.toml
+++ b/integrations/actix-web/Cargo.toml
@@ -12,9 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "5.0.6"
 
 [dependencies]
-async-graphql = { workspace = true, default-features = false, features = [
-    "playground",
-] }
+async-graphql = { workspace = true, features = ["playground"] }
 
 actix = "0.13.0"
 actix-http = "3.1.0"

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "5.0.6"
 
 [dependencies]
-async-graphql = { workspace = true, default-features = false }
+async-graphql = { workspace = true }
 
 async-trait.workspace = true
 axum = { version = "0.6.0", features = ["ws", "headers"] }

--- a/integrations/poem/Cargo.toml
+++ b/integrations/poem/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "5.0.6"
 
 [dependencies]
-async-graphql = { workspace = true, default-features = false }
+async-graphql = { workspace = true }
 
 futures-util = { workspace = true, default-features = false }
 poem = { version = "1.3.48", features = ["websocket"] }

--- a/integrations/rocket/Cargo.toml
+++ b/integrations/rocket/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "5.0.6"
 
 [dependencies]
-async-graphql = { workspace = true, default-features = false }
+async-graphql = { workspace = true }
 
 rocket = { version = "0.5.0-rc.2", default-features = false }
 serde.workspace = true

--- a/integrations/tide/Cargo.toml
+++ b/integrations/tide/Cargo.toml
@@ -16,7 +16,7 @@ default = ["websocket"]
 websocket = ["tide-websockets"]
 
 [dependencies]
-async-graphql = { workspace = true, default-features = false }
+async-graphql = { workspace = true }
 
 async-trait.workspace = true
 futures-util.workspace = true

--- a/integrations/warp/Cargo.toml
+++ b/integrations/warp/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "5.0.6"
 
 [dependencies]
-async-graphql = { workspace = true, default-features = false }
+async-graphql = { workspace = true }
 
 futures-util = { workspace = true, default-features = false, features = [
   "sink",


### PR DESCRIPTION
All the other crates (in the `integrations` dir) that are referencing the parent crate (async-graphql) in the workspace have it turned off in their own Cargo.toml files, but since it's defined with the default features on the workspace level, and it's inherited in the other crates, specifying the `default-features = false` in the integration crates toml files doesn't have any effect.

Therefore, moving the `default-features = false` flag on the `async-graphql` dep in the `[workspace.dependencies]` instead.