### PR TITLE
Make type_name pub

### DIFF
--- a/src/dynamic/type_ref.rs
+++ b/src/dynamic/type_ref.rs
@@ -117,7 +117,7 @@ impl TypeRef {
     }
 
     #[inline(always)]
-    pub(crate) fn type_name(&self) -> &str {
+    pub fn type_name(&self) -> &str {
         self.0.type_name()
     }
 


### PR DESCRIPTION
I am building some somewhat complex code where I build a schema by recursing through an existing tree of types. I have a function with this signature:

```
pub fn my_type_to_field_type(field_type: &MoveType) -> TypeRef
```

As I recurse, sometimes it is necessary to know the type inside the `TypeRef`. The `TypeRef.type_name` function does exactly that, but it's marked as `pub(crate)` so I can't access it.

This change would make my code much simpler. Without it I have to do something like this:
```
enum Nullability {
    Named,
    NonNull,
    List,
}

pub fn my_type_to_field_type(field_type: &MoveType) -> (&'static str, Nullability)
```

This seems silly given `TypeRef` already captures this info, it's just currently inaccessible.