### PR TITLE
fix: fix incorrect sdl optionality with schema defaults

### DIFF
--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -245,6 +245,7 @@ pub fn generate(
                     .map(|s| quote! {::std::option::Option::Some(::std::string::ToString::to_string(#s))})
                     .unwrap_or_else(|| quote! {::std::option::Option::None});
                 let default = generate_default(default, default_with)?;
+                let has_schema_default = default.is_some();
                 let schema_default = default
                     .as_ref()
                     .map(|value| {
@@ -265,7 +266,7 @@ pub fn generate(
                         args.insert(::std::borrow::ToOwned::to_owned(#name), #crate_name::registry::MetaInputValue {
                             name: ::std::string::ToString::to_string(#name),
                             description: #desc,
-                            ty: <#ty as #crate_name::InputType>::create_type_info(registry),
+                            ty: <#ty as #crate_name::InputType>::create_type_info(registry, #has_schema_default),
                             default_value: #schema_default,
                             visible: #visible,
                             inaccessible: #inaccessible,

--- a/derive/src/directive.rs
+++ b/derive/src/directive.rs
@@ -75,6 +75,7 @@ pub fn generate(
             .map(|s| quote! {::std::option::Option::Some(::std::string::ToString::to_string(#s))})
             .unwrap_or_else(|| quote! {::std::option::Option::None});
         let default = generate_default(&default, &default_with)?;
+        let has_schema_default = default.is_some();
         let schema_default = default
             .as_ref()
             .map(|value| {
@@ -91,7 +92,7 @@ pub fn generate(
             args.insert(::std::borrow::ToOwned::to_owned(#name), #crate_name::registry::MetaInputValue {
                 name: ::std::string::ToString::to_string(#name),
                 description: #desc,
-                ty: <#arg_ty as #crate_name::InputType>::create_type_info(registry),
+                ty: <#arg_ty as #crate_name::InputType>::create_type_info(registry, #has_schema_default),
                 default_value: #schema_default,
                 visible: #visible,
                 inaccessible: false,

--- a/derive/src/enum.rs
+++ b/derive/src/enum.rs
@@ -145,7 +145,7 @@ pub fn generate(enum_args: &args::Enum) -> GeneratorResult<TokenStream> {
                 #gql_typename
             }
 
-            fn __create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
+            fn __create_type_info(registry: &mut #crate_name::registry::Registry, has_schema_default: bool) -> ::std::string::String {
                 registry.create_input_type::<Self, _>(#crate_name::registry::MetaTypeId::Enum, |registry| {
                     #crate_name::registry::MetaType::Enum {
                         name: ::std::borrow::Cow::into_owned(#gql_typename),
@@ -155,6 +155,7 @@ pub fn generate(enum_args: &args::Enum) -> GeneratorResult<TokenStream> {
                             #(#schema_enum_items)*
                             enum_items
                         },
+                        has_schema_default,
                         visible: #visible,
                         inaccessible: #inaccessible,
                         tags: ::std::vec![ #(#tags),* ],
@@ -172,8 +173,8 @@ pub fn generate(enum_args: &args::Enum) -> GeneratorResult<TokenStream> {
                 Self::__type_name()
             }
 
-            fn create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
-                Self::__create_type_info(registry)
+            fn create_type_info(registry: &mut #crate_name::registry::Registry, has_schema_default: bool) -> ::std::string::String {
+                Self::__create_type_info(registry, has_schema_default)
             }
 
             fn parse(value: ::std::option::Option<#crate_name::Value>) -> #crate_name::InputValueResult<Self> {
@@ -196,7 +197,7 @@ pub fn generate(enum_args: &args::Enum) -> GeneratorResult<TokenStream> {
             }
 
             fn create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
-                Self::__create_type_info(registry)
+                Self::__create_type_info(registry, false)
             }
 
             async fn resolve(&self, _: &#crate_name::ContextSelectionSet<'_>, _field: &#crate_name::Positioned<#crate_name::parser::types::Field>) -> #crate_name::ServerResult<#crate_name::Value> {

--- a/derive/src/input_object.rs
+++ b/derive/src/input_object.rs
@@ -103,12 +103,28 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
                 Some(quote!(.map_err(#crate_name::InputValueError::propagate))),
             )?;
 
+        let desc = get_rustdoc(&field.attrs)?
+            .map(|s| quote! { ::std::option::Option::Some(::std::string::ToString::to_string(#s)) })
+            .unwrap_or_else(|| quote! {::std::option::Option::None});
+        let default = generate_default(&field.default, &field.default_with)?;
+        let has_schema_default = default.is_some();
+        let schema_default = default
+            .as_ref()
+            .map(|value| {
+                quote! {
+                    ::std::option::Option::Some(::std::string::ToString::to_string(
+                        &<#ty as #crate_name::InputType>::to_value(&#value)
+                    ))
+                }
+            })
+            .unwrap_or_else(|| quote!(::std::option::Option::None));
+
         if field.flatten {
             flatten_fields.push((ident, ty));
 
             schema_fields.push(quote! {
                 #crate_name::static_assertions::assert_impl_one!(#ty: #crate_name::InputObjectType);
-                <#ty as  #crate_name::InputType>::create_type_info(registry);
+                <#ty as  #crate_name::InputType>::create_type_info(registry, has_schema_default);
                 if let #crate_name::registry::MetaType::InputObject { input_fields, .. } =
                     registry.create_fake_input_type::<#ty>() {
                     fields.extend(input_fields);
@@ -134,22 +150,7 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
             continue;
         }
 
-        let desc = get_rustdoc(&field.attrs)?
-            .map(|s| quote! { ::std::option::Option::Some(::std::string::ToString::to_string(#s)) })
-            .unwrap_or_else(|| quote! {::std::option::Option::None});
-        let default = generate_default(&field.default, &field.default_with)?;
-        let schema_default = default
-            .as_ref()
-            .map(|value| {
-                quote! {
-                    ::std::option::Option::Some(::std::string::ToString::to_string(
-                        &<#ty as #crate_name::InputType>::to_value(&#value)
-                    ))
-                }
-            })
-            .unwrap_or_else(|| quote!(::std::option::Option::None));
         let secret = field.secret;
-
         if let Some(default) = default {
             get_fields.push(quote! {
                 #[allow(non_snake_case)]
@@ -187,11 +188,12 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
 
         fields.push(ident);
         let visible = visible_fn(&field.visible);
+
         schema_fields.push(quote! {
             fields.insert(::std::borrow::ToOwned::to_owned(#name), #crate_name::registry::MetaInputValue {
                 name: ::std::string::ToString::to_string(#name),
                 description: #desc,
-                ty: <#ty as #crate_name::InputType>::create_type_info(registry),
+                ty: <#ty as #crate_name::InputType>::create_type_info(registry, #has_schema_default),
                 default_value: #schema_default,
                 visible: #visible,
                 inaccessible: #inaccessible,
@@ -243,7 +245,7 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
                     #gql_typename
                 }
 
-                fn create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
+                fn create_type_info(registry: &mut #crate_name::registry::Registry, has_schema_default: bool) -> ::std::string::String {
                     registry.create_input_type::<Self, _>(#crate_name::registry::MetaTypeId::InputObject, |registry| #crate_name::registry::MetaType::InputObject {
                         name: ::std::borrow::Cow::into_owned(#gql_typename),
                         description: #desc,
@@ -252,6 +254,7 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
                             #(#schema_fields)*
                             fields
                         },
+                        has_schema_default,
                         visible: #visible,
                         inaccessible: #inaccessible,
                         tags: ::std::vec![ #(#tags),* ],
@@ -294,7 +297,7 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
         code.push(quote! {
             #[allow(clippy::all, clippy::pedantic)]
             impl #impl_generics #ident #ty_generics #where_clause {
-                fn __internal_create_type_info_input_object(registry: &mut #crate_name::registry::Registry, name: &str) -> ::std::string::String where Self: #crate_name::InputType {
+                fn __internal_create_type_info_input_object(registry: &mut #crate_name::registry::Registry, name: &str, has_schema_default: bool) -> ::std::string::String where Self: #crate_name::InputType {
                     registry.create_input_type::<Self, _>(#crate_name::registry::MetaTypeId::InputObject, |registry| #crate_name::registry::MetaType::InputObject {
                         name: ::std::borrow::ToOwned::to_owned(name),
                         description: #desc,
@@ -303,6 +306,7 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
                             #(#schema_fields)*
                             fields
                         },
+                        has_schema_default,
                         visible: #visible,
                         inaccessible: #inaccessible,
                         tags: ::std::vec![ #(#tags),* ],
@@ -338,7 +342,6 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
             let gql_typename = &concrete.name;
             let params = &concrete.params.0;
             let concrete_type = quote! { #ident<#(#params),*> };
-
             let expanded = quote! {
                 #[allow(clippy::all, clippy::pedantic)]
                 impl #crate_name::InputType for #concrete_type {
@@ -348,8 +351,8 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
                         ::std::borrow::Cow::Borrowed(#gql_typename)
                     }
 
-                    fn create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
-                        Self::__internal_create_type_info_input_object(registry, #gql_typename)
+                    fn create_type_info(registry: &mut #crate_name::registry::Registry, has_schema_default: bool) -> ::std::string::String {
+                        Self::__internal_create_type_info_input_object(registry, #gql_typename, has_schema_default)
                     }
 
                     fn parse(value: ::std::option::Option<#crate_name::Value>) -> #crate_name::InputValueResult<Self> {

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -212,6 +212,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
             use_params.push(quote! { #ident });
 
             let default = generate_default(default, default_with)?;
+            let has_schema_default = default.is_some();
             let get_default = match &default {
                 Some(default) => quote! { ::std::option::Option::Some(|| -> #ty { #default }) },
                 None => quote! { ::std::option::Option::None },
@@ -244,7 +245,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
                     args.insert(::std::borrow::ToOwned::to_owned(#name), #crate_name::registry::MetaInputValue {
                         name: ::std::string::ToString::to_string(#name),
                         description: #desc,
-                        ty: <#ty as #crate_name::InputType>::create_type_info(registry),
+                        ty: <#ty as #crate_name::InputType>::create_type_info(registry, #has_schema_default),
                         default_value: #schema_default,
                         visible: #visible,
                         inaccessible: #inaccessible,

--- a/derive/src/newtype.rs
+++ b/derive/src/newtype.rs
@@ -57,13 +57,14 @@ pub fn generate(newtype_args: &args::NewType) -> GeneratorResult<TokenStream> {
                 description: #desc,
                 is_valid: ::std::option::Option::Some(::std::sync::Arc::new(|value| <#ident as #crate_name::ScalarType>::is_valid(value))),
                 visible: #visible,
+                has_schema_default: false,
                 inaccessible: #inaccessible,
                 tags: ::std::vec![ #(#tags),* ],
                 specified_by_url: #specified_by_url,
             })
         }
     } else {
-        quote! { <#inner_ty as #crate_name::InputType>::create_type_info(registry) }
+        quote! { <#inner_ty as #crate_name::InputType>::create_type_info(registry, false) }
     };
 
     let expanded = quote! {
@@ -99,7 +100,7 @@ pub fn generate(newtype_args: &args::NewType) -> GeneratorResult<TokenStream> {
                 #type_name
             }
 
-            fn create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
+            fn create_type_info(registry: &mut #crate_name::registry::Registry, has_schema_default: bool) -> ::std::string::String {
                 #create_type_info
             }
 

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -403,6 +403,7 @@ pub fn generate(
                         .map(|s| quote! {::std::option::Option::Some(::std::string::ToString::to_string(#s))})
                         .unwrap_or_else(|| quote! {::std::option::Option::None});
                     let default = generate_default(default, default_with)?;
+                    let has_schema_default = default.is_some();
                     let schema_default = default
                         .as_ref()
                         .map(|value| {
@@ -424,7 +425,7 @@ pub fn generate(
                             args.insert(::std::borrow::ToOwned::to_owned(#name), #crate_name::registry::MetaInputValue {
                                 name: ::std::string::ToString::to_string(#name),
                                 description: #desc,
-                                ty: <#ty as #crate_name::InputType>::create_type_info(registry),
+                                ty: <#ty as #crate_name::InputType>::create_type_info(registry, #has_schema_default),
                                 default_value: #schema_default,
                                 visible: #visible,
                                 inaccessible: #inaccessible,

--- a/derive/src/oneof_object.rs
+++ b/derive/src/oneof_object.rs
@@ -95,7 +95,7 @@ pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream>
                 fields.insert(::std::borrow::ToOwned::to_owned(#field_name), #crate_name::registry::MetaInputValue {
                     name: ::std::string::ToString::to_string(#field_name),
                     description: #desc,
-                    ty: <::std::option::Option<#ty> as #crate_name::InputType>::create_type_info(registry),
+                    ty: <::std::option::Option<#ty> as #crate_name::InputType>::create_type_info(registry, false),
                     default_value: ::std::option::Option::None,
                     visible: #visible,
                     inaccessible: #inaccessible,
@@ -142,7 +142,7 @@ pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream>
                     #gql_typename
                 }
 
-                fn create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
+                fn create_type_info(registry: &mut #crate_name::registry::Registry, has_schema_default: bool) -> ::std::string::String {
                     registry.create_input_type::<Self, _>(#crate_name::registry::MetaTypeId::InputObject, |registry| #crate_name::registry::MetaType::InputObject {
                         name: ::std::borrow::Cow::into_owned(#gql_typename),
                         description: #desc,
@@ -152,6 +152,7 @@ pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream>
                             fields
                         },
                         visible: #visible,
+                        has_schema_default,
                         inaccessible: #inaccessible,
                         tags: ::std::vec![ #(#tags),* ],
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
@@ -194,7 +195,7 @@ pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream>
         code.push(quote! {
             #[allow(clippy::all, clippy::pedantic)]
             impl #impl_generics #ident #ty_generics #where_clause {
-                fn __internal_create_type_info(registry: &mut #crate_name::registry::Registry, name: &str) -> ::std::string::String where Self: #crate_name::InputType {
+                fn __internal_create_type_info(registry: &mut #crate_name::registry::Registry, name: &str, has_schema_default: bool) -> ::std::string::String where Self: #crate_name::InputType {
                     registry.create_input_type::<Self, _>(#crate_name::registry::MetaTypeId::InputObject, |registry| #crate_name::registry::MetaType::InputObject {
                         name: ::std::borrow::ToOwned::to_owned(name),
                         description: #desc,
@@ -203,6 +204,7 @@ pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream>
                             #(#schema_fields)*
                             fields
                         },
+                        has_schema_default,
                         visible: #visible,
                         inaccessible: #inaccessible,
                         tags: ::std::vec![ #(#tags),* ],
@@ -244,8 +246,8 @@ pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream>
                         ::std::borrow::Cow::Borrowed(#gql_typename)
                     }
 
-                    fn create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
-                        Self::__internal_create_type_info(registry, #gql_typename)
+                    fn create_type_info(registry: &mut #crate_name::registry::Registry, has_schema_default: bool) -> ::std::string::String {
+                        Self::__internal_create_type_info(registry, #gql_typename, has_schema_default)
                     }
 
                     fn parse(value: ::std::option::Option<#crate_name::Value>) -> #crate_name::InputValueResult<Self> {

--- a/derive/src/scalar.rs
+++ b/derive/src/scalar.rs
@@ -59,11 +59,12 @@ pub fn generate(
                 #gql_typename
             }
 
-            fn create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
+            fn create_type_info(registry: &mut #crate_name::registry::Registry, has_schema_default: bool) -> ::std::string::String {
                 registry.create_input_type::<#self_ty, _>(#crate_name::registry::MetaTypeId::Scalar, |_| #crate_name::registry::MetaType::Scalar {
                     name: ::std::borrow::Cow::into_owned(#gql_typename),
                     description: #desc,
                     is_valid: ::std::option::Option::Some(::std::sync::Arc::new(|value| <#self_ty as #crate_name::ScalarType>::is_valid(value))),
+                    has_schema_default,
                     visible: #visible,
                     inaccessible: #inaccessible,
                     tags: ::std::vec![ #(#tags),* ],
@@ -96,6 +97,7 @@ pub fn generate(
                     name: ::std::borrow::Cow::into_owned(#gql_typename),
                     description: #desc,
                     is_valid: ::std::option::Option::Some(::std::sync::Arc::new(|value| <#self_ty as #crate_name::ScalarType>::is_valid(value))),
+                    has_schema_default: false,
                     visible: #visible,
                     inaccessible: #inaccessible,
                     tags: ::std::vec![ #(#tags),* ],

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -104,7 +104,7 @@ pub fn generate(
                     .map(|s| quote! {::std::option::Option::Some(::std::string::ToString::to_string(#s))})
                     .unwrap_or_else(|| quote! {::std::option::Option::None});
                 let default = generate_default(default, default_with)?;
-
+                let has_schema_default = default.is_some();
                 let schema_default = default
                     .as_ref()
                     .map(|value| {
@@ -121,7 +121,7 @@ pub fn generate(
                     args.insert(::std::borrow::ToOwned::to_owned(#name), #crate_name::registry::MetaInputValue {
                             name: ::std::string::ToString::to_string(#name),
                             description: #desc,
-                            ty: <#ty as #crate_name::InputType>::create_type_info(registry),
+                            ty: <#ty as #crate_name::InputType>::create_type_info(registry, #has_schema_default),
                             default_value: #schema_default,
                             visible: #visible,
                             inaccessible: false,

--- a/derive/src/type_directive.rs
+++ b/derive/src/type_directive.rs
@@ -79,6 +79,7 @@ pub fn generate(
             .map(|s| quote! {::std::option::Option::Some(::std::string::ToString::to_string(#s))})
             .unwrap_or_else(|| quote! {::std::option::Option::None});
         let default = generate_default(&default, &default_with)?;
+        let has_schema_default = default.is_some();
         let schema_default = default
             .as_ref()
             .map(|value| {
@@ -95,7 +96,7 @@ pub fn generate(
             args.insert(::std::borrow::ToOwned::to_owned(#name), #crate_name::registry::MetaInputValue {
                 name: ::std::string::ToString::to_string(#name),
                 description: #desc,
-                ty: <#arg_ty as #crate_name::InputType>::create_type_info(registry),
+                ty: <#arg_ty as #crate_name::InputType>::create_type_info(registry, #has_schema_default),
                 default_value: #schema_default,
                 visible: #visible,
                 inaccessible: false,

--- a/src/base.rs
+++ b/src/base.rs
@@ -40,8 +40,13 @@ pub trait InputType: Send + Sync + Sized {
         format!("{}!", Self::type_name())
     }
 
+    /// Optional version of the Qualified typename
+    fn qualified_type_name_optional() -> String {
+        Self::type_name().to_string()
+    }
+
     /// Create type information in the registry and return qualified typename.
-    fn create_type_info(registry: &mut registry::Registry) -> String;
+    fn create_type_info(registry: &mut registry::Registry, has_schema_default: bool) -> String;
 
     /// Parse from `Value`. None represents undefined.
     fn parse(value: Option<Value>) -> InputValueResult<Self>;
@@ -185,8 +190,8 @@ impl<T: InputType> InputType for Box<T> {
         T::type_name()
     }
 
-    fn create_type_info(registry: &mut Registry) -> String {
-        T::create_type_info(registry)
+    fn create_type_info(registry: &mut Registry, has_schema_default: bool) -> String {
+        T::create_type_info(registry, has_schema_default)
     }
 
     fn parse(value: Option<ConstValue>) -> InputValueResult<Self> {
@@ -231,8 +236,8 @@ impl<T: InputType> InputType for Arc<T> {
         T::type_name()
     }
 
-    fn create_type_info(registry: &mut Registry) -> String {
-        T::create_type_info(registry)
+    fn create_type_info(registry: &mut Registry, has_schema_default: bool) -> String {
+        T::create_type_info(registry, has_schema_default)
     }
 
     fn parse(value: Option<ConstValue>) -> InputValueResult<Self> {

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -265,6 +265,7 @@ impl MetaTypeId {
                 name: "".to_string(),
                 description: None,
                 is_valid: None,
+                has_schema_default: false,
                 visible: None,
                 inaccessible: false,
                 tags: vec![],
@@ -310,6 +311,7 @@ impl MetaTypeId {
                 name: "".to_string(),
                 description: None,
                 enum_values: Default::default(),
+                has_schema_default: false,
                 visible: None,
                 inaccessible: false,
                 tags: vec![],
@@ -319,6 +321,7 @@ impl MetaTypeId {
                 name: "".to_string(),
                 description: None,
                 input_fields: Default::default(),
+                has_schema_default: false,
                 visible: None,
                 inaccessible: false,
                 tags: vec![],
@@ -358,6 +361,8 @@ pub enum MetaType {
         description: Option<String>,
         /// A function that uses to check if the scalar is valid
         is_valid: Option<ScalarValidatorFn>,
+        /// Whether or not the scalar is associated with any schema-defined defaults.
+        has_schema_default: bool,
         /// A function that uses to check if the scalar should be exported to
         /// schemas
         visible: Option<MetaVisibleFn>,
@@ -505,6 +510,8 @@ pub enum MetaType {
         description: Option<String>,
         /// The values of the enum
         enum_values: IndexMap<String, MetaEnumValue>,
+        /// Whether or not the Enum is associated with any schema-defined defaults.
+        has_schema_default: bool,
         /// A function that uses to check if the enum should be exported to
         /// schemas
         visible: Option<MetaVisibleFn>,
@@ -534,6 +541,8 @@ pub enum MetaType {
         /// A function that uses to check if the input object should be exported
         /// to schemas
         visible: Option<MetaVisibleFn>,
+        /// Whether or not the input object is associated with any schema-defined defaults.
+        has_schema_default: bool,
         /// Indicate that a input object is not accessible from a supergraph
         /// when using Apollo Federation
         ///
@@ -786,11 +795,11 @@ impl Registry {
         });
 
         // create system scalars
-        <bool as InputType>::create_type_info(self);
-        <i32 as InputType>::create_type_info(self);
-        <f32 as InputType>::create_type_info(self);
-        <String as InputType>::create_type_info(self);
-        <ID as InputType>::create_type_info(self);
+        <bool as InputType>::create_type_info(self, false);
+        <i32 as InputType>::create_type_info(self, false);
+        <f32 as InputType>::create_type_info(self, false);
+        <String as InputType>::create_type_info(self, false);
+        <ID as InputType>::create_type_info(self, false);
     }
 
     pub fn create_input_type<T, F>(&mut self, type_id: MetaTypeId, mut f: F) -> String
@@ -798,8 +807,26 @@ impl Registry {
         T: InputType + ?Sized,
         F: FnMut(&mut Registry) -> MetaType,
     {
+        let has_schema_default = match f(self) {
+            MetaType::InputObject {
+                has_schema_default, ..
+            } => has_schema_default,
+            MetaType::Scalar {
+                has_schema_default, ..
+            } => has_schema_default,
+            MetaType::Enum {
+                has_schema_default, ..
+            } => has_schema_default,
+            _ => false,
+        };
+
         self.create_type(&mut f, &T::type_name(), std::any::type_name::<T>(), type_id);
-        T::qualified_type_name()
+
+        if has_schema_default {
+            T::qualified_type_name_optional()
+        } else {
+            T::qualified_type_name()
+        }
     }
 
     pub fn create_output_type<T, F>(&mut self, type_id: MetaTypeId, mut f: F) -> String
@@ -877,7 +904,7 @@ impl Registry {
     }
 
     pub fn create_fake_input_type<T: InputType>(&mut self) -> MetaType {
-        T::create_type_info(self);
+        T::create_type_info(self, false);
         self.types
             .get(&*T::type_name())
             .cloned()
@@ -1117,7 +1144,7 @@ impl Registry {
     }
 
     pub(crate) fn create_federation_types(&mut self) {
-        <Any as InputType>::create_type_info(self);
+        <Any as InputType>::create_type_info(self, false);
 
         self.types.insert(
             "_Service".to_string(),

--- a/src/resolver_utils/scalar.rs
+++ b/src/resolver_utils/scalar.rs
@@ -157,6 +157,7 @@ macro_rules! scalar_internal {
 
             fn create_type_info(
                 registry: &mut $crate::registry::Registry,
+                has_schema_default: bool,
             ) -> ::std::string::String {
                 registry.create_input_type::<$ty, _>($crate::registry::MetaTypeId::Scalar, |_| {
                     $crate::registry::MetaType::Scalar {
@@ -165,6 +166,7 @@ macro_rules! scalar_internal {
                         is_valid: ::std::option::Option::Some(::std::sync::Arc::new(|value| {
                             <$ty as $crate::ScalarType>::is_valid(value)
                         })),
+                        has_schema_default,
                         visible: ::std::option::Option::None,
                         inaccessible: false,
                         tags: ::std::default::Default::default(),
@@ -204,6 +206,7 @@ macro_rules! scalar_internal {
                         is_valid: ::std::option::Option::Some(::std::sync::Arc::new(|value| {
                             <$ty as $crate::ScalarType>::is_valid(value)
                         })),
+                        has_schema_default: false,
                         visible: ::std::option::Option::None,
                         inaccessible: false,
                         tags: ::std::default::Default::default(),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -60,8 +60,8 @@ impl<Query, Mutation, Subscription> SchemaBuilder<Query, Mutation, Subscription>
     /// You can use this function to register schema types that are not directly
     /// referenced.
     #[must_use]
-    pub fn register_input_type<T: InputType>(mut self) -> Self {
-        T::create_type_info(&mut self.registry);
+    pub fn register_input_type<T: InputType>(mut self, has_schema_default: bool) -> Self {
+        T::create_type_info(&mut self.registry, has_schema_default);
         self
     }
 

--- a/src/types/connection/mod.rs
+++ b/src/types/connection/mod.rs
@@ -258,7 +258,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// 
+///
 /// use async_graphql::*;
 /// use async_graphql::types::connection::*;
 ///

--- a/src/types/external/json_object/btreemap.rs
+++ b/src/types/external/json_object/btreemap.rs
@@ -23,10 +23,11 @@ where
         Cow::Borrowed("JSONObject")
     }
 
-    fn create_type_info(registry: &mut Registry) -> String {
+    fn create_type_info(registry: &mut Registry, has_schema_default: bool) -> String {
         registry.create_input_type::<Self, _>(MetaTypeId::Scalar, |_| MetaType::Scalar {
             name: <Self as InputType>::type_name().to_string(),
             description: Some("A scalar that can represent any JSON Object value.".to_string()),
+            has_schema_default,
             is_valid: None,
             visible: None,
             inaccessible: false,
@@ -84,6 +85,7 @@ where
         registry.create_output_type::<Self, _>(MetaTypeId::Scalar, |_| MetaType::Scalar {
             name: <Self as OutputType>::type_name().to_string(),
             description: Some("A scalar that can represent any JSON Object value.".to_string()),
+            has_schema_default: false,
             is_valid: None,
             visible: None,
             inaccessible: false,

--- a/src/types/external/json_object/hashmap.rs
+++ b/src/types/external/json_object/hashmap.rs
@@ -30,10 +30,11 @@ where
         Cow::Borrowed("JSONObject")
     }
 
-    fn create_type_info(registry: &mut Registry) -> String {
+    fn create_type_info(registry: &mut Registry, has_schema_default: bool) -> String {
         registry.create_input_type::<Self, _>(MetaTypeId::Scalar, |_| MetaType::Scalar {
             name: <Self as InputType>::type_name().to_string(),
             description: Some("A scalar that can represent any JSON Object value.".to_string()),
+            has_schema_default,
             is_valid: None,
             visible: None,
             inaccessible: false,
@@ -92,6 +93,7 @@ where
         registry.create_output_type::<Self, _>(MetaTypeId::Scalar, |_| MetaType::Scalar {
             name: <Self as OutputType>::type_name().to_string(),
             description: Some("A scalar that can represent any JSON Object value.".to_string()),
+            has_schema_default: false,
             is_valid: None,
             visible: None,
             inaccessible: false,

--- a/src/types/external/list/array.rs
+++ b/src/types/external/list/array.rs
@@ -16,8 +16,8 @@ impl<T: InputType, const N: usize> InputType for [T; N] {
         format!("[{}]!", T::qualified_type_name())
     }
 
-    fn create_type_info(registry: &mut registry::Registry) -> String {
-        T::create_type_info(registry);
+    fn create_type_info(registry: &mut registry::Registry, has_schema_default: bool) -> String {
+        T::create_type_info(registry, has_schema_default);
         Self::qualified_type_name()
     }
 

--- a/src/types/external/list/btree_set.rs
+++ b/src/types/external/list/btree_set.rs
@@ -16,8 +16,8 @@ impl<T: InputType + Ord> InputType for BTreeSet<T> {
         format!("[{}]!", T::qualified_type_name())
     }
 
-    fn create_type_info(registry: &mut registry::Registry) -> String {
-        T::create_type_info(registry);
+    fn create_type_info(registry: &mut registry::Registry, has_schema_default: bool) -> String {
+        T::create_type_info(registry, has_schema_default);
         Self::qualified_type_name()
     }
 

--- a/src/types/external/list/hash_set.rs
+++ b/src/types/external/list/hash_set.rs
@@ -16,8 +16,8 @@ impl<T: InputType + Hash + Eq> InputType for HashSet<T> {
         format!("[{}]!", T::qualified_type_name())
     }
 
-    fn create_type_info(registry: &mut registry::Registry) -> String {
-        T::create_type_info(registry);
+    fn create_type_info(registry: &mut registry::Registry, has_schema_default: bool) -> String {
+        T::create_type_info(registry, has_schema_default);
         Self::qualified_type_name()
     }
 

--- a/src/types/external/list/linked_list.rs
+++ b/src/types/external/list/linked_list.rs
@@ -16,8 +16,8 @@ impl<T: InputType> InputType for LinkedList<T> {
         format!("[{}]!", T::qualified_type_name())
     }
 
-    fn create_type_info(registry: &mut registry::Registry) -> String {
-        T::create_type_info(registry);
+    fn create_type_info(registry: &mut registry::Registry, has_schema_default: bool) -> String {
+        T::create_type_info(registry, has_schema_default);
         Self::qualified_type_name()
     }
 

--- a/src/types/external/list/slice.rs
+++ b/src/types/external/list/slice.rs
@@ -73,8 +73,11 @@ macro_rules! impl_input_slice_for_smart_ptr {
                 format!("[{}]!", T::qualified_type_name())
             }
 
-            fn create_type_info(registry: &mut registry::Registry) -> String {
-                T::create_type_info(registry);
+            fn create_type_info(
+                registry: &mut registry::Registry,
+                has_schema_default: bool,
+            ) -> String {
+                T::create_type_info(registry, has_schema_default);
                 Self::qualified_type_name()
             }
 

--- a/src/types/external/list/vec.rs
+++ b/src/types/external/list/vec.rs
@@ -16,8 +16,8 @@ impl<T: InputType> InputType for Vec<T> {
         format!("[{}]!", T::qualified_type_name())
     }
 
-    fn create_type_info(registry: &mut registry::Registry) -> String {
-        T::create_type_info(registry);
+    fn create_type_info(registry: &mut registry::Registry, has_schema_default: bool) -> String {
+        T::create_type_info(registry, has_schema_default);
         Self::qualified_type_name()
     }
 

--- a/src/types/external/list/vec_deque.rs
+++ b/src/types/external/list/vec_deque.rs
@@ -16,8 +16,8 @@ impl<T: InputType> InputType for VecDeque<T> {
         format!("[{}]!", T::qualified_type_name())
     }
 
-    fn create_type_info(registry: &mut registry::Registry) -> String {
-        T::create_type_info(registry);
+    fn create_type_info(registry: &mut registry::Registry, has_schema_default: bool) -> String {
+        T::create_type_info(registry, has_schema_default);
         Self::qualified_type_name()
     }
 

--- a/src/types/external/optional.rs
+++ b/src/types/external/optional.rs
@@ -16,8 +16,8 @@ impl<T: InputType> InputType for Option<T> {
         T::type_name().to_string()
     }
 
-    fn create_type_info(registry: &mut registry::Registry) -> String {
-        T::create_type_info(registry);
+    fn create_type_info(registry: &mut registry::Registry, has_schema_default: bool) -> String {
+        T::create_type_info(registry, has_schema_default);
         T::type_name().to_string()
     }
 

--- a/src/types/external/string.rs
+++ b/src/types/external/string.rs
@@ -37,8 +37,8 @@ macro_rules! impl_input_string_for_smart_ptr {
                 Cow::Borrowed("String")
             }
 
-            fn create_type_info(registry: &mut Registry) -> String {
-                <String as OutputType>::create_type_info(registry)
+            fn create_type_info(registry: &mut Registry, has_schema_default: bool) -> String {
+                <String as InputType>::create_type_info(registry, has_schema_default)
             }
 
             fn parse(value: Option<Value>) -> InputValueResult<Self> {

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -48,10 +48,11 @@ impl<T: DeserializeOwned + Serialize + Send + Sync> InputType for Json<T> {
         Cow::Borrowed("JSON")
     }
 
-    fn create_type_info(registry: &mut Registry) -> String {
+    fn create_type_info(registry: &mut Registry, has_schema_default: bool) -> String {
         registry.create_input_type::<Json<T>, _>(MetaTypeId::Scalar, |_| MetaType::Scalar {
             name: <Self as InputType>::type_name().to_string(),
             description: Some("A scalar that can represent any JSON value.".to_string()),
+            has_schema_default,
             is_valid: None,
             visible: None,
             inaccessible: false,
@@ -84,6 +85,7 @@ impl<T: Serialize + Send + Sync> OutputType for Json<T> {
             name: <Self as OutputType>::type_name().to_string(),
             description: Some("A scalar that can represent any JSON value.".to_string()),
             is_valid: None,
+            has_schema_default: false,
             visible: None,
             inaccessible: false,
             tags: Default::default(),
@@ -107,12 +109,13 @@ impl InputType for serde_json::Value {
         Cow::Borrowed("JSON")
     }
 
-    fn create_type_info(registry: &mut Registry) -> String {
+    fn create_type_info(registry: &mut Registry, has_schema_default: bool) -> String {
         registry.create_input_type::<serde_json::Value, _>(MetaTypeId::Scalar, |_| {
             MetaType::Scalar {
                 name: <Self as InputType>::type_name().to_string(),
                 description: Some("A scalar that can represent any JSON value.".to_string()),
                 is_valid: None,
+                has_schema_default,
                 visible: None,
                 inaccessible: false,
                 tags: Default::default(),
@@ -146,6 +149,7 @@ impl OutputType for serde_json::Value {
                 name: <Self as OutputType>::type_name().to_string(),
                 description: Some("A scalar that can represent any JSON value.".to_string()),
                 is_valid: None,
+                has_schema_default: false,
                 visible: None,
                 inaccessible: false,
                 tags: Default::default(),

--- a/src/types/maybe_undefined.rs
+++ b/src/types/maybe_undefined.rs
@@ -214,8 +214,8 @@ impl<T: InputType> InputType for MaybeUndefined<T> {
         T::type_name().to_string()
     }
 
-    fn create_type_info(registry: &mut registry::Registry) -> String {
-        T::create_type_info(registry);
+    fn create_type_info(registry: &mut registry::Registry, has_schema_default: bool) -> String {
+        T::create_type_info(registry, has_schema_default);
         T::type_name().to_string()
     }
 

--- a/src/types/upload.rs
+++ b/src/types/upload.rs
@@ -147,12 +147,13 @@ impl InputType for Upload {
         Cow::Borrowed("Upload")
     }
 
-    fn create_type_info(registry: &mut registry::Registry) -> String {
+    fn create_type_info(registry: &mut registry::Registry, has_schema_default: bool) -> String {
         registry.create_input_type::<Self, _>(MetaTypeId::Scalar, |_| registry::MetaType::Scalar {
             name: Self::type_name().to_string(),
             description: None,
             is_valid: Some(Arc::new(|value| matches!(value, Value::String(_)))),
             visible: None,
+            has_schema_default,
             inaccessible: false,
             tags: Default::default(),
             specified_by_url: Some(

--- a/tests/oneof_object.rs
+++ b/tests/oneof_object.rs
@@ -199,7 +199,7 @@ async fn test_oneof_object_rename_fields() {
     }
 
     let mut registry = Registry::default();
-    MyInput::create_type_info(&mut registry);
+    MyInput::create_type_info(&mut registry, false);
 
     let ty: &MetaType = registry.types.get("MyInput").unwrap();
     match ty {
@@ -223,7 +223,7 @@ async fn test_oneof_object_rename_field() {
     }
 
     let mut registry = Registry::default();
-    MyInput::create_type_info(&mut registry);
+    MyInput::create_type_info(&mut registry, false);
 
     let ty: &MetaType = registry.types.get("MyInput").unwrap();
     match ty {

--- a/tests/sdl_export.rs
+++ b/tests/sdl_export.rs
@@ -1,0 +1,79 @@
+use async_graphql::*;
+
+#[tokio::test]
+pub async fn test_schema_defaults_sdl_export() {
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn sample(&self, _input: SampleInput) -> i32 {
+            1
+        }
+    }
+
+    #[derive(InputObject)]
+    struct SampleNestedInputObject {
+        #[graphql(default = "DEFAULT STRING")]
+        nested_input_1: String,
+        #[graphql(default = true)]
+        nested_input_2: bool,
+    }
+
+    fn default_input_object() -> SampleNestedInputObject {
+        SampleNestedInputObject {
+            nested_input_1: "Hello".to_string(),
+            nested_input_2: false,
+        }
+    }
+
+    #[derive(InputObject)]
+    struct SampleInput {
+        required_input: i32,
+
+        #[graphql(default = 1)]
+        optional_input_defaulted: i32,
+
+        truly_optional_input: Option<i32>,
+
+        #[graphql(default_with = "default_input_object()")]
+        optional_object_defaulted: SampleNestedInputObject,
+
+        truly_optional_object: Option<SampleNestedInputObject>,
+    }
+
+    let schema = Schema::build(Query, EmptyMutation, EmptySubscription).finish();
+
+    let sdl_opts = SDLExportOptions::new().sorted_arguments().sorted_fields();
+
+    let sdl_output = schema.sdl_with_options(sdl_opts);
+
+    let expected_output = r#"
+
+
+
+type Query {
+    sample(input: SampleInput!): Int!
+}
+
+input SampleInput {
+    optionalInputDefaulted: Int = 1
+    optionalObjectDefaulted: SampleNestedInputObject = {nestedInput1: "Hello",nestedInput2: false}
+    requiredInput: Int!
+    trulyOptionalInput: Int
+    trulyOptionalObject: SampleNestedInputObject
+}
+
+input SampleNestedInputObject {
+    nestedInput1: String = "DEFAULT STRING"
+    nestedInput2: Boolean = true
+}
+
+
+schema {
+    query: Query
+}
+"#
+    .replace("    ", "\t");
+
+    assert_eq!(sdl_output, expected_output);
+}


### PR DESCRIPTION
Fixes: https://github.com/async-graphql/async-graphql/issues/1321

We need to know whether or not each type has a schema-default value in order to generate the SDL with correct optionality of fields. 

Say you have the following InputObject:
```
#[derive(InputObject)]
struct SampleInput {
    #[graphql(default = 1)]
    optional_input_defaulted: i32
}
```

The SDL currently generated by this is:
```
input SampleInput {
    optionalInputDefaulted: Int! = 1
}
```

Which means that callers are required to pass in a value `optionalInputDefaulted` as input, even though we are specifying that we are defaulting this value in the schema.

Then, in order to solve this issue, you would need to change your input object to the following:
```
#[derive(InputObject)]
struct SampleInput {
    #[graphql(default = 1)]
    optional_input_defaulted: Option<i32>
}
```

This generates the correct SDL of:
```
input SampleInput {
    optionalInputDefaulted: Int = 1
}
```
Which lets the caller make use of the defaulting behavior by not passing in a value.

----

By requiring types to be wrapped as Options even though they are being defaulted, we need to treat them as Options throughout the project, which is silly since we know that they are being defaulted and therefore are always `Some`. 

This change fixes that, by marking input fields with defaults as optional in the SDL.