### PR TITLE
Schema (type) level directive support with optional support of federation composeDirective

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -29,3 +29,4 @@ syn = { version = "2.0", features = [
   "visit",
 ] }
 thiserror.workspace = true
+strum= { version ="0.25.0", features=["derive"]}

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -284,6 +284,8 @@ pub struct ObjectField {
     #[darling(default, multiple)]
     pub derived: Vec<DerivedField>,
     pub flatten: bool,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<String>,
 }
 
 #[derive(FromMeta, Default, Clone)]
@@ -902,12 +904,14 @@ pub struct TypeDirective {
 #[darling(rename_all = "lowercase")]
 pub enum TypeDirectiveLocation {
     FieldDefinition,
+    Object,
 }
 
 impl Display for TypeDirectiveLocation {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             TypeDirectiveLocation::FieldDefinition => write!(f, "FIELD_DEFINITION"),
+            TypeDirectiveLocation::Object => write!(f, "OBJECT"),
         }
     }
 }

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -911,20 +911,12 @@ pub struct TypeDirective {
     pub composable: Option<String>,
 }
 
-#[derive(Debug, Copy, Clone, FromMeta)]
+#[derive(Debug, Copy, Clone, FromMeta, strum::Display)]
 #[darling(rename_all = "lowercase")]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum TypeDirectiveLocation {
     FieldDefinition,
     Object,
-}
-
-impl Display for TypeDirectiveLocation {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            TypeDirectiveLocation::FieldDefinition => write!(f, "FIELD_DEFINITION"),
-            TypeDirectiveLocation::Object => write!(f, "OBJECT"),
-        }
-    }
 }
 
 impl TypeDirectiveLocation {

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -6,6 +6,7 @@ use darling::{
     FromDeriveInput, FromField, FromMeta, FromVariant,
 };
 use inflector::Inflector;
+use quote::format_ident;
 use syn::{Attribute, Expr, Generics, Ident, Lit, LitBool, LitStr, Meta, Path, Type, Visibility};
 
 use crate::validators::Validators;
@@ -923,5 +924,11 @@ impl Display for TypeDirectiveLocation {
             TypeDirectiveLocation::FieldDefinition => write!(f, "FIELD_DEFINITION"),
             TypeDirectiveLocation::Object => write!(f, "OBJECT"),
         }
+    }
+}
+
+impl TypeDirectiveLocation {
+    pub fn location_trait_identifier(&self) -> Ident {
+        format_ident!("Directive_At_{}", self.to_string())
     }
 }

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -285,7 +285,7 @@ pub struct ObjectField {
     pub derived: Vec<DerivedField>,
     pub flatten: bool,
     #[darling(default, multiple, rename = "directive")]
-    pub directives: Vec<String>,
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromMeta, Default, Clone)]

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -883,3 +883,31 @@ impl Display for DirectiveLocation {
         }
     }
 }
+
+#[derive(FromMeta, Default)]
+#[darling(default)]
+pub struct TypeDirective {
+    pub internal: bool,
+    pub name: Option<String>,
+    #[darling(default)]
+    pub name_type: bool,
+    pub visible: Option<Visible>,
+    pub repeatable: bool,
+    pub rename_args: Option<RenameRule>,
+    #[darling(multiple, rename = "location")]
+    pub locations: Vec<TypeDirectiveLocation>,
+}
+
+#[derive(Debug, Copy, Clone, FromMeta)]
+#[darling(rename_all = "lowercase")]
+pub enum TypeDirectiveLocation {
+    FieldDefinition,
+}
+
+impl Display for TypeDirectiveLocation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            TypeDirectiveLocation::FieldDefinition => write!(f, "FIELD_DEFINITION"),
+        }
+    }
+}

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -174,6 +174,8 @@ pub struct SimpleObjectField {
     pub flatten: bool,
     #[darling(default)]
     pub secret: bool,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromDeriveInput)]
@@ -219,6 +221,8 @@ pub struct SimpleObject {
     pub input_name: Option<String>,
     #[darling(default)]
     pub guard: Option<Expr>,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromMeta, Default)]
@@ -260,6 +264,8 @@ pub struct Object {
     pub concretes: Vec<ConcreteType>,
     #[darling(default)]
     pub guard: Option<Expr>,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromMeta, Default)]
@@ -673,6 +679,8 @@ pub struct MergedObject {
     pub visible: Option<Visible>,
     #[darling(default)]
     pub serial: bool,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromField)]

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -898,6 +898,8 @@ pub struct TypeDirective {
     pub rename_args: Option<RenameRule>,
     #[darling(multiple, rename = "location")]
     pub locations: Vec<TypeDirectiveLocation>,
+    #[darling(default)]
+    pub composable: Option<String>,
 }
 
 #[derive(Debug, Copy, Clone, FromMeta)]

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -386,7 +386,7 @@ pub fn generate(
                     override_from: #override_from,
                     visible: #visible,
                     compute_complexity: #complexity,
-                    directives: ::std::vec![],
+                    raw_directives: ::std::vec![],
                 }));
             });
 

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -386,6 +386,7 @@ pub fn generate(
                     override_from: #override_from,
                     visible: #visible,
                     compute_complexity: #complexity,
+                    directives: ::std::vec![],
                 }));
             });
 

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -386,7 +386,7 @@ pub fn generate(
                     override_from: #override_from,
                     visible: #visible,
                     compute_complexity: #complexity,
-                    raw_directives: ::std::vec![],
+                    directive_invocations: ::std::vec![],
                 }));
             });
 

--- a/derive/src/directive.rs
+++ b/derive/src/directive.rs
@@ -160,7 +160,7 @@ pub fn generate(
                     },
                     is_repeatable: #repeatable,
                     visible: #visible,
-                    composable: false,
+                    composable: None,
                 };
                 registry.add_directive(meta);
             }

--- a/derive/src/directive.rs
+++ b/derive/src/directive.rs
@@ -160,6 +160,7 @@ pub fn generate(
                     },
                     is_repeatable: #repeatable,
                     visible: #visible,
+                    composable: false,
                 };
                 registry.add_directive(meta);
             }

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -311,6 +311,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
                 override_from: #override_from,
                 visible: #visible,
                 compute_complexity: ::std::option::Option::None,
+                raw_directives: ::std::vec![],
             });
         });
 

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -311,7 +311,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
                 override_from: #override_from,
                 visible: #visible,
                 compute_complexity: ::std::option::Option::None,
-                raw_directives: ::std::vec![],
+                directive_invocations: ::std::vec![],
             });
         });
 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -21,6 +21,7 @@ mod output_type;
 mod scalar;
 mod simple_object;
 mod subscription;
+mod type_directive;
 mod union;
 mod utils;
 mod validators;
@@ -214,6 +215,17 @@ pub fn Directive(args: TokenStream, input: TokenStream) -> TokenStream {
     let directive_args = parse_nested_meta!(args::Directive, args);
     let mut item_fn = parse_macro_input!(input as ItemFn);
     match directive::generate(&directive_args, &mut item_fn) {
+        Ok(expanded) => expanded,
+        Err(err) => err.write_errors().into(),
+    }
+}
+
+#[proc_macro_attribute]
+#[allow(non_snake_case)]
+pub fn TypeDirective(args: TokenStream, input: TokenStream) -> TokenStream {
+    let directive_args = parse_nested_meta!(args::TypeDirective, args);
+    let mut item_fn = parse_macro_input!(input as ItemFn);
+    match type_directive::generate(&directive_args, &mut item_fn) {
         Ok(expanded) => expanded,
         Err(err) => err.write_errors().into(),
     }

--- a/derive/src/merged_object.rs
+++ b/derive/src/merged_object.rs
@@ -4,6 +4,7 @@ use proc_macro2::Span;
 use quote::quote;
 use syn::{Error, LitInt};
 
+use crate::args::TypeDirectiveLocation;
 use crate::utils::gen_directive_calls;
 use crate::{
     args::{self, RenameTarget},
@@ -32,7 +33,7 @@ pub fn generate(object_args: &args::MergedObject) -> GeneratorResult<TokenStream
         quote!(<Self as #crate_name::TypeName>::type_name())
     };
 
-    let directives = gen_directive_calls(&object_args.directives);
+    let directives = gen_directive_calls(&object_args.directives, TypeDirectiveLocation::Object);
 
     let desc = get_rustdoc(&object_args.attrs)?
         .map(|s| quote! { ::std::option::Option::Some(::std::string::ToString::to_string(#s)) })

--- a/derive/src/merged_object.rs
+++ b/derive/src/merged_object.rs
@@ -125,7 +125,7 @@ pub fn generate(object_args: &args::MergedObject) -> GeneratorResult<TokenStream
                         visible: #visible,
                         is_subscription: false,
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
-                        raw_directives: ::std::vec![ #(#directives),* ],
+                        directive_invocations: ::std::vec![ #(#directives),* ],
                     }
                 })
             }

--- a/derive/src/merged_object.rs
+++ b/derive/src/merged_object.rs
@@ -4,7 +4,7 @@ use proc_macro2::Span;
 use quote::quote;
 use syn::{Error, LitInt};
 
-use crate::utils::gen_directive_call;
+use crate::utils::gen_directive_calls;
 use crate::{
     args::{self, RenameTarget},
     utils::{get_crate_name, get_rustdoc, visible_fn, GeneratorResult},
@@ -32,7 +32,7 @@ pub fn generate(object_args: &args::MergedObject) -> GeneratorResult<TokenStream
         quote!(<Self as #crate_name::TypeName>::type_name())
     };
 
-    let directives = gen_directive_call(&object_args.directives);
+    let directives = gen_directive_calls(&object_args.directives);
 
     let desc = get_rustdoc(&object_args.attrs)?
         .map(|s| quote! { ::std::option::Option::Some(::std::string::ToString::to_string(#s)) })

--- a/derive/src/merged_object.rs
+++ b/derive/src/merged_object.rs
@@ -4,6 +4,7 @@ use proc_macro2::Span;
 use quote::quote;
 use syn::{Error, LitInt};
 
+use crate::utils::gen_directive_call;
 use crate::{
     args::{self, RenameTarget},
     utils::{get_crate_name, get_rustdoc, visible_fn, GeneratorResult},
@@ -30,6 +31,8 @@ pub fn generate(object_args: &args::MergedObject) -> GeneratorResult<TokenStream
     } else {
         quote!(<Self as #crate_name::TypeName>::type_name())
     };
+
+    let directives = gen_directive_call(&object_args.directives);
 
     let desc = get_rustdoc(&object_args.attrs)?
         .map(|s| quote! { ::std::option::Option::Some(::std::string::ToString::to_string(#s)) })
@@ -122,6 +125,7 @@ pub fn generate(object_args: &args::MergedObject) -> GeneratorResult<TokenStream
                         visible: #visible,
                         is_subscription: false,
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
+                        raw_directives: ::std::vec![ #(#directives),* ],
                     }
                 })
             }

--- a/derive/src/merged_subscription.rs
+++ b/derive/src/merged_subscription.rs
@@ -85,7 +85,7 @@ pub fn generate(object_args: &args::MergedSubscription) -> GeneratorResult<Token
                         tags: ::std::default::Default::default(),
                         is_subscription: true,
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
-                        raw_directives: ::std::default::Default::default(),
+                        directive_invocations: ::std::default::Default::default(),
                     }
                 })
             }

--- a/derive/src/merged_subscription.rs
+++ b/derive/src/merged_subscription.rs
@@ -85,6 +85,7 @@ pub fn generate(object_args: &args::MergedSubscription) -> GeneratorResult<Token
                         tags: ::std::default::Default::default(),
                         is_subscription: true,
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
+                        raw_directives: ::std::default::Default::default(),
                     }
                 })
             }

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -12,8 +12,8 @@ use crate::{
     args::{self, RenameRuleExt, RenameTarget},
     output_type::OutputType,
     utils::{
-        extract_input_args, gen_deprecation, generate_default, generate_guards, get_cfg_attrs,
-        get_crate_name, get_rustdoc, get_type_path_and_name, parse_complexity_expr,
+        extract_input_args, gen_deprecation, gen_directive_call, generate_default, generate_guards,
+        get_cfg_attrs, get_crate_name, get_rustdoc, get_type_path_and_name, parse_complexity_expr,
         parse_graphql_attrs, remove_graphql_attrs, visible_fn, GeneratorResult,
     },
 };
@@ -33,6 +33,7 @@ pub fn generate(
         .iter()
         .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
         .collect::<Vec<_>>();
+    let directives = gen_directive_call(&object_args.directives);
     let gql_typename = if !object_args.name_type {
         object_args
             .name
@@ -330,11 +331,7 @@ pub fn generate(
                     .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
                     .collect::<Vec<_>>();
 
-                let directives = method_args
-                    .directives
-                    .iter()
-                    .map(|directive| quote!(#directive))
-                    .collect::<Vec<_>>();
+                let directives = gen_directive_call(&method_args.directives);
 
                 let override_from = match &method_args.override_from {
                     Some(from) => {
@@ -686,6 +683,7 @@ pub fn generate(
                         visible: #visible,
                         is_subscription: false,
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
+                        raw_directives: ::std::vec![ #(#directives),* ]
                     });
                     #(#create_entity_types)*
                     #(#add_keys)*
@@ -728,6 +726,7 @@ pub fn generate(
                         visible: #visible,
                         is_subscription: false,
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
+                        raw_directives: ::std::vec![ #(#directives),* ],
                     });
                     #(#create_entity_types)*
                     #(#add_keys)*

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -543,7 +543,7 @@ pub fn generate(
                         override_from: #override_from,
                         visible: #visible,
                         compute_complexity: #complexity,
-                        directives: ::std::vec![ #(#directives),* ]
+                        raw_directives: ::std::vec![ #(#directives),* ]
                     });
                 });
 

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -12,9 +12,10 @@ use crate::{
     args::{self, RenameRuleExt, RenameTarget},
     output_type::OutputType,
     utils::{
-        extract_input_args, gen_deprecation, gen_directive_call, generate_default, generate_guards,
-        get_cfg_attrs, get_crate_name, get_rustdoc, get_type_path_and_name, parse_complexity_expr,
-        parse_graphql_attrs, remove_graphql_attrs, visible_fn, GeneratorResult,
+        extract_input_args, gen_deprecation, gen_directive_calls, generate_default,
+        generate_guards, get_cfg_attrs, get_crate_name, get_rustdoc, get_type_path_and_name,
+        parse_complexity_expr, parse_graphql_attrs, remove_graphql_attrs, visible_fn,
+        GeneratorResult,
     },
 };
 
@@ -33,7 +34,7 @@ pub fn generate(
         .iter()
         .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
         .collect::<Vec<_>>();
-    let directives = gen_directive_call(&object_args.directives);
+    let directives = gen_directive_calls(&object_args.directives);
     let gql_typename = if !object_args.name_type {
         object_args
             .name
@@ -331,7 +332,7 @@ pub fn generate(
                     .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
                     .collect::<Vec<_>>();
 
-                let directives = gen_directive_call(&method_args.directives);
+                let directives = gen_directive_calls(&method_args.directives);
 
                 let override_from = match &method_args.override_from {
                     Some(from) => {

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -8,6 +8,7 @@ use syn::{
     ReturnType, Token, Type, TypeReference,
 };
 
+use crate::args::TypeDirectiveLocation;
 use crate::{
     args::{self, RenameRuleExt, RenameTarget},
     output_type::OutputType,
@@ -34,7 +35,7 @@ pub fn generate(
         .iter()
         .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
         .collect::<Vec<_>>();
-    let directives = gen_directive_calls(&object_args.directives);
+    let directives = gen_directive_calls(&object_args.directives, TypeDirectiveLocation::Object);
     let gql_typename = if !object_args.name_type {
         object_args
             .name
@@ -332,7 +333,10 @@ pub fn generate(
                     .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
                     .collect::<Vec<_>>();
 
-                let directives = gen_directive_calls(&method_args.directives);
+                let directives = gen_directive_calls(
+                    &method_args.directives,
+                    TypeDirectiveLocation::FieldDefinition,
+                );
 
                 let override_from = match &method_args.override_from {
                     Some(from) => {

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -329,6 +329,13 @@ pub fn generate(
                     .iter()
                     .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
                     .collect::<Vec<_>>();
+
+                let directives = method_args
+                    .directives
+                    .iter()
+                    .map(|directive| quote!(::std::string::ToString::to_string(#directive)))
+                    .collect::<Vec<_>>();
+
                 let override_from = match &method_args.override_from {
                     Some(from) => {
                         quote! { ::std::option::Option::Some(::std::string::ToString::to_string(#from)) }
@@ -536,6 +543,7 @@ pub fn generate(
                         override_from: #override_from,
                         visible: #visible,
                         compute_complexity: #complexity,
+                        directives: ::std::vec![ #(#directives),* ]
                     });
                 });
 

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -541,7 +541,7 @@ pub fn generate(
                         override_from: #override_from,
                         visible: #visible,
                         compute_complexity: #complexity,
-                        raw_directives: ::std::vec![ #(#directives),* ]
+                        directive_invocations: ::std::vec![ #(#directives),* ]
                     });
                 });
 
@@ -684,7 +684,7 @@ pub fn generate(
                         visible: #visible,
                         is_subscription: false,
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
-                        raw_directives: ::std::vec![ #(#directives),* ]
+                        directive_invocations: ::std::vec![ #(#directives),* ]
                     });
                     #(#create_entity_types)*
                     #(#add_keys)*
@@ -727,7 +727,7 @@ pub fn generate(
                         visible: #visible,
                         is_subscription: false,
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
-                        raw_directives: ::std::vec![ #(#directives),* ],
+                        directive_invocations: ::std::vec![ #(#directives),* ],
                     });
                     #(#create_entity_types)*
                     #(#add_keys)*

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -333,7 +333,7 @@ pub fn generate(
                 let directives = method_args
                     .directives
                     .iter()
-                    .map(|directive| quote!(::std::string::ToString::to_string(#directive)))
+                    .map(|directive| quote!(#directive))
                     .collect::<Vec<_>>();
 
                 let override_from = match &method_args.override_from {

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -208,7 +208,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                     override_from: #override_from,
                     visible: #visible,
                     compute_complexity: ::std::option::Option::None,
-                    raw_directives: ::std::vec![ #(#directives),* ],
+                    directive_invocations: ::std::vec![ #(#directives),* ],
                 });
             });
         } else {
@@ -373,7 +373,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                         visible: #visible,
                         is_subscription: false,
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
-                        raw_directives: ::std::vec![ #(#object_directives),* ],
+                        directive_invocations: ::std::vec![ #(#object_directives),* ],
                     })
                 }
 
@@ -441,7 +441,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                         visible: #visible,
                         is_subscription: false,
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
-                        raw_directives: ::std::vec![ #(#object_directives),* ],
+                        directive_invocations: ::std::vec![ #(#object_directives),* ],
                     })
                 }
 

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -206,6 +206,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                     override_from: #override_from,
                     visible: #visible,
                     compute_complexity: ::std::option::Option::None,
+                    directives: ::std::vec![],
                 });
             });
         } else {

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -8,7 +8,7 @@ use syn::{ext::IdentExt, visit::Visit, Error, Ident, LifetimeParam, Path, Type};
 use crate::{
     args::{self, RenameRuleExt, RenameTarget, SimpleObjectField},
     utils::{
-        gen_deprecation, gen_directive_call, generate_guards, get_crate_name, get_rustdoc,
+        gen_deprecation, gen_directive_calls, generate_guards, get_crate_name, get_rustdoc,
         visible_fn, GeneratorResult,
     },
 };
@@ -38,7 +38,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
         .iter()
         .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
         .collect::<Vec<_>>();
-    let object_directives = gen_directive_call(&object_args.directives);
+    let object_directives = gen_directive_calls(&object_args.directives);
     let gql_typename = if !object_args.name_type {
         object_args
             .name
@@ -189,7 +189,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
         };
 
         let visible = visible_fn(&field.visible);
-        let directives = gen_directive_call(&field.directives);
+        let directives = gen_directive_calls(&field.directives);
         if !field.flatten {
             schema_fields.push(quote! {
                 fields.insert(::std::borrow::ToOwned::to_owned(#field_name), #crate_name::registry::MetaField {

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -206,7 +206,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                     override_from: #override_from,
                     visible: #visible,
                     compute_complexity: ::std::option::Option::None,
-                    directives: ::std::vec![],
+                    raw_directives: ::std::vec![],
                 });
             });
         } else {

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -5,6 +5,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{ext::IdentExt, visit::Visit, Error, Ident, LifetimeParam, Path, Type};
 
+use crate::args::TypeDirectiveLocation;
 use crate::{
     args::{self, RenameRuleExt, RenameTarget, SimpleObjectField},
     utils::{
@@ -38,7 +39,8 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
         .iter()
         .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
         .collect::<Vec<_>>();
-    let object_directives = gen_directive_calls(&object_args.directives);
+    let object_directives =
+        gen_directive_calls(&object_args.directives, TypeDirectiveLocation::Object);
     let gql_typename = if !object_args.name_type {
         object_args
             .name
@@ -189,7 +191,8 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
         };
 
         let visible = visible_fn(&field.visible);
-        let directives = gen_directive_calls(&field.directives);
+        let directives =
+            gen_directive_calls(&field.directives, TypeDirectiveLocation::FieldDefinition);
         if !field.flatten {
             schema_fields.push(quote! {
                 fields.insert(::std::borrow::ToOwned::to_owned(#field_name), #crate_name::registry::MetaField {

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -266,6 +266,7 @@ pub fn generate(
                     inaccessible: false,
                     tags: ::std::default::Default::default(),
                     compute_complexity: #complexity,
+                    raw_directives: ::std::vec![],
                 });
             });
 

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -266,7 +266,7 @@ pub fn generate(
                     inaccessible: false,
                     tags: ::std::default::Default::default(),
                     compute_complexity: #complexity,
-                    raw_directives: ::std::default::Default::default(),
+                    directive_invocations: ::std::default::Default::default(),
                 });
             });
 
@@ -413,7 +413,7 @@ pub fn generate(
                     tags: ::std::default::Default::default(),
                     is_subscription: true,
                     rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
-                    raw_directives: ::std::default::Default::default(),
+                    directive_invocations: ::std::default::Default::default(),
                 })
             }
 

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -266,7 +266,7 @@ pub fn generate(
                     inaccessible: false,
                     tags: ::std::default::Default::default(),
                     compute_complexity: #complexity,
-                    raw_directives: ::std::vec![],
+                    raw_directives: ::std::default::Default::default(),
                 });
             });
 

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -413,6 +413,7 @@ pub fn generate(
                     tags: ::std::default::Default::default(),
                     is_subscription: true,
                     rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
+                    raw_directives: ::std::default::Default::default(),
                 })
             }
 

--- a/derive/src/type_directive.rs
+++ b/derive/src/type_directive.rs
@@ -128,6 +128,12 @@ pub fn generate(
         .into());
     }
 
+    let location_traits = directive_args
+        .locations
+        .iter()
+        .map(|loc| loc.location_trait_identifier())
+        .collect::<Vec<_>>();
+
     let expanded = quote! {
         #[allow(non_camel_case_types)]
         #vis struct #ident;
@@ -156,6 +162,8 @@ pub fn generate(
             }
 
         }
+
+       #(impl #crate_name::registry::location_traits::#location_traits for #ident {})*
 
         impl #ident {
             pub fn apply(#(#input_args),*) -> #crate_name::registry::MetaDirectiveInvocation {

--- a/derive/src/type_directive.rs
+++ b/derive/src/type_directive.rs
@@ -35,6 +35,8 @@ pub fn generate(
     let mut use_params = Vec::new();
     let mut schema_args = Vec::new();
 
+    let input_args = item_fn.sig.inputs.clone();
+
     for arg in item_fn.sig.inputs.iter_mut() {
         let mut arg_info = None;
 
@@ -139,7 +141,6 @@ pub fn generate(
         #[allow(non_camel_case_types)]
         #vis struct #ident;
 
-        #[#crate_name::async_trait::async_trait]
         impl #crate_name::TypeDirective for #ident {
             fn name(&self) -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                 #directive_name
@@ -161,6 +162,14 @@ pub fn generate(
                     composable: true,
                 };
                 registry.add_directive(meta);
+            }
+
+        }
+
+        impl #ident {
+            pub fn apply(#input_args) -> String {
+                let directive = #directive_name.to_owned();
+                format!("@{}", directive)
             }
         }
     };

--- a/derive/src/type_directive.rs
+++ b/derive/src/type_directive.rs
@@ -1,0 +1,169 @@
+use crate::args;
+use crate::args::{Argument, RenameRuleExt, RenameTarget};
+use crate::utils::{
+    generate_default, get_crate_name, get_rustdoc, parse_graphql_attrs, remove_graphql_attrs,
+    visible_fn, GeneratorResult,
+};
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::ext::IdentExt;
+use syn::{FnArg, ItemFn, Pat};
+
+pub fn generate(
+    directive_args: &args::TypeDirective,
+    item_fn: &mut ItemFn,
+) -> GeneratorResult<TokenStream> {
+    let crate_name = get_crate_name(directive_args.internal);
+    let ident = &item_fn.sig.ident;
+    let vis = &item_fn.vis;
+    let directive_name = if !directive_args.name_type {
+        let name = directive_args
+            .name
+            .clone()
+            .unwrap_or_else(|| item_fn.sig.ident.to_string());
+        quote!(::std::borrow::Cow::Borrowed(#name))
+    } else {
+        quote!(<Self as #crate_name::TypeName>::type_name())
+    };
+    let desc = get_rustdoc(&item_fn.attrs)?
+        .map(|s| quote!(::std::option::Option::Some(::std::string::ToString::to_string(#s))))
+        .unwrap_or_else(|| quote!(::std::option::Option::None));
+    let visible = visible_fn(&directive_args.visible);
+    let repeatable = directive_args.repeatable;
+
+    let mut get_params = Vec::new();
+    let mut use_params = Vec::new();
+    let mut schema_args = Vec::new();
+
+    for arg in item_fn.sig.inputs.iter_mut() {
+        let mut arg_info = None;
+
+        if let FnArg::Typed(pat) = arg {
+            if let Pat::Ident(ident) = &*pat.pat {
+                arg_info = Some((ident.clone(), pat.ty.clone(), pat.attrs.clone()));
+                remove_graphql_attrs(&mut pat.attrs);
+            }
+        }
+
+        let (arg_ident, arg_ty, arg_attrs) = match arg_info {
+            Some(info) => info,
+            None => {
+                return Err(syn::Error::new_spanned(arg, "Invalid argument type.").into());
+            }
+        };
+
+        let Argument {
+            name,
+            desc,
+            default,
+            default_with,
+            validator,
+            visible,
+            secret,
+            ..
+        } = parse_graphql_attrs::<args::Argument>(&arg_attrs)?.unwrap_or_default();
+
+        let name = name.clone().unwrap_or_else(|| {
+            directive_args
+                .rename_args
+                .rename(arg_ident.ident.unraw().to_string(), RenameTarget::Argument)
+        });
+        let desc = desc
+            .as_ref()
+            .map(|s| quote! {::std::option::Option::Some(::std::string::ToString::to_string(#s))})
+            .unwrap_or_else(|| quote! {::std::option::Option::None});
+        let default = generate_default(&default, &default_with)?;
+        let schema_default = default
+            .as_ref()
+            .map(|value| {
+                quote! {
+                    ::std::option::Option::Some(::std::string::ToString::to_string(
+                        &<#arg_ty as #crate_name::InputType>::to_value(&#value)
+                    ))
+                }
+            })
+            .unwrap_or_else(|| quote! {::std::option::Option::None});
+        let visible = visible_fn(&visible);
+
+        schema_args.push(quote! {
+            args.insert(::std::borrow::ToOwned::to_owned(#name), #crate_name::registry::MetaInputValue {
+                name: ::std::string::ToString::to_string(#name),
+                description: #desc,
+                ty: <#arg_ty as #crate_name::InputType>::create_type_info(registry),
+                default_value: #schema_default,
+                visible: #visible,
+                inaccessible: false,
+                tags: ::std::default::Default::default(),
+                is_secret: #secret,
+            });
+        });
+
+        let validators = validator.clone().unwrap_or_default().create_validators(
+            &crate_name,
+            quote!(&#arg_ident),
+            Some(quote!(.map_err(|err| err.into_server_error(__pos)))),
+        )?;
+
+        let default = match default {
+            Some(default) => {
+                quote! { ::std::option::Option::Some(|| -> #arg_ty { #default }) }
+            }
+            None => quote! { ::std::option::Option::None },
+        };
+        get_params.push(quote! {
+            let (__pos, #arg_ident) = ctx.param_value::<#arg_ty>(#name, #default)?;
+            #validators
+        });
+
+        use_params.push(quote! { #arg_ident });
+    }
+
+    let locations = directive_args
+        .locations
+        .iter()
+        .map(|loc| {
+            let loc = quote::format_ident!("{}", loc.to_string());
+            quote!(#crate_name::registry::__DirectiveLocation::#loc)
+        })
+        .collect::<Vec<_>>();
+
+    if locations.is_empty() {
+        return Err(syn::Error::new(
+            ident.span(),
+            "At least one location is required for the directive.",
+        )
+        .into());
+    }
+
+    let expanded = quote! {
+        #[allow(non_camel_case_types)]
+        #vis struct #ident;
+
+        #[#crate_name::async_trait::async_trait]
+        impl #crate_name::TypeDirective for #ident {
+            fn name(&self) -> ::std::borrow::Cow<'static, ::std::primitive::str> {
+                #directive_name
+            }
+
+            fn register(&self, registry: &mut #crate_name::registry::Registry) {
+                let meta = #crate_name::registry::MetaDirective {
+                    name: ::std::borrow::Cow::into_owned(#directive_name),
+                    description: #desc,
+                    locations: vec![#(#locations),*],
+                    args: {
+                        #[allow(unused_mut)]
+                        let mut args = #crate_name::indexmap::IndexMap::new();
+                        #(#schema_args)*
+                        args
+                    },
+                    is_repeatable: #repeatable,
+                    visible: #visible,
+                    composable: true,
+                };
+                registry.add_directive(meta);
+            }
+        }
+    };
+
+    Ok(expanded.into())
+}

--- a/derive/src/type_directive.rs
+++ b/derive/src/type_directive.rs
@@ -106,7 +106,7 @@ pub fn generate(
 
         directive_input_args.push(quote! {
             if let Some(val) = #crate_name::InputType::as_raw_value(&#arg_ident) {
-                directive_args.push(format!("{}: {}" , #name, #crate_name::ScalarType::to_value(val)));
+                args.insert(::std::string::ToString::to_string(#name), #crate_name::ScalarType::to_value(val));
             };
         });
     }
@@ -158,16 +158,14 @@ pub fn generate(
         }
 
         impl #ident {
-            pub fn apply(#(#input_args),*) -> ::std::string::String {
-                let directive = #directive_name.to_owned();
-                let mut directive_args: Vec<::std::string::String> = vec![];
+            pub fn apply(#(#input_args),*) -> #crate_name::registry::MetaDirectiveInvocation {
+                let directive = ::std::borrow::Cow::into_owned(#directive_name);
+                let mut args = #crate_name::indexmap::IndexMap::new();
                 #(#directive_input_args)*;
-                let formatted_args = if directive_args.is_empty() {
-                    ::std::string::String::new()
-                }else {
-                    format!("({})", directive_args.join(", "))
-                };
-                format!("@{}{}", directive, formatted_args)
+                #crate_name::registry::MetaDirectiveInvocation {
+                    name: directive,
+                    args,
+                }
             }
         }
     };

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -315,7 +315,7 @@ impl VisitMut for RemoveLifetime {
     }
 }
 
-pub fn gen_directive_call(directives: &Vec<Expr>) -> Vec<TokenStream> {
+pub fn gen_directive_calls(directives: &[Expr]) -> Vec<TokenStream> {
     directives
         .iter()
         .map(|directive| quote!(#directive))

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -314,3 +314,10 @@ impl VisitMut for RemoveLifetime {
         visit_mut::visit_lifetime_mut(self, i);
     }
 }
+
+pub fn gen_directive_call(directives: &Vec<Expr>) -> Vec<TokenStream> {
+    directives
+        .iter()
+        .map(|directive| quote!(#directive))
+        .collect::<Vec<_>>()
+}

--- a/schema.sdl
+++ b/schema.sdl
@@ -1,0 +1,12 @@
+extend schema @link(
+	url: "https://specs.apollo.dev/federation/v2.1",
+	import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires", "@composeDirective"]
+)
+
+extend schema @link(
+	url: "https://custom.spec.dev/extension/v1.0"
+	import: ["@abc"]
+)
+	@composeDirective(name: "@abc")
+
+directive @abc on FIELD_DEFINITION

--- a/schema.sdl
+++ b/schema.sdl
@@ -1,3 +1,9 @@
+type Query {
+	value: String! @myTestDirective(stringInput: "123", intInput: 5)
+	value2: Int! @noArgsDirective
+}
+
+
 extend schema @link(
 	url: "https://specs.apollo.dev/federation/v2.1",
 	import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires", "@composeDirective"]
@@ -5,8 +11,12 @@ extend schema @link(
 
 extend schema @link(
 	url: "https://custom.spec.dev/extension/v1.0"
-	import: ["@abc"]
+	import: ["@myTestDirective","@noArgsDirective"]
 )
-	@composeDirective(name: "@abc")
+	@composeDirective(name: "@myTestDirective")
+	@composeDirective(name: "@noArgsDirective")
 
-directive @abc on FIELD_DEFINITION
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @myTestDirective(stringInput: String!, intInput: Int!, optionalInt: Int) on FIELD_DEFINITION | OBJECT
+directive @noArgsDirective on FIELD_DEFINITION
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/schema.sdl
+++ b/schema.sdl
@@ -1,6 +1,10 @@
-type Query {
-	value: String! @myTestDirective(stringInput: "123", intInput: 5)
-	value2: Int! @noArgsDirective
+type Query @testDirective(scope: "object type", input: 3) {
+	value: String! @testDirective(scope: "object field", input: 4) @noArgsDirective
+	anotherValue: SimpleValue!
+}
+
+type SimpleValue @testDirective(scope: "simple object type", input: 1, opt: 3) {
+	someData: String! @testDirective(scope: "field and param with \" symbol", input: 2, opt: 3)
 }
 
 
@@ -11,12 +15,12 @@ extend schema @link(
 
 extend schema @link(
 	url: "https://custom.spec.dev/extension/v1.0"
-	import: ["@myTestDirective","@noArgsDirective"]
+	import: ["@noArgsDirective","@testDirective"]
 )
-	@composeDirective(name: "@myTestDirective")
 	@composeDirective(name: "@noArgsDirective")
+	@composeDirective(name: "@testDirective")
 
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-directive @myTestDirective(stringInput: String!, intInput: Int!, optionalInt: Int) on FIELD_DEFINITION | OBJECT
 directive @noArgsDirective on FIELD_DEFINITION
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @testDirective(scope: String!, input: Int!, opt: Int) on FIELD_DEFINITION | OBJECT

--- a/src/custom_directive.rs
+++ b/src/custom_directive.rs
@@ -18,6 +18,14 @@ pub trait CustomDirectiveFactory: Send + Sync + 'static {
     ) -> ServerResult<Box<dyn CustomDirective>>;
 }
 
+#[doc(hidden)]
+// minimal amount required to register directive into registry
+pub trait TypeDirective {
+    fn name(&self) -> Cow<'static, str>;
+
+    fn register(&self, registry: &mut Registry);
+}
+
 /// Represents a custom directive.
 #[async_trait::async_trait]
 #[allow(unused_variables)]

--- a/src/dynamic/interface.rs
+++ b/src/dynamic/interface.rs
@@ -235,6 +235,7 @@ impl Interface {
                     tags: field.tags.clone(),
                     override_from: field.override_from.clone(),
                     compute_complexity: None,
+                    raw_directives: vec![],
                 },
             );
         }

--- a/src/dynamic/interface.rs
+++ b/src/dynamic/interface.rs
@@ -235,7 +235,7 @@ impl Interface {
                     tags: field.tags.clone(),
                     override_from: field.override_from.clone(),
                     compute_complexity: None,
-                    raw_directives: vec![],
+                    directive_invocations: vec![],
                 },
             );
         }

--- a/src/dynamic/object.rs
+++ b/src/dynamic/object.rs
@@ -179,6 +179,7 @@ impl Object {
                 tags: self.tags.clone(),
                 is_subscription: false,
                 rust_typename: None,
+                raw_directives: vec![],
             },
         );
 

--- a/src/dynamic/object.rs
+++ b/src/dynamic/object.rs
@@ -155,6 +155,7 @@ impl Object {
                     tags: field.tags.clone(),
                     override_from: field.override_from.clone(),
                     compute_complexity: None,
+                    raw_directives: vec![],
                 },
             );
         }

--- a/src/dynamic/object.rs
+++ b/src/dynamic/object.rs
@@ -155,7 +155,7 @@ impl Object {
                     tags: field.tags.clone(),
                     override_from: field.override_from.clone(),
                     compute_complexity: None,
-                    raw_directives: vec![],
+                    directive_invocations: vec![],
                 },
             );
         }
@@ -179,7 +179,7 @@ impl Object {
                 tags: self.tags.clone(),
                 is_subscription: false,
                 rust_typename: None,
-                raw_directives: vec![],
+                directive_invocations: vec![],
             },
         );
 

--- a/src/dynamic/subscription.rs
+++ b/src/dynamic/subscription.rs
@@ -162,6 +162,7 @@ impl Subscription {
                     tags: vec![],
                     override_from: None,
                     compute_complexity: None,
+                    raw_directives: vec![],
                 },
             );
         }

--- a/src/dynamic/subscription.rs
+++ b/src/dynamic/subscription.rs
@@ -162,7 +162,7 @@ impl Subscription {
                     tags: vec![],
                     override_from: None,
                     compute_complexity: None,
-                    raw_directives: vec![],
+                    directive_invocations: vec![],
                 },
             );
         }
@@ -182,7 +182,7 @@ impl Subscription {
                 tags: vec![],
                 is_subscription: true,
                 rust_typename: None,
-                raw_directives: vec![],
+                directive_invocations: vec![],
             },
         );
 

--- a/src/dynamic/subscription.rs
+++ b/src/dynamic/subscription.rs
@@ -182,6 +182,7 @@ impl Subscription {
                 tags: vec![],
                 is_subscription: true,
                 rust_typename: None,
+                raw_directives: vec![],
             },
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,5 +291,6 @@ pub use async_graphql_derive::Scalar;
 pub use async_graphql_derive::SimpleObject;
 #[doc = include_str!("docs/subscription.md")]
 pub use async_graphql_derive::Subscription;
+pub use async_graphql_derive::TypeDirective;
 #[doc = include_str!("docs/union.md")]
 pub use async_graphql_derive::Union;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ pub use base::{
 #[doc(hidden)]
 pub use context::ContextSelectionSet;
 pub use context::*;
-pub use custom_directive::{CustomDirective, CustomDirectiveFactory};
+pub use custom_directive::{CustomDirective, CustomDirectiveFactory, TypeDirective};
 pub use error::{
     Error, ErrorExtensionValues, ErrorExtensions, InputValueError, InputValueResult,
     ParseRequestError, PathSegment, Result, ResultExt, ServerError, ServerResult,

--- a/src/model/directive.rs
+++ b/src/model/directive.rs
@@ -66,6 +66,20 @@ pub enum __DirectiveLocation {
     INPUT_FIELD_DEFINITION,
 }
 
+// Traits for compile time checking if location at which directive is called is supported by directives definition
+// Would be nice to auto generate traits from variants of __DirectiveLocation
+#[doc(hidden)]
+#[allow(non_camel_case_types)]
+pub mod location_traits {
+    pub trait Directive_At_FIELD_DEFINITION {
+        fn check() {}
+    }
+
+    pub trait Directive_At_OBJECT {
+        fn check() {}
+    }
+}
+
 pub struct __Directive<'a> {
     pub registry: &'a registry::Registry,
     pub visible_types: &'a HashSet<&'a str>,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -6,7 +6,7 @@ mod kind;
 mod schema;
 mod r#type;
 
-pub use directive::{__Directive, __DirectiveLocation};
+pub use directive::{__Directive, __DirectiveLocation, location_traits};
 pub use enum_value::__EnumValue;
 pub use field::__Field;
 pub use input_value::__InputValue;

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -136,7 +136,7 @@ impl Registry {
                     .collect::<Vec<_>>();
 
                 writeln!(sdl, "extend schema @link(").ok();
-                writeln!(sdl, "\turl: \"https://custom_schema_extension/v1.0\"").ok();
+                writeln!(sdl, "\turl: \"https://custom.spec.dev/extension/v1.0\"").ok();
                 writeln!(sdl, "\timport: [{}]", compose_directives_names.join(",")).ok();
                 writeln!(sdl, ")").ok();
                 for name in compose_directives_names {
@@ -634,15 +634,15 @@ mod tests {
 
 extend schema @link(
 	url: "https://custom.spec.dev/extension/v1.0"
-	import: ["@abc"]
+	import: ["@custom_type_directive"]
 )
-	@composeDirective(name: "@abc")
+	@composeDirective(name: "@custom_type_directive")
 
-directive @abc on FIELD_DEFINITION
+directive @custom_type_directive on FIELD_DEFINITION
 "#;
         let mut registry = Registry::default();
         registry.add_directive(MetaDirective {
-            name: "abc".to_string(),
+            name: "custom_type_directive".to_string(),
             description: None,
             locations: vec![__DirectiveLocation::FIELD_DEFINITION],
             args: Default::default(),

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -238,6 +238,9 @@ impl Registry {
                 if let Some(from) = &field.override_from {
                     write!(sdl, " @override(from: \"{}\")", from).ok();
                 }
+                for directive in &field.directives {
+                    write!(sdl, " {}", directive).ok();
+                }
             }
 
             writeln!(sdl).ok();

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -248,8 +248,8 @@ impl Registry {
                 if let Some(from) = &field.override_from {
                     write!(sdl, " @override(from: \"{}\")", from).ok();
                 }
-                for directive in &field.raw_directives {
-                    write!(sdl, " {}", directive).ok();
+                for directive in &field.directive_invocations {
+                    write!(sdl, " {}", directive.sdl()).ok();
                 }
             }
 
@@ -308,7 +308,7 @@ impl Registry {
                 shareable,
                 inaccessible,
                 tags,
-                raw_directives,
+                directive_invocations: raw_directives,
                 ..
             } => {
                 if Some(name.as_str()) == self.subscription_type.as_deref()
@@ -364,8 +364,8 @@ impl Registry {
                         write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                     }
 
-                    for raw_directive in raw_directives {
-                        write!(sdl, " {}", raw_directive).ok();
+                    for directive_invocation in raw_directives {
+                        write!(sdl, " {}", directive_invocation.sdl()).ok();
                     }
                 }
 

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -308,6 +308,7 @@ impl Registry {
                 shareable,
                 inaccessible,
                 tags,
+                raw_directives,
                 ..
             } => {
                 if Some(name.as_str()) == self.subscription_type.as_deref()
@@ -361,6 +362,10 @@ impl Registry {
 
                     for tag in tags {
                         write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
+                    }
+
+                    for raw_directive in raw_directives {
+                        write!(sdl, " {}", raw_directive).ok();
                     }
                 }
 

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -205,6 +205,8 @@ pub struct MetaField {
     pub override_from: Option<String>,
     /// A constant or function to get the complexity
     pub compute_complexity: Option<ComputeComplexityFn>,
+    /// Custom type directives (if compose feature is enabled they will be propagated to supergraph)
+    pub directives: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -957,6 +959,7 @@ impl Registry {
                     override_from: None,
                     visible: None,
                     compute_complexity: None,
+                    directives: vec![],
                 },
             );
         }
@@ -1010,6 +1013,7 @@ impl Registry {
                         tags: Default::default(),
                         override_from: None,
                         compute_complexity: None,
+                        directives: vec![],
                     },
                 );
             }
@@ -1038,6 +1042,7 @@ impl Registry {
                     visible: None,
                     compute_complexity: None,
                     override_from: None,
+                    directives: vec![],
                 },
             );
 
@@ -1075,6 +1080,7 @@ impl Registry {
                     override_from: None,
                     visible: None,
                     compute_complexity: None,
+                    directives: vec![],
                 },
             );
         }
@@ -1108,6 +1114,7 @@ impl Registry {
                             tags: Default::default(),
                             override_from: None,
                             compute_complexity: None,
+                            directives: vec![],
                         },
                     );
                     fields

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -256,6 +256,7 @@ impl MetaTypeId {
                 visible: None,
                 is_subscription: false,
                 rust_typename: Some(rust_typename),
+                raw_directives: vec![],
             },
             MetaTypeId::Interface => MetaType::Interface {
                 name: "".to_string(),
@@ -396,6 +397,8 @@ pub enum MetaType {
         is_subscription: bool,
         /// The Rust typename corresponding to the object
         rust_typename: Option<&'static str>,
+        /// raw directive "calls" or decorators
+        raw_directives: Vec<String>,
     },
     /// Interface
     ///
@@ -1128,6 +1131,7 @@ impl Registry {
                 tags: Default::default(),
                 is_subscription: false,
                 rust_typename: Some("async_graphql::federation::Service"),
+                raw_directives: vec![],
             },
         );
 

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -205,8 +205,8 @@ pub struct MetaField {
     pub override_from: Option<String>,
     /// A constant or function to get the complexity
     pub compute_complexity: Option<ComputeComplexityFn>,
-    /// Custom type directives (if compose feature is enabled they will be propagated to supergraph)
-    pub directives: Vec<String>,
+    /// Custom type directives (if compose directive is enabled they will be propagated to supergraph)
+    pub raw_directives: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -657,7 +657,7 @@ pub struct MetaDirective {
     pub args: IndexMap<String, MetaInputValue>,
     pub is_repeatable: bool,
     pub visible: Option<MetaVisibleFn>,
-    pub composable: bool,
+    pub composable: Option<String>,
 }
 
 impl MetaDirective {
@@ -725,7 +725,7 @@ impl Registry {
             },
             is_repeatable: false,
             visible: None,
-            composable: false,
+            composable: None,
         });
 
         self.add_directive(MetaDirective {
@@ -752,7 +752,7 @@ impl Registry {
             },
             is_repeatable: false,
             visible: None,
-            composable: false,
+            composable: None,
         });
 
         // create system scalars
@@ -959,7 +959,7 @@ impl Registry {
                     override_from: None,
                     visible: None,
                     compute_complexity: None,
-                    directives: vec![],
+                    raw_directives: vec![],
                 },
             );
         }
@@ -1013,7 +1013,7 @@ impl Registry {
                         tags: Default::default(),
                         override_from: None,
                         compute_complexity: None,
-                        directives: vec![],
+                        raw_directives: vec![],
                     },
                 );
             }
@@ -1042,7 +1042,7 @@ impl Registry {
                     visible: None,
                     compute_complexity: None,
                     override_from: None,
-                    directives: vec![],
+                    raw_directives: vec![],
                 },
             );
 
@@ -1080,7 +1080,7 @@ impl Registry {
                     override_from: None,
                     visible: None,
                     compute_complexity: None,
-                    directives: vec![],
+                    raw_directives: vec![],
                 },
             );
         }
@@ -1114,7 +1114,7 @@ impl Registry {
                             tags: Default::default(),
                             override_from: None,
                             compute_complexity: None,
-                            directives: vec![],
+                            raw_directives: vec![],
                         },
                     );
                     fields

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -12,7 +12,7 @@ pub use cache_control::CacheControl;
 pub use export_sdl::SDLExportOptions;
 use indexmap::{map::IndexMap, set::IndexSet};
 
-pub use crate::model::__DirectiveLocation;
+pub use crate::model::{__DirectiveLocation, location_traits};
 use crate::{
     model::__Schema,
     parser::types::{BaseType as ParsedBaseType, Field, Type as ParsedType, VariableDefinition},

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -655,6 +655,7 @@ pub struct MetaDirective {
     pub args: IndexMap<String, MetaInputValue>,
     pub is_repeatable: bool,
     pub visible: Option<MetaVisibleFn>,
+    pub composable: bool,
 }
 
 impl MetaDirective {
@@ -722,6 +723,7 @@ impl Registry {
             },
             is_repeatable: false,
             visible: None,
+            composable: false,
         });
 
         self.add_directive(MetaDirective {
@@ -748,6 +750,7 @@ impl Registry {
             },
             is_repeatable: false,
             visible: None,
+            composable: false,
         });
 
         // create system scalars

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -205,7 +205,7 @@ pub struct MetaField {
     pub override_from: Option<String>,
     /// A constant or function to get the complexity
     pub compute_complexity: Option<ComputeComplexityFn>,
-    /// Custom type directives (if compose directive is enabled they will be propagated to supergraph)
+    /// Custom directives applied
     pub raw_directives: Vec<String>,
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -213,13 +213,6 @@ impl<Query, Mutation, Subscription> SchemaBuilder<Query, Mutation, Subscription>
         self
     }
 
-    /// Register a custom type directive
-    #[must_use]
-    pub fn type_directive<T: TypeDirective>(mut self, directive: T) -> Self {
-        directive.register(&mut self.registry);
-        self
-    }
-
     /// Disable field suggestions.
     #[must_use]
     pub fn disable_suggestions(mut self) -> Self {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -24,7 +24,7 @@ use crate::{
     validation::{check_rules, ValidationMode},
     BatchRequest, BatchResponse, CacheControl, ContextBase, EmptyMutation, EmptySubscription,
     Executor, InputType, ObjectType, OutputType, QueryEnv, Request, Response, ServerError,
-    ServerResult, SubscriptionType, Variables,
+    ServerResult, SubscriptionType, TypeDirective, Variables,
 };
 
 /// Introspection mode
@@ -209,6 +209,16 @@ impl<Query, Mutation, Subscription> SchemaBuilder<Query, Mutation, Subscription>
         {
             panic!("Directive `{}` already exists", name);
         }
+
+        self
+    }
+
+    /// Register a custom type directive
+    #[must_use]
+    pub fn type_directive<T: TypeDirective>(mut self, directive: T) -> Self {
+        let instance = Box::new(directive);
+
+        instance.register(&mut self.registry);
 
         self
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -216,10 +216,7 @@ impl<Query, Mutation, Subscription> SchemaBuilder<Query, Mutation, Subscription>
     /// Register a custom type directive
     #[must_use]
     pub fn type_directive<T: TypeDirective>(mut self, directive: T) -> Self {
-        let instance = Box::new(directive);
-
-        instance.register(&mut self.registry);
-
+        directive.register(&mut self.registry);
         self
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -24,7 +24,7 @@ use crate::{
     validation::{check_rules, ValidationMode},
     BatchRequest, BatchResponse, CacheControl, ContextBase, EmptyMutation, EmptySubscription,
     Executor, InputType, ObjectType, OutputType, QueryEnv, Request, Response, ServerError,
-    ServerResult, SubscriptionType, TypeDirective, Variables,
+    ServerResult, SubscriptionType, Variables,
 };
 
 /// Introspection mode

--- a/src/types/empty_mutation.rs
+++ b/src/types/empty_mutation.rs
@@ -61,6 +61,7 @@ impl OutputType for EmptyMutation {
             tags: Default::default(),
             is_subscription: false,
             rust_typename: Some(std::any::type_name::<Self>()),
+            raw_directives: vec![],
         })
     }
 

--- a/src/types/empty_mutation.rs
+++ b/src/types/empty_mutation.rs
@@ -61,7 +61,7 @@ impl OutputType for EmptyMutation {
             tags: Default::default(),
             is_subscription: false,
             rust_typename: Some(std::any::type_name::<Self>()),
-            raw_directives: Default::default(),
+            directive_invocations: Default::default(),
         })
     }
 

--- a/src/types/empty_mutation.rs
+++ b/src/types/empty_mutation.rs
@@ -61,7 +61,7 @@ impl OutputType for EmptyMutation {
             tags: Default::default(),
             is_subscription: false,
             rust_typename: Some(std::any::type_name::<Self>()),
-            raw_directives: vec![],
+            raw_directives: Default::default(),
         })
     }
 

--- a/src/types/empty_subscription.rs
+++ b/src/types/empty_subscription.rs
@@ -30,7 +30,7 @@ impl SubscriptionType for EmptySubscription {
             tags: Default::default(),
             is_subscription: true,
             rust_typename: Some(std::any::type_name::<Self>()),
-            raw_directives: Default::default(),
+            directive_invocations: Default::default(),
         })
     }
 

--- a/src/types/empty_subscription.rs
+++ b/src/types/empty_subscription.rs
@@ -30,6 +30,7 @@ impl SubscriptionType for EmptySubscription {
             tags: Default::default(),
             is_subscription: true,
             rust_typename: Some(std::any::type_name::<Self>()),
+            raw_directives: vec![],
         })
     }
 

--- a/src/types/empty_subscription.rs
+++ b/src/types/empty_subscription.rs
@@ -30,7 +30,7 @@ impl SubscriptionType for EmptySubscription {
             tags: Default::default(),
             is_subscription: true,
             rust_typename: Some(std::any::type_name::<Self>()),
-            raw_directives: vec![],
+            raw_directives: Default::default(),
         })
     }
 

--- a/src/types/merged_object.rs
+++ b/src/types/merged_object.rs
@@ -84,7 +84,7 @@ where
                 tags: Default::default(),
                 is_subscription: false,
                 rust_typename: Some(std::any::type_name::<Self>()),
-                raw_directives: vec![],
+                raw_directives: Default::default(),
             }
         })
     }
@@ -146,7 +146,7 @@ where
                 tags: Default::default(),
                 is_subscription: false,
                 rust_typename: Some(std::any::type_name::<Self>()),
-                raw_directives: vec![],
+                raw_directives: Default::default(),
             }
         })
     }
@@ -183,7 +183,7 @@ impl SubscriptionType for MergedObjectTail {
             tags: Default::default(),
             is_subscription: false,
             rust_typename: Some(std::any::type_name::<Self>()),
-            raw_directives: vec![],
+            raw_directives: Default::default(),
         })
     }
 

--- a/src/types/merged_object.rs
+++ b/src/types/merged_object.rs
@@ -84,7 +84,7 @@ where
                 tags: Default::default(),
                 is_subscription: false,
                 rust_typename: Some(std::any::type_name::<Self>()),
-                raw_directives: Default::default(),
+                directive_invocations: Default::default(),
             }
         })
     }
@@ -146,7 +146,7 @@ where
                 tags: Default::default(),
                 is_subscription: false,
                 rust_typename: Some(std::any::type_name::<Self>()),
-                raw_directives: Default::default(),
+                directive_invocations: Default::default(),
             }
         })
     }
@@ -183,7 +183,7 @@ impl SubscriptionType for MergedObjectTail {
             tags: Default::default(),
             is_subscription: false,
             rust_typename: Some(std::any::type_name::<Self>()),
-            raw_directives: Default::default(),
+            directive_invocations: Default::default(),
         })
     }
 

--- a/src/types/merged_object.rs
+++ b/src/types/merged_object.rs
@@ -84,6 +84,7 @@ where
                 tags: Default::default(),
                 is_subscription: false,
                 rust_typename: Some(std::any::type_name::<Self>()),
+                raw_directives: vec![],
             }
         })
     }
@@ -145,6 +146,7 @@ where
                 tags: Default::default(),
                 is_subscription: false,
                 rust_typename: Some(std::any::type_name::<Self>()),
+                raw_directives: vec![],
             }
         })
     }
@@ -181,6 +183,7 @@ impl SubscriptionType for MergedObjectTail {
             tags: Default::default(),
             is_subscription: false,
             rust_typename: Some(std::any::type_name::<Self>()),
+            raw_directives: vec![],
         })
     }
 

--- a/tests/schemas/test_entity_inaccessible.schema.graphql
+++ b/tests/schemas/test_entity_inaccessible.schema.graphql
@@ -67,7 +67,7 @@ extend type Query {
 
 extend schema @link(
 	url: "https://specs.apollo.dev/federation/v2.1",
-	import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires"]
+	import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires", "@composeDirective"]
 )
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/tests/schemas/test_entity_tag.schema.graphql
+++ b/tests/schemas/test_entity_tag.schema.graphql
@@ -67,7 +67,7 @@ extend type Query {
 
 extend schema @link(
 	url: "https://specs.apollo.dev/federation/v2.1",
-	import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires"]
+	import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires", "@composeDirective"]
 )
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/tests/schemas/test_fed2_compose.schema.graphql
+++ b/tests/schemas/test_fed2_compose.schema.graphql
@@ -1,3 +1,7 @@
+
+
+
+
 type Query @testDirective(scope: "object type", input: 3) {
 	value: String! @testDirective(scope: "object field", input: 4) @noArgsDirective
 	anotherValue: SimpleValue!

--- a/tests/schemas/test_fed2_link.schema.graphqls
+++ b/tests/schemas/test_fed2_link.schema.graphqls
@@ -22,7 +22,7 @@ extend type User @key(fields: "id") {
 
 extend schema @link(
 	url: "https://specs.apollo.dev/federation/v2.1",
-	import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires"]
+	import: ["@key", "@tag", "@shareable", "@inaccessible", "@override", "@external", "@provides", "@requires", "@composeDirective"]
 )
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/tests/type_directive.rs
+++ b/tests/type_directive.rs
@@ -49,10 +49,7 @@ pub fn test_type_directive() {
         }
     }
 
-    let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
-        .type_directive(testDirective)
-        .type_directive(noArgsDirective)
-        .finish();
+    let schema = Schema::build(Query, EmptyMutation, EmptySubscription).finish();
 
     let sdl = schema.sdl_with_options(SDLExportOptions::new().federation().compose_directive());
 

--- a/tests/type_directive.rs
+++ b/tests/type_directive.rs
@@ -1,0 +1,29 @@
+use async_graphql::{EmptyMutation, EmptySubscription, SDLExportOptions, Schema};
+use async_graphql_derive::Object;
+use async_graphql_derive::TypeDirective;
+
+#[test]
+fn test_type_directive() {
+    #[TypeDirective(location = "fielddefinition")]
+    fn my_test_directive(string_input: String, int_input: u32) {}
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        pub async fn value(&self) -> &'static str {
+            "abc"
+        }
+    }
+
+    let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
+        .type_directive(my_test_directive)
+        .finish();
+
+    let sdl = schema.sdl_with_options(
+        SDLExportOptions::new()
+            .federation()
+            .enable_compose_directive(),
+    );
+    println!("{}", sdl)
+}

--- a/tests/type_directive.rs
+++ b/tests/type_directive.rs
@@ -3,15 +3,15 @@ use async_graphql_derive::Object;
 use async_graphql_derive::TypeDirective;
 
 #[test]
-fn test_type_directive() {
+pub fn test_type_directive() {
     #[TypeDirective(location = "fielddefinition", location = "object")]
-    fn myTestDirective(string_input: String, int_input: u32, optional_int: Option<u64>) {}
+    fn myTestDirective(_string_input: String, _int_input: u32, _optional_int: Option<u64>) {}
 
     struct Query;
 
     #[Object]
     impl Query {
-        #[graphql(directive = "@myTestDirective(stringInput: \"abc\", intInput: 2345)")]
+        #[graphql(directive = myTestDirective::apply("123".to_string(), 3 + 2, Some(4)))]
         pub async fn value(&self) -> &'static str {
             "abc"
         }

--- a/tests/type_directive.rs
+++ b/tests/type_directive.rs
@@ -4,27 +4,39 @@ use async_graphql_derive::TypeDirective;
 
 #[test]
 pub fn test_type_directive() {
-    #[TypeDirective(location = "fielddefinition", location = "object")]
-    fn myTestDirective(_string_input: String, _int_input: u32, _optional_int: Option<u64>) {}
+    #[TypeDirective(
+        location = "fielddefinition",
+        location = "object",
+        composable = "https://custom.spec.dev/extension/v1.0"
+    )]
+    fn myTestDirective(string_input: String, int_input: u32, optional_int: Option<u64>) {}
+
+    #[TypeDirective(
+        location = "fielddefinition",
+        composable = "https://custom.spec.dev/extension/v1.0"
+    )]
+    pub fn noArgsDirective() {}
 
     struct Query;
 
     #[Object]
     impl Query {
-        #[graphql(directive = myTestDirective::apply("123".to_string(), 3 + 2, Some(4)))]
+        #[graphql(directive = myTestDirective::apply("123".to_string(), 3 + 2, None))]
         pub async fn value(&self) -> &'static str {
             "abc"
+        }
+
+        #[graphql(directive = noArgsDirective::apply())]
+        pub async fn value2(&self) -> u32 {
+            123
         }
     }
 
     let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
         .type_directive(myTestDirective)
+        .type_directive(noArgsDirective)
         .finish();
 
-    let sdl = schema.sdl_with_options(
-        SDLExportOptions::new()
-            .federation()
-            .enable_compose_directive(),
-    );
+    let sdl = schema.sdl_with_options(SDLExportOptions::new().federation().compose_directive());
     println!("{}", sdl)
 }

--- a/tests/type_directive.rs
+++ b/tests/type_directive.rs
@@ -4,20 +4,21 @@ use async_graphql_derive::TypeDirective;
 
 #[test]
 fn test_type_directive() {
-    #[TypeDirective(location = "fielddefinition")]
-    fn my_test_directive(string_input: String, int_input: u32) {}
+    #[TypeDirective(location = "fielddefinition", location = "object")]
+    fn myTestDirective(string_input: String, int_input: u32, optional_int: Option<u64>) {}
 
     struct Query;
 
     #[Object]
     impl Query {
+        #[graphql(directive = "@myTestDirective(stringInput: \"abc\", intInput: 2345)")]
         pub async fn value(&self) -> &'static str {
             "abc"
         }
     }
 
     let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
-        .type_directive(my_test_directive)
+        .type_directive(myTestDirective)
         .finish();
 
     let sdl = schema.sdl_with_options(

--- a/tests/type_directive.rs
+++ b/tests/type_directive.rs
@@ -55,5 +55,7 @@ pub fn test_type_directive() {
         .finish();
 
     let sdl = schema.sdl_with_options(SDLExportOptions::new().federation().compose_directive());
-    println!("{}", sdl)
+
+    let expected = include_str!("schemas/test_fed2_compose.schema.graphql");
+    assert_eq!(expected, &sdl)
 }


### PR DESCRIPTION
Currently `async_graphql` supports only "execution" type directives (which can be specified on query fields) and provided function is called during query execution.

There is another type of directives supported by grapqhl spec - type system directives, which simply acts like type level decorators http://spec.graphql.org/June2018/#TypeSystemDirectiveLocation

Although those type of directives doesn't (and shouldn't) alter the behaviour of library itself, but its a powerful tool to communicate additional metadata to schema introspectors and with @composeDirective support, it can be used in various ways to communicate meta type info to supergraph routers etc.

The alternative way would be reuse already available @tag directives, limitation being that the value of tag is just a string which lacks further syntax check etc.

This PR proposes new proc macro `TypeDirective` which is similar to currently implemented `Directive` and is also is applied to rust functions. The difference is that function is used to generate arguments for directive definition, and later can be called on graphql construct to generate actual directive "invocation". Example:
```rust
    #[TypeDirective(
        location = "fielddefinition",
        location = "object",
    )]
    fn testDirective(scope: String, input: u32, opt: Option<u64>) {}
```
will result in following defintion on generated SDL schema:
```
directive @testDirective(scope: String!, input: Int!, opt: Int) on FIELD_DEFINITION | OBJECT
```
and can be invoked on object or field level like this:
```rust
    struct Query;
    ...
    #[Object(
        directive = testDirective::apply("object type".to_string(), 3, None),
    )]
    impl Query {
        #[graphql(
        directive = testDirective::apply("object field".to_string(), 4, None),
        ]
        async fn value(&self) -> &'static str {
            "abc"
        }
    }
```
which will result in the following SDL fragment:
```
type Query @testDirective(scope: "object type", input: 3) {
	value: String! @testDirective(scope: "object field", input: 4) @noArgsDirective
}
```
This allows to a nice way to extend grapqhl schema with additional metadata information.
Another powerful feature which is defined by apollo federation v2.1 is @composeDirective, which essentially says that any directives which need to be preserved on supergraph composition need to be declared with @composeDirective.
In order to achieve that two additional things need to be done on TypeDirective level and on SDL export options:
```rust
// enable composeDirective support
SDLExportOptions::new().federation().compose_directive();
```
and on TypeDirective additional property is requred:
```rust
    #[TypeDirective(
        location = "fielddefinition",
        location = "object",
        composable = "https://custom.spec.dev/extension/v1.0"
    )]
    fn testDirective(scope: String, input: u32, opt: Option<u64>) {}
```
composable property needs to contain strict URL with at least two path segments (last is always semver style version like v1.0) or apollo federation supergraph checks will fail.
The addtions above will result in additional schema fragment, which basically exposes directive as composable and is preserved in supergraph construction:
```
extend schema @link(
	url: "https://custom.spec.dev/extension/v1.0"
	import: ["@testDirective"]
)
	@composeDirective(name: "@testDirective")
```
Different type directives can contain different compose extension urls - they will be grouped accordingly.

Limitations:
Currently this PR supporst only OBJECT and FIELD_DEFINITION locations, to keep the scope a bit smaller, but support for other grapqhl constructs can be added easily in the future.

Questions:
- which name is better TypeDirective or SchemaDirective for macro?
- it is possible to call function directly instead of directive::apply(...) style but since we generate a struct under the hood which we register as directive in that case we need a separate name for struct itself i.e:
```rust
#[TypeDirective]
fn something(...)
```
and invocation can be 
```rust
directive=something(...)
```
But the struct can be named as `somethingDirective` and registered as `schema.type_directive(somethingDirective)`. For me this might feel a little bit more natural, but generates two objects instead of one (currently apply function is a method inside struct).