### PR TITLE
Bump `indexmap` to `^2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `syn` from `1.0` to `2.0`
 - Bump `darling` from `0.14` to `0.20`
+- Bump `indexmap` from `1.6.2` to `2`
 - Attributes `guard`, `process_with`, `complexity` support expression or string as value [#1295](https://github.com/async-graphql/async-graphql/issues/1295)
 - Schema (type) level directive support with optional support of federation composeDirective [#1308](https://github.com/async-graphql/async-graphql/pull/1308)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ async-graphql-value = { path = "value", version = "5.0.10" }
 
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
-indexmap = { version = "1.6.2", features = ["serde"] }
+indexmap = { version = "2", features = ["serde"] }
 bytes = { version = "1.0.1", features = ["serde"] }
 thiserror = "1.0.24"
 async-trait = "0.1.51"


### PR DESCRIPTION
As far as I can tell, no code changes are required.

I added this to the release notes for `6.0.0`, but I don't think this requires a major versjon bump, so feel free to include it in a minor release.