### PR TITLE
Added 3 new fns to the ObjectAccessor.

### DIFF
--- a/src/dynamic/value_accessor.rs
+++ b/src/dynamic/value_accessor.rs
@@ -133,6 +133,24 @@ impl<'a> ObjectAccessor<'a> {
             .iter()
             .map(|(name, value)| (name, ValueAccessor(value)))
     }
+
+    /// Return an iterator over the keys of the object, in their order
+    #[inline]
+    pub fn keys(&'a self) -> impl Iterator<Item = &Name> + 'a {
+        self.0.keys()
+    }
+
+    /// Return an iterator over the values of the object, in their order
+    #[inline]
+    pub fn values(&'a self) -> impl Iterator<Item = ValueAccessor<'_>> + 'a {
+        self.0.values().map(|value| ValueAccessor(value))
+    }
+
+    /// Returns the number of elements in the object
+    #[inline]
+    pub fn len(&'a self) -> usize {
+        self.0.len()
+    }
 }
 
 /// A list accessor


### PR DESCRIPTION
Hello, I added 3 simple functions  to ObjectAccessor, which may help developers using the DynamicSchema.

The first two are `keys()` and `values()`, which are analogous to the hashmap fns in rust std (https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.keys)

The last is `len()`, which is mainly why I brought this PR. It would be very helpful to be able to allocate a `Vec::with_capacity(ctx.args.len())` instead of creating a vector, then trimming the empty items when finished.

Let me know what you think.