### PR TITLE
Make TypeRefInner pub

### DIFF
--- a/src/dynamic/mod.rs
+++ b/src/dynamic/mod.rs
@@ -63,6 +63,6 @@ pub use request::{DynamicRequest, DynamicRequestExt};
 pub use scalar::Scalar;
 pub use schema::{Schema, SchemaBuilder};
 pub use subscription::{Subscription, SubscriptionField, SubscriptionFieldFuture};
-pub use type_ref::TypeRef;
+pub use type_ref::{TypeRef, TypeRefInner};
 pub use union::Union;
 pub use value_accessor::{ListAccessor, ObjectAccessor, ValueAccessor};

--- a/src/dynamic/type_ref.rs
+++ b/src/dynamic/type_ref.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub(crate) enum TypeRefInner {
+pub enum TypeRefInner {
     Named(Cow<'static, str>),
     NonNull(Box<TypeRefInner>),
     List(Box<TypeRefInner>),
@@ -32,7 +32,7 @@ impl TypeRefInner {
 
 /// A type reference
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct TypeRef(pub(crate) TypeRefInner);
+pub struct TypeRef(pub TypeRefInner);
 
 impl Display for TypeRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Previously I made a PR where I made another type in this file pub. The reason was I have some code that builds GraphQL values dynamically rather than building a schema and querying it. I need this to be public for the same reason.

This is an example of the code that needs the type to be public: https://gist.github.com/banool/e4cf4397fa24dca6a9214a33ef991295.