### PR TITLE
Make `value` in `ValueAccessor` public

### DIFF
--- a/src/dynamic/value_accessor.rs
+++ b/src/dynamic/value_accessor.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use crate::{Error, Name, Result, Value};
 
 /// A value accessor
-pub struct ValueAccessor<'a>(&'a Value);
+pub struct ValueAccessor<'a>(pub &'a Value);
 
 impl<'a> ValueAccessor<'a> {
     /// Returns `true` if the value is null, otherwise returns `false`

--- a/src/dynamic/value_accessor.rs
+++ b/src/dynamic/value_accessor.rs
@@ -6,7 +6,7 @@ use serde::de::DeserializeOwned;
 use crate::{Error, Name, Result, Value};
 
 /// A value accessor
-pub struct ValueAccessor<'a>(pub &'a Value);
+pub struct ValueAccessor<'a>(&'a Value);
 
 impl<'a> ValueAccessor<'a> {
     /// Returns `true` if the value is null, otherwise returns `false`
@@ -208,5 +208,11 @@ impl<'a> ListAccessor<'a> {
         } else {
             Err(Error::new("internal: invalid slice indices"))
         }
+    }
+
+    /// Returns a reference to the underlying `Value`
+    #[inline]
+    pub fn as_value(&self) -> &Value {
+        self.0
     }
 }

--- a/src/dynamic/value_accessor.rs
+++ b/src/dynamic/value_accessor.rs
@@ -103,6 +103,12 @@ impl<'a> ValueAccessor<'a> {
     pub fn deserialize<T: DeserializeOwned>(&self) -> Result<T> {
         T::deserialize(self.0.clone()).map_err(|err| format!("internal: {}", err).into())
     }
+
+    /// Returns a reference to the underlying `Value`
+    #[inline]
+    pub fn as_value(&self) -> &'a Value {
+        self.0
+    }
 }
 
 /// A object accessor
@@ -210,9 +216,9 @@ impl<'a> ListAccessor<'a> {
         }
     }
 
-    /// Returns a reference to the underlying `Value`
+    /// Returns a reference to the underlying `&[Value]`
     #[inline]
-    pub fn as_value(&self) -> &Value {
+    pub fn as_values_slice(&self) -> &'a [Value] {
         self.0
     }
 }


### PR DESCRIPTION
This is usecase for us where we need to read the arguments as value without concerning about it's type. Eg

**Current Implementation**
```rust
fn get_arg<'a>(ctx: ResolverContext<'a>, name: String) -> &'a Value {
  let arg = ctx.args.get(name);

  // use a if-else ladder to check and convert from ValueAccessor to Value
  if let Ok(str) = arg..string() {
    Value::from(str).unwrap();
  } else if {
    // .. add more cases
  }
}
```

**Proposed Implementation**
```rust
fn get_arg<'a>(ctx: ResolverContext<'a>, name: String) -> &'a Value {
  ctx.args.get(name).0
}
```

This would be significantly faster for our usecase.