### PR TITLE
feat: support bigdecimal 0.4.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ opentelemetry = { version = "0.19.0", optional = true, default-features = false,
   "trace",
 ] }
 rust_decimal = { version = "1.14.3", optional = true }
-bigdecimal = { version = "0.3.0", optional = true }
+bigdecimal = { version = ">=0.3.0, <0.5.0", optional = true }
 secrecy = { version = "0.8.0", optional = true }
 smol_str = { version = "0.1.21", optional = true }
 time = { version = "0.3.5", optional = true, features = [


### PR DESCRIPTION
implements https://github.com/async-graphql/async-graphql/issues/1357 by allowing `bigdecimal` version `0.4.x`