### PR TITLE
Fix/improve README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,54 +28,72 @@ _This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented i
 ```rs
 use std::error::Error;
 
-use async_graphql::*;
+use async_graphql::{http::GraphiQLSource, EmptyMutation, EmptySubscription, Object, Schema};
 use async_graphql_poem::*;
-use poem::{*, listener::TcpListener};
+use poem::{listener::TcpListener, web::Html, *};
 
 struct Query;
 
 #[Object]
 impl Query {
-  async fn howdy(&self) -> &'static str {
-    "partner"
-  }
+    async fn howdy(&self) -> &'static str {
+        "partner"
+    }
 }
 
-async fn main() -> Result<(), Box<dyn Error>> {
-  // create the schema
-  let schema = Schema::build(Query, EmptyMutation, EmptySubscription).finish();
+#[handler]
+async fn graphiql() -> impl IntoResponse {
+    Html(GraphiQLSource::build().finish())
+}
 
-  // start the http server
-  let app = Route::new().at("/", get(graphiql).post(GraphQL::new(schema)));
-  println!("GraphiQL: http://localhost:8000");
-  Server::new(TcpListener::bind("0.0.0.0:8000")).run(app).await?;
-  Ok(())
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // create the schema
+    let schema = Schema::build(Query, EmptyMutation, EmptySubscription).finish();
+
+    // start the http server
+    let app = Route::new().at("/", get(graphiql).post(GraphQL::new(schema)));
+    println!("GraphiQL: http://localhost:8000");
+    Server::new(TcpListener::bind("0.0.0.0:8000"))
+        .run(app)
+        .await?;
+    Ok(())
 }
 ```
 
 ## Dynamic schema
+Requires the `dynamic-schema` feature to be enabled.
 
 ```rs
 use std::error::Error;
 
-use async_graphql::dynamic::*;
+use async_graphql::{dynamic::*, http::GraphiQLSource};
 use async_graphql_poem::*;
-use poem::{*, listener::TcpListener};
+use poem::{listener::TcpListener, web::Html, *};
 
-let query = Object::new("Query")
-  .field(Field::new("howdy", TypeRef::named_nn(TypeRef::STRING), |_| FieldFuture::new(async { "partner" })));
+#[handler]
+async fn graphiql() -> impl IntoResponse {
+    Html(GraphiQLSource::build().finish())
+}
 
+#[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-  // create the schema
-  let schema = Schema::build(query, None, None)
-    .register(query)
-    .finish()?;
+    let query = Object::new("Query").field(Field::new(
+        "howdy",
+        TypeRef::named_nn(TypeRef::STRING),
+        |_| FieldFuture::new(async { "partner" }),
+    ));
 
-  // start the http server
-  let app = Route::new().at("/", get(graphiql).post(GraphQL::new(schema)));
-  println!("GraphiQL: http://localhost:8000");
-  Server::new(TcpListener::bind("0.0.0.0:8000")).run(app).await?;
-  Ok(())
+    // create the schema
+    let schema = Schema::build(query, None, None).register(query).finish()?;
+
+    // start the http server
+    let app = Route::new().at("/", get(graphiql).post(GraphQL::new(schema)));
+    println!("GraphiQL: http://localhost:8000");
+    Server::new(TcpListener::bind("0.0.0.0:8000"))
+        .run(app)
+        .await?;
+    Ok(())
 }
 ```
 


### PR DESCRIPTION
Addresses #1281 

- Example for static schema compiles now
- Example for dynamic schema still doesn't compile, but is closer now
- Let `cargo fmt` do its thing
- Add note that dynamic schema requires `dynamic-schema` cargo feature

Fix details:
- Removing wildcard import disambiguates the use of `Result`
- Adding `graphiql` handler that uses `GraphiQLSource` fixes `graphiql` not being found (requires a few new imports)
- Adding `#[tokio::main]` prevents `main() can't be async` errors

I couldn't get [doc tests for README.md](https://github.com/async-graphql/async-graphql/issues/1281#issuecomment-1575299985) to work, but it may be worth trying again in the future


Thank you for the work you do :pray: 