### PR TITLE
Dataloader get_cached_values

### DIFF
--- a/src/dataloader/cache.rs
+++ b/src/dataloader/cache.rs
@@ -37,6 +37,9 @@ pub trait CacheStorage: Send + Sync + 'static {
 
     /// Clears the cache, removing all key-value pairs.
     fn clear(&mut self);
+
+    /// Returns an iterator over the key-value pairs in the cache.
+    fn iter(&self) -> Box<dyn Iterator<Item = (&'_ Self::Key, &'_ Self::Value)> + '_>;
 }
 
 /// No cache.
@@ -81,6 +84,10 @@ where
 
     #[inline]
     fn clear(&mut self) {}
+
+    fn iter(&self) -> Box<dyn Iterator<Item = (&'_ Self::Key, &'_ Self::Value)> + '_> {
+        Box::new(std::iter::empty())
+    }
 }
 
 /// [std::collections::HashMap] cache.
@@ -141,6 +148,10 @@ where
     fn clear(&mut self) {
         self.0.clear();
     }
+
+    fn iter(&self) -> Box<dyn Iterator<Item = (&'_ Self::Key, &'_ Self::Value)> + '_> {
+        Box::new(self.0.iter())
+    }
 }
 
 /// LRU cache.
@@ -193,5 +204,9 @@ where
     #[inline]
     fn clear(&mut self) {
         self.0.clear();
+    }
+
+    fn iter(&self) -> Box<dyn Iterator<Item = (&'_ Self::Key, &'_ Self::Value)> + '_> {
+        Box::new(self.0.iter())
     }
 }

--- a/src/dataloader/mod.rs
+++ b/src/dataloader/mod.rs
@@ -461,6 +461,27 @@ impl<T, C: CacheFactory> DataLoader<T, C> {
             .unwrap();
         typed_requests.cache_storage.clear();
     }
+
+    /// Gets all values in the cache.
+    pub fn get_cached_values<K>(&self) -> HashMap<K, T::Value>
+    where
+        K: Send + Sync + Hash + Eq + Clone + 'static,
+        T: Loader<K>,
+    {
+        let tid = TypeId::of::<K>();
+        let requests = self.inner.requests.lock().unwrap();
+        match requests.get(&tid) {
+            None => HashMap::new(),
+            Some(requests) => {
+                let typed_requests = requests.downcast_ref::<Requests<K, T>>().unwrap();
+                typed_requests
+                    .cache_storage
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect()
+            }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds a method to the dataloader cache so that callers can access the contents of the cache without knowing the keys.