### PR TITLE
Upgrade opentelemetry to 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ fast_chemail = { version = "0.9.6", optional = true }
 hashbrown = { version = "0.12.0", optional = true }
 iso8601 = { version = "0.6.0", optional = true }
 log = { version = "0.4.16", optional = true }
-opentelemetry = { version = "0.18.0", optional = true, default-features = false, features = [
+opentelemetry = { version = "0.19.0", optional = true, default-features = false, features = [
   "trace",
 ] }
 rust_decimal = { version = "1.14.3", optional = true }


### PR DESCRIPTION
Since `opentelemetry` 0.19 is not compatible with 0.18, we need to update the dependency to use the OpenTelemetry extension with the latest `opentelemetry` crate.

We also need to fix the example repository after this PR is merged.