### PR TITLE
Add support for generic structs derriving InputObject and SimpleObject

### DIFF
--- a/derive/src/input_object.rs
+++ b/derive/src/input_object.rs
@@ -294,7 +294,7 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
         code.push(quote! {
             #[allow(clippy::all, clippy::pedantic)]
             impl #impl_generics #ident #ty_generics #where_clause {
-                fn __internal_create_type_info(registry: &mut #crate_name::registry::Registry, name: &str) -> ::std::string::String where Self: #crate_name::InputType {
+                fn __internal_create_type_info_input_object(registry: &mut #crate_name::registry::Registry, name: &str) -> ::std::string::String where Self: #crate_name::InputType {
                     registry.create_input_type::<Self, _>(#crate_name::registry::MetaTypeId::InputObject, |registry| #crate_name::registry::MetaType::InputObject {
                         name: ::std::borrow::ToOwned::to_owned(name),
                         description: #desc,
@@ -349,7 +349,7 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
                     }
 
                     fn create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
-                        Self::__internal_create_type_info(registry, #gql_typename)
+                        Self::__internal_create_type_info_input_object(registry, #gql_typename)
                     }
 
                     fn parse(value: ::std::option::Option<#crate_name::Value>) -> #crate_name::InputValueResult<Self> {

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -420,7 +420,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
             impl #impl_generics #ident #ty_generics #where_clause {
                 #(#getters)*
 
-                fn __internal_create_type_info(
+                fn __internal_create_type_info_simple_object(
                     registry: &mut #crate_name::registry::Registry,
                     name: &str,
                     complex_fields: #crate_name::indexmap::IndexMap<::std::string::String, #crate_name::registry::MetaField>,
@@ -479,7 +479,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                     fn create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
                         let mut fields = #crate_name::indexmap::IndexMap::new();
                         #concat_complex_fields
-                        Self::__internal_create_type_info(registry, #gql_typename, fields)
+                        Self::__internal_create_type_info_simple_object(registry, #gql_typename, fields)
                     }
 
                     async fn resolve(&self, ctx: &#crate_name::ContextSelectionSet<'_>, _field: &#crate_name::Positioned<#crate_name::parser::types::Field>) -> #crate_name::ServerResult<#crate_name::Value> {


### PR DESCRIPTION
## Description
Allows for generic structs which derive `SimpleObject` and `InputObject` to compile. For example:
```rs
#[derive(SimpleObject, InputObject)]
#[graphql(concrete(name = "MyObjectU32", params(u32)))]
#[graphql(concrete(name = "MyObjectString", params(String)))]
#[allow(dead_code)]
struct MyObject<T: InputType + OutputType> {
    a: T
}
```

Currently, this code generates the following error:
```rs
error[E0592]: duplicate definitions with name `__internal_create_type_info`
   --> tests/input_object.rs:412:14
    |
412 |     #[derive(SimpleObject, InputObject)]
    |              ^^^^^^^^^^^^  ----------- other definition for `__internal_create_type_info`
    |              |
    |              duplicate definitions for `__internal_create_type_info`
```

Please note that I have very little experience with this codebase outside of the public interface.

