### PR TITLE
Remove ::default() for unit structs

### DIFF
--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -72,7 +72,7 @@ pub fn check_rules(
                 .with(rules::PossibleFragmentSpreads::default())
                 .with(rules::ProvidedNonNullArguments)
                 .with(rules::KnownDirectives::default())
-                .with(rules::DirectivesUnique::default())
+                .with(rules::DirectivesUnique)
                 .with(rules::OverlappingFieldsCanBeMerged)
                 .with(rules::UploadFile)
                 .with(visitors::CacheControlCalculate {

--- a/src/validation/rules/known_fragment_names.rs
+++ b/src/validation/rules/known_fragment_names.rs
@@ -30,7 +30,7 @@ mod tests {
     use super::*;
 
     pub fn factory() -> KnownFragmentNames {
-        KnownFragmentNames::default()
+        KnownFragmentNames
     }
 
     #[test]

--- a/src/validation/rules/known_type_names.rs
+++ b/src/validation/rules/known_type_names.rs
@@ -58,7 +58,7 @@ mod tests {
     use super::*;
 
     pub fn factory() -> KnownTypeNames {
-        KnownTypeNames::default()
+        KnownTypeNames
     }
 
     #[test]


### PR DESCRIPTION
This lint was added to Clippy in Rust 1.71.0, and is currently failing on master.

https://rust-lang.github.io/rust-clippy/master/index.html#/default_constructed_unit_structs