### PR TITLE
Added OutputType implementation for std::sync::Weak

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, sync::Arc, sync::Weak};
 
 use async_graphql_value::ConstValue;
 
@@ -247,6 +247,25 @@ impl<T: InputType> InputType for Arc<T> {
 
     fn as_raw_value(&self) -> Option<&Self::RawValueType> {
         self.as_ref().as_raw_value()
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: OutputType + ?Sized> OutputType for Weak<T> {
+    fn type_name() -> Cow<'static, str> {
+        <Option<Arc<T>> as OutputType>::type_name()
+    }
+
+    fn create_type_info(registry: &mut Registry) -> String {
+        <Option<Arc<T>> as OutputType>::create_type_info(registry)
+    }
+
+    async fn resolve(
+        &self,
+        ctx: &ContextSelectionSet<'_>,
+        field: &Positioned<Field>,
+    ) -> ServerResult<Value> {
+        self.upgrade().resolve(ctx, field).await
     }
 }
 


### PR DESCRIPTION
Hey, first of all thank you for your work on this great tool.
I found myself needing to use Weak pointers and noticed that there were no OutputType implementation for this, so I figured I'd contribute to the main repo.
I'm a Rust beginner, so any suggestion is more than welcome (or even if you think it doesn't make sense to add this here 🙂 )