### PR TITLE
Prevent recursive input type checking from hitting stack overflow

### DIFF
--- a/src/dynamic/check.rs
+++ b/src/dynamic/check.rs
@@ -236,16 +236,16 @@ impl SchemaInner {
         obj: &InputObject,
     ) -> Result<(), SchemaError> {
         for field in obj.fields.values() {
-            if field.ty.type_name() == current {
-                if !field.ty.is_named() && !field.ty.is_list() {
+            if !field.ty.is_named() && !field.ty.is_list() {
+                if field.ty.type_name() == current {
                     return Err(format!("\"{}\" references itself either directly or through referenced Input Objects, at least one of the fields in the chain of references must be either a nullable or a List type.", current).into());
+                } else if let Some(obj) = self
+                    .types
+                    .get(field.ty.type_name())
+                    .and_then(Type::as_input_object)
+                {
+                    self.check_input_object_reference(current, obj)?;
                 }
-            } else if let Some(obj) = self
-                .types
-                .get(field.ty.type_name())
-                .and_then(Type::as_input_object)
-            {
-                self.check_input_object_reference(current, obj)?;
             }
         }
 


### PR DESCRIPTION
I think the behaviour present in the dynamic schema checks is incorrect for input types that reference themselves as nullable fields.

As an example, if I have this kind of type system:

```
input type Parent {
    child: Child
}

input type Child {
    parent: Parent
}
```

then the checks would hit a stack overflow.

My attempt at a fix is to move the recursive part of the checks inside of the if statement which is handling nullable or list types. This also means reversing the order of the if statements.

This should mean that neither schema below will hit a stack overflow, and the first should pass where the second fails:

```
type TopLevel {
    mid: MidLevel!
}
type MidLevel {
    bottom: BottomLevel
    list_bottom: [BottomLevel!]!
}
type BottomLevel {
    top: TopLevel!
}
```

```
type TopLevel {
    mid: MidLevel!
}
type MidLevel {
    bottom: BottomLevel!
}
type BottomLevel {
    top: TopLevel!
}
```

As part of doing this, I included a `typeref_nonnullable_name` function. The logic of this is suspiciously absent from the `type_ref.rs` implementation and I wonder if I should move this code to that location?

I also added some tests. Is this an okay location for them, or would you like them to be moved to the tests folder?