### PR TITLE
Sendless futures

### DIFF
--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -444,7 +444,7 @@ pub fn generate(
         #item_impl
 
         #[allow(clippy::all, clippy::pedantic)]
-        #[#crate_name::async_trait::async_trait]
+        #[#crate_name::async_trait::async_trait(?Send)]
         impl #generics #crate_name::ComplexObject for #self_ty #where_clause {
             fn fields(registry: &mut #crate_name::registry::Registry) -> ::std::vec::Vec<(::std::string::String, #crate_name::registry::MetaField)> {
                 let mut fields = ::std::vec::Vec::new();

--- a/derive/src/directive.rs
+++ b/derive/src/directive.rs
@@ -141,7 +141,7 @@ pub fn generate(
         #[allow(non_camel_case_types)]
         #vis struct #ident;
 
-        #[#crate_name::async_trait::async_trait]
+        #[#crate_name::async_trait::async_trait(?Send)]
         impl #crate_name::CustomDirectiveFactory for #ident {
             fn name(&self) -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                 #directive_name

--- a/derive/src/enum.rs
+++ b/derive/src/enum.rs
@@ -189,7 +189,7 @@ pub fn generate(enum_args: &args::Enum) -> GeneratorResult<TokenStream> {
             }
         }
 
-        #[#crate_name::async_trait::async_trait]
+        #[#crate_name::async_trait::async_trait(?Send)]
         impl #crate_name::OutputType for #ident {
             fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                 Self::__type_name()

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -350,7 +350,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
         }
 
         #[allow(clippy::all, clippy::pedantic)]
-        #[#crate_name::async_trait::async_trait]
+        #[#crate_name::async_trait::async_trait(?Send)]
         impl #impl_generics #crate_name::resolver_utils::ContainerType for #ident #ty_generics #where_clause {
             async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::Value>> {
                 #(#resolvers)*
@@ -365,7 +365,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
         }
 
         #[allow(clippy::all, clippy::pedantic)]
-        #[#crate_name::async_trait::async_trait]
+        #[#crate_name::async_trait::async_trait(?Send)]
         impl #impl_generics #crate_name::OutputType for #ident #ty_generics #where_clause {
             fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                 #gql_typename

--- a/derive/src/merged_object.rs
+++ b/derive/src/merged_object.rs
@@ -80,7 +80,7 @@ pub fn generate(object_args: &args::MergedObject) -> GeneratorResult<TokenStream
 
     let expanded = quote! {
         #[allow(clippy::all, clippy::pedantic)]
-        #[#crate_name::async_trait::async_trait]
+        #[#crate_name::async_trait::async_trait(?Send)]
         impl #impl_generics #crate_name::resolver_utils::ContainerType for #ident #ty_generics #where_clause {
             async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::Value>> {
                 #create_merged_obj.resolve_field(ctx).await
@@ -92,7 +92,7 @@ pub fn generate(object_args: &args::MergedObject) -> GeneratorResult<TokenStream
         }
 
         #[allow(clippy::all, clippy::pedantic)]
-        #[#crate_name::async_trait::async_trait]
+        #[#crate_name::async_trait::async_trait(?Send)]
         impl #impl_generics #crate_name::OutputType for #ident #ty_generics #where_clause {
             fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                 #gql_typename

--- a/derive/src/merged_subscription.rs
+++ b/derive/src/merged_subscription.rs
@@ -94,7 +94,7 @@ pub fn generate(object_args: &args::MergedSubscription) -> GeneratorResult<Token
             fn create_field_stream<'__life>(
                 &'__life self,
                 ctx: &'__life #crate_name::Context<'__life>
-            ) -> ::std::option::Option<::std::pin::Pin<::std::boxed::Box<dyn #crate_name::futures_util::stream::Stream<Item = #crate_name::Response> + ::std::marker::Send + '__life>>> {
+            ) -> ::std::option::Option<::std::pin::Pin<::std::boxed::Box<dyn #crate_name::futures_util::stream::Stream<Item = #crate_name::Response> + '__life>>> {
                 ::std::option::Option::None #create_field_stream
             }
         }

--- a/derive/src/newtype.rs
+++ b/derive/src/newtype.rs
@@ -117,7 +117,7 @@ pub fn generate(newtype_args: &args::NewType) -> GeneratorResult<TokenStream> {
         }
 
         #[allow(clippy::all, clippy::pedantic)]
-        #[#crate_name::async_trait::async_trait]
+        #[#crate_name::async_trait::async_trait(?Send)]
         impl #impl_generics #crate_name::OutputType for #ident #ty_generics #where_clause {
             fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                 #type_name

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -639,7 +639,7 @@ pub fn generate(
 
             #[allow(clippy::all, clippy::pedantic, clippy::suspicious_else_formatting)]
             #[allow(unused_braces, unused_variables, unused_parens, unused_mut)]
-            #[#crate_name::async_trait::async_trait]
+            #[#crate_name::async_trait::async_trait(?Send)]
             impl #impl_generics #crate_name::resolver_utils::ContainerType for #self_ty #where_clause {
                 async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::Value>> {
                     #(#resolvers)*
@@ -664,7 +664,7 @@ pub fn generate(
             }
 
             #[allow(clippy::all, clippy::pedantic)]
-            #[#crate_name::async_trait::async_trait]
+            #[#crate_name::async_trait::async_trait(?Send)]
             impl #impl_generics #crate_name::OutputType for #self_ty #where_clause {
                 fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                     #gql_typename
@@ -776,7 +776,7 @@ pub fn generate(
             let concrete_type = quote! { #ty<#(#params),*> };
 
             codes.push(quote! {
-                #[#crate_name::async_trait::async_trait]
+                #[#crate_name::async_trait::async_trait(?Send)]
                 impl #crate_name::resolver_utils::ContainerType for #concrete_type {
                     async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::Value>> {
                         self.__internal_resolve_field(ctx).await
@@ -787,7 +787,7 @@ pub fn generate(
                     }
                 }
 
-                #[#crate_name::async_trait::async_trait]
+                #[#crate_name::async_trait::async_trait(?Send)]
                 impl #crate_name::OutputType for #concrete_type {
                     fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                         ::std::borrow::Cow::Borrowed(#gql_typename)

--- a/derive/src/scalar.rs
+++ b/derive/src/scalar.rs
@@ -85,7 +85,7 @@ pub fn generate(
         }
 
         #[allow(clippy::all, clippy::pedantic)]
-        #[#crate_name::async_trait::async_trait]
+        #[#crate_name::async_trait::async_trait(?Send)]
         impl #generic #crate_name::OutputType for #self_ty #where_clause {
             fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                 #gql_typename

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -340,7 +340,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
             }
 
             #[allow(clippy::all, clippy::pedantic)]
-            #[#crate_name::async_trait::async_trait]
+            #[#crate_name::async_trait::async_trait(?Send)]
 
             impl #impl_generics #crate_name::resolver_utils::ContainerType for #ident #ty_generics #where_clause {
                 async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::Value>> {
@@ -351,7 +351,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
             }
 
             #[allow(clippy::all, clippy::pedantic)]
-            #[#crate_name::async_trait::async_trait]
+            #[#crate_name::async_trait::async_trait(?Send)]
             impl #impl_generics #crate_name::OutputType for #ident #ty_generics #where_clause {
                 fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                     #gql_typename
@@ -464,7 +464,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
 
             let expanded = quote! {
                 #[allow(clippy::all, clippy::pedantic)]
-                #[#crate_name::async_trait::async_trait]
+                #[#crate_name::async_trait::async_trait(?Send)]
                 impl #def_lifetimes #crate_name::resolver_utils::ContainerType for #concrete_type {
                     async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::Value>> {
                         #complex_resolver
@@ -473,7 +473,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
                 }
 
                 #[allow(clippy::all, clippy::pedantic)]
-                #[#crate_name::async_trait::async_trait]
+                #[#crate_name::async_trait::async_trait(?Send)]
                 impl #def_lifetimes #crate_name::OutputType for #concrete_type {
                     fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                         ::std::borrow::Cow::Borrowed(#gql_typename)

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -421,7 +421,7 @@ pub fn generate(
             fn create_field_stream<'__life>(
                 &'__life self,
                 ctx: &'__life #crate_name::Context<'_>,
-            ) -> ::std::option::Option<::std::pin::Pin<::std::boxed::Box<dyn #crate_name::futures_util::stream::Stream<Item = #crate_name::Response> + ::std::marker::Send + '__life>>> {
+            ) -> ::std::option::Option<::std::pin::Pin<::std::boxed::Box<dyn #crate_name::futures_util::stream::Stream<Item = #crate_name::Response> + '__life>>> {
                 #(#create_stream)*
                 ::std::option::Option::None
             }

--- a/derive/src/union.rs
+++ b/derive/src/union.rs
@@ -160,7 +160,7 @@ pub fn generate(union_args: &args::Union) -> GeneratorResult<TokenStream> {
         #(#type_into_impls)*
 
         #[allow(clippy::all, clippy::pedantic)]
-        #[#crate_name::async_trait::async_trait]
+        #[#crate_name::async_trait::async_trait(?Send)]
 
         impl #impl_generics #crate_name::resolver_utils::ContainerType for #ident #ty_generics #where_clause {
             async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::Value>> {
@@ -175,7 +175,7 @@ pub fn generate(union_args: &args::Union) -> GeneratorResult<TokenStream> {
         }
 
         #[allow(clippy::all, clippy::pedantic)]
-        #[#crate_name::async_trait::async_trait]
+        #[#crate_name::async_trait::async_trait(?Send)]
         impl #impl_generics #crate_name::OutputType for #ident #ty_generics #where_clause {
             fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                #gql_typename

--- a/docs/en/src/custom_directive.md
+++ b/docs/en/src/custom_directive.md
@@ -14,7 +14,7 @@ struct ConcatDirective {
     value: String,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl CustomDirective for ConcatDirective {
     async fn resolve_field(&self, _ctx: &Context<'_>, resolve: ResolveFut<'_>) -> ServerResult<Option<Value>> {
         resolve.await.map(|value| {
@@ -41,7 +41,7 @@ Register the directive when building the schema:
 # #[Object]
 # impl Query { async fn version(&self) -> &str { "1.0" } }
 # struct ConcatDirective { value: String, }
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl CustomDirective for ConcatDirective {
 #   async fn resolve_field(&self, _ctx: &Context<'_>, resolve: ResolveFut<'_>) -> ServerResult<Option<Value>> { todo!() }
 # }

--- a/docs/en/src/dataloader.md
+++ b/docs/en/src/dataloader.md
@@ -80,7 +80,7 @@ struct UserNameLoader {
     pool: sqlx::PgPool,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Loader<u64> for UserNameLoader {
     type Value = String;
     type Error = Arc<sqlx::Error>;
@@ -140,7 +140,7 @@ struct PostgresLoader {
     pool: sqlx::PgPool,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Loader<UserId> for PostgresLoader {
     type Value = User;
     type Error = Arc<sqlx::Error>;
@@ -150,7 +150,7 @@ impl Loader<UserId> for PostgresLoader {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Loader<TodoId> for PostgresLoader {
     type Value = Todo;
     type Error = sqlx::Error;

--- a/docs/en/src/extensions_available.md
+++ b/docs/en/src/extensions_available.md
@@ -17,7 +17,7 @@ This extension doesn't force you to use some cache strategy, you can choose the 
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait CacheStorage: Send + Sync + Clone + 'static {
     /// Load the query by `key`.
     async fn get(&self, key: String) -> Option<String>;

--- a/docs/en/src/extensions_inner_working.md
+++ b/docs/en/src/extensions_inner_working.md
@@ -42,7 +42,7 @@ Default implementation for `request`:
 # use async_graphql::*;
 # use async_graphql::extensions::*;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
     next.run(ctx).await
@@ -58,7 +58,7 @@ Depending on where you put your logic code, it'll be executed at the beginning o
 # use async_graphql::*;
 # use async_graphql::extensions::*;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
     // The code here will be run before the prepare_request is executed.
@@ -79,7 +79,7 @@ Just after the `request`, we will have the `prepare_request` lifecycle, which wi
 # use async_graphql::*;
 # use async_graphql::extensions::*;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 async fn prepare_request(
     &self,
@@ -105,7 +105,7 @@ The `parse_query` will create a GraphQL `ExecutableDocument` on your query, it'l
 # use async_graphql::extensions::*;
 # use async_graphql::parser::types::ExecutableDocument;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 /// Called at parse query.
 async fn parse_query(
@@ -131,7 +131,7 @@ The `validation` step will check (depending on your `validation_mode`) rules the
 # use async_graphql::*;
 # use async_graphql::extensions::*;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 /// Called at validation query.
 async fn validation(
@@ -153,7 +153,7 @@ The `execution` step is a huge one, it'll start the execution of the query by ca
 # use async_graphql::*;
 # use async_graphql::extensions::*;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 /// Called at execute query.
 async fn execute(
@@ -179,7 +179,7 @@ The `resolve` step is launched for each field.
 # use async_graphql::*;
 # use async_graphql::extensions::*;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware { 
 /// Called at resolve field.
 async fn resolve(
@@ -206,7 +206,7 @@ The `subscribe` lifecycle has the same behavior as the `request` but for a `Subs
 # use async_graphql::extensions::*;
 # use futures_util::stream::BoxStream;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 /// Called at subscribe request.
 fn subscribe<'s>(

--- a/docs/en/src/field_guard.md
+++ b/docs/en/src/field_guard.md
@@ -21,7 +21,7 @@ impl RoleGuard {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Guard for RoleGuard {
     async fn check(&self, ctx: &Context<'_>) -> Result<()> {
         if ctx.data_opt::<Role>() == Some(&self.role) {
@@ -42,7 +42,7 @@ Use it with the `guard` attribute:
 # enum Role { Admin, Guest, }
 # struct RoleGuard { role: Role, }
 # impl RoleGuard { fn new(role: Role) -> Self { Self { role } } }
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Guard for RoleGuard { async fn check(&self, ctx: &Context<'_>) -> Result<()> { todo!() } }
 #[derive(SimpleObject)]
 struct Query {
@@ -73,7 +73,7 @@ impl EqGuard {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Guard for EqGuard {
     async fn check(&self, _ctx: &Context<'_>) -> Result<()> {
         if self.expect != self.actual {

--- a/docs/zh-CN/src/custom_directive.md
+++ b/docs/zh-CN/src/custom_directive.md
@@ -13,7 +13,7 @@ struct ConcatDirective {
     value: String,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl CustomDirective for ConcatDirective {
     async fn resolve_field(&self, _ctx: &Context<'_>, resolve: ResolveFut<'_>) -> ServerResult<Option<Value>> {
         resolve.await.map(|value| {
@@ -40,7 +40,7 @@ fn concat(value: String) -> impl CustomDirective {
 # #[Object]
 # impl Query { async fn version(&self) -> &str { "1.0" } }
 # struct ConcatDirective { value: String, }
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl CustomDirective for ConcatDirective {
 #   async fn resolve_field(&self, _ctx: &Context<'_>, resolve: ResolveFut<'_>) -> ServerResult<Option<Value>> { todo!() }
 # }

--- a/docs/zh-CN/src/dataloader.md
+++ b/docs/zh-CN/src/dataloader.md
@@ -73,7 +73,7 @@ struct UserNameLoader {
     pool: sqlx::Pool<Postgres>,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Loader<u64> for UserNameLoader {
     type Value = String;
     type Error = Arc<sqlx::Error>;
@@ -129,7 +129,7 @@ struct PostgresLoader {
     pool: sqlx::Pool<Postgres>,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Loader<UserId> for PostgresLoader {
     type Value = User;
     type Error = Arc<sqlx::Error>;
@@ -139,7 +139,7 @@ impl Loader<UserId> for PostgresLoader {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Loader<TodoId> for PostgresLoader {
     type Value = Todo;
     type Error = sqlx::Error;

--- a/docs/zh-CN/src/extensions_available.md
+++ b/docs/zh-CN/src/extensions_available.md
@@ -17,7 +17,7 @@
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait CacheStorage: Send + Sync + Clone + 'static {
     /// Load the query by `key`.
     async fn get(&self, key: String) -> Option<String>;

--- a/docs/zh-CN/src/extensions_inner_working.md
+++ b/docs/zh-CN/src/extensions_inner_working.md
@@ -38,7 +38,7 @@ Default implementation for `request`:
 # use async_graphql::*;
 # use async_graphql::extensions::*;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
     next.run(ctx).await
@@ -54,7 +54,7 @@ async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Re
 # use async_graphql::*;
 # use async_graphql::extensions::*;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
     // 此处的代码将在执行 prepare_request 之前运行。
@@ -75,7 +75,7 @@ async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Re
 # use async_graphql::*;
 # use async_graphql::extensions::*;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 async fn prepare_request(
     &self,
@@ -101,7 +101,7 @@ async fn prepare_request(
 # use async_graphql::extensions::*;
 # use async_graphql::parser::types::ExecutableDocument;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 /// Called at parse query.
 async fn parse_query(
@@ -127,7 +127,7 @@ async fn parse_query(
 # use async_graphql::*;
 # use async_graphql::extensions::*;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 /// Called at validation query.
 async fn validation(
@@ -149,7 +149,7 @@ async fn validation(
 # use async_graphql::*;
 # use async_graphql::extensions::*;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 /// Called at execute query.
 async fn execute(
@@ -175,7 +175,7 @@ async fn execute(
 # use async_graphql::*;
 # use async_graphql::extensions::*;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware { 
 /// Called at resolve field.
 async fn resolve(
@@ -202,7 +202,7 @@ async fn resolve(
 # use async_graphql::extensions::*;
 # use futures_util::stream::BoxStream;
 # struct MyMiddleware;
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Extension for MyMiddleware {
 /// Called at subscribe request.
 fn subscribe<'s>(

--- a/docs/zh-CN/src/field_guard.md
+++ b/docs/zh-CN/src/field_guard.md
@@ -21,7 +21,7 @@ impl RoleGuard {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Guard for RoleGuard {
     async fn check(&self, ctx: &Context<'_>) -> Result<()> {
         if ctx.data_opt::<Role>() == Some(&self.role) {
@@ -42,7 +42,7 @@ impl Guard for RoleGuard {
 # enum Role { Admin, Guest, }
 # struct RoleGuard { role: Role, }
 # impl RoleGuard { fn new(role: Role) -> Self { Self { role } } }
-# #[async_trait::async_trait]
+# #[async_trait::async_trait(?Send)]
 # impl Guard for RoleGuard { async fn check(&self, ctx: &Context<'_>) -> Result<()> { todo!() } }
 #[derive(SimpleObject)]
 struct Query {
@@ -73,7 +73,7 @@ impl EqGuard {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Guard for EqGuard {
     async fn check(&self, _ctx: &Context<'_>) -> Result<()> {
         if self.expect != self.actual {

--- a/integrations/actix-web/src/subscription.rs
+++ b/integrations/actix-web/src/subscription.rs
@@ -51,8 +51,8 @@ impl<E> GraphQLSubscription<E, DefaultOnConnInitType> {
 impl<E, OnInit, OnInitFut> GraphQLSubscription<E, OnInit>
 where
     E: Executor,
-    OnInit: FnOnce(serde_json::Value) -> OnInitFut + Unpin + Send + 'static,
-    OnInitFut: Future<Output = async_graphql::Result<Data>> + Send + 'static,
+    OnInit: FnOnce(serde_json::Value) -> OnInitFut + Unpin + 'static,
+    OnInitFut: Future<Output = async_graphql::Result<Data>> + 'static,
 {
     /// Specify the initial subscription context data, usually you can get
     /// something from the incoming request to create it.
@@ -72,8 +72,8 @@ where
         callback: OnConnInit2,
     ) -> GraphQLSubscription<E, OnConnInit2>
     where
-        OnConnInit2: FnOnce(serde_json::Value) -> Fut + Unpin + Send + 'static,
-        Fut: Future<Output = async_graphql::Result<Data>> + Send + 'static,
+        OnConnInit2: FnOnce(serde_json::Value) -> Fut + Unpin + 'static,
+        Fut: Future<Output = async_graphql::Result<Data>> + 'static,
     {
         GraphQLSubscription {
             executor: self.executor,
@@ -127,8 +127,8 @@ struct GraphQLSubscriptionActor<E, OnInit> {
 impl<E, OnInit, OnInitFut> GraphQLSubscriptionActor<E, OnInit>
 where
     E: Executor,
-    OnInit: FnOnce(serde_json::Value) -> OnInitFut + Unpin + Send + 'static,
-    OnInitFut: Future<Output = Result<Data>> + Send + 'static,
+    OnInit: FnOnce(serde_json::Value) -> OnInitFut + Unpin + 'static,
+    OnInitFut: Future<Output = Result<Data>> + 'static,
 {
     fn send_heartbeats(&self, ctx: &mut WebsocketContext<Self>) {
         ctx.run_interval(HEARTBEAT_INTERVAL, |act, ctx| {
@@ -143,8 +143,8 @@ where
 impl<E, OnInit, OnInitFut> Actor for GraphQLSubscriptionActor<E, OnInit>
 where
     E: Executor,
-    OnInit: FnOnce(serde_json::Value) -> OnInitFut + Unpin + Send + 'static,
-    OnInitFut: Future<Output = Result<Data>> + Send + 'static,
+    OnInit: FnOnce(serde_json::Value) -> OnInitFut + Unpin + 'static,
+    OnInitFut: Future<Output = Result<Data>> + 'static,
 {
     type Context = WebsocketContext<Self>;
 
@@ -175,8 +175,8 @@ impl<E, OnInit, OnInitFut> StreamHandler<Result<Message, ProtocolError>>
     for GraphQLSubscriptionActor<E, OnInit>
 where
     E: Executor,
-    OnInit: FnOnce(serde_json::Value) -> OnInitFut + Unpin + Send + 'static,
-    OnInitFut: Future<Output = Result<Data>> + Send + 'static,
+    OnInit: FnOnce(serde_json::Value) -> OnInitFut + Unpin + 'static,
+    OnInitFut: Future<Output = Result<Data>> + 'static,
 {
     fn handle(&mut self, msg: Result<Message, ProtocolError>, ctx: &mut Self::Context) {
         let msg = match msg {

--- a/integrations/axum/src/extract.rs
+++ b/integrations/axum/src/extract.rs
@@ -60,7 +60,7 @@ pub mod rejection {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<S, B, R> FromRequest<S, B> for GraphQLRequest<R>
 where
     B: HttpBody + Send + Sync + 'static,
@@ -96,7 +96,7 @@ impl<R> GraphQLBatchRequest<R> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<S, B, R> FromRequest<S, B> for GraphQLBatchRequest<R>
 where
     B: HttpBody + Send + Sync + 'static,

--- a/integrations/axum/src/extract.rs
+++ b/integrations/axum/src/extract.rs
@@ -63,10 +63,9 @@ pub mod rejection {
 #[async_trait::async_trait(?Send)]
 impl<S, B, R> FromRequest<S, B> for GraphQLRequest<R>
 where
-    B: HttpBody + Send + Sync + 'static,
+    B: HttpBody + 'static,
     B::Data: Into<Bytes>,
     B::Error: Into<BoxError>,
-    S: Send + Sync,
     R: IntoResponse + From<ParseRequestError>,
 {
     type Rejection = R;
@@ -99,10 +98,9 @@ impl<R> GraphQLBatchRequest<R> {
 #[async_trait::async_trait(?Send)]
 impl<S, B, R> FromRequest<S, B> for GraphQLBatchRequest<R>
 where
-    B: HttpBody + Send + Sync + 'static,
+    B: HttpBody + 'static,
     B::Data: Into<Bytes>,
     B::Error: Into<BoxError>,
-    S: Send + Sync,
     R: IntoResponse + From<ParseRequestError>,
 {
     type Rejection = R;

--- a/integrations/axum/src/query.rs
+++ b/integrations/axum/src/query.rs
@@ -16,7 +16,7 @@ use axum::{
     BoxError,
 };
 use bytes::Bytes;
-use futures_util::{future::BoxFuture, StreamExt};
+use futures_util::StreamExt;
 use tower_service::Service;
 
 use crate::{
@@ -38,14 +38,14 @@ impl<E> GraphQL<E> {
 
 impl<B, E> Service<HttpRequest<B>> for GraphQL<E>
 where
-    B: HttpBody + Send + Sync + 'static,
+    B: HttpBody + 'static,
     B::Data: Into<Bytes>,
     B::Error: Into<BoxError>,
     E: Executor,
 {
     type Response = HttpResponse<BoxBody>;
     type Error = Infallible;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))

--- a/integrations/axum/src/subscription.rs
+++ b/integrations/axum/src/subscription.rs
@@ -17,7 +17,7 @@ use axum::{
 };
 use futures_util::{
     future,
-    future::{BoxFuture, Ready},
+    future::{LocalBoxFuture, Ready},
     stream::{SplitSink, SplitStream},
     Sink, SinkExt, Stream, StreamExt,
 };
@@ -30,10 +30,7 @@ use tower_service::Service;
 pub struct GraphQLProtocol(WebSocketProtocols);
 
 #[async_trait::async_trait(?Send)]
-impl<S> FromRequestParts<S> for GraphQLProtocol
-where
-    S: Send + Sync,
-{
+impl<S> FromRequestParts<S> for GraphQLProtocol {
     type Rejection = StatusCode;
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
@@ -79,12 +76,12 @@ where
 
 impl<B, E> Service<Request<B>> for GraphQLSubscription<E>
 where
-    B: HttpBody + Send + 'static,
+    B: HttpBody + 'static,
     E: Executor,
 {
     type Response = Response<BoxBody>;
     type Error = Infallible;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
@@ -174,8 +171,8 @@ where
     Sink: futures_util::sink::Sink<Message>,
     Stream: futures_util::stream::Stream<Item = Result<Message, Error>>,
     E: Executor,
-    OnConnInit: FnOnce(serde_json::Value) -> OnConnInitFut + Send + 'static,
-    OnConnInitFut: Future<Output = async_graphql::Result<Data>> + Send + 'static,
+    OnConnInit: FnOnce(serde_json::Value) -> OnConnInitFut + 'static,
+    OnConnInitFut: Future<Output = async_graphql::Result<Data>> + 'static,
 {
     /// Specify the initial subscription context data, usually you can get
     /// something from the incoming request to create it.

--- a/integrations/axum/src/subscription.rs
+++ b/integrations/axum/src/subscription.rs
@@ -29,7 +29,7 @@ use tower_service::Service;
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct GraphQLProtocol(WebSocketProtocols);
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<S> FromRequestParts<S> for GraphQLProtocol
 where
     S: Send + Sync,

--- a/integrations/poem/src/extractor.rs
+++ b/integrations/poem/src/extractor.rs
@@ -47,7 +47,7 @@ use tokio_util::compat::TokioAsyncReadCompatExt;
 /// ```
 pub struct GraphQLRequest(pub async_graphql::Request);
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a> FromRequest<'a> for GraphQLRequest {
     async fn from_request(req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         Ok(GraphQLRequest(
@@ -63,7 +63,7 @@ impl<'a> FromRequest<'a> for GraphQLRequest {
 /// An extractor for GraphQL batch request.
 pub struct GraphQLBatchRequest(pub async_graphql::BatchRequest);
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<'a> FromRequest<'a> for GraphQLBatchRequest {
     async fn from_request(req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         if req.method() == Method::GET {

--- a/integrations/poem/src/query.rs
+++ b/integrations/poem/src/query.rs
@@ -43,7 +43,7 @@ impl<E> GraphQL<E> {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<E> Endpoint for GraphQL<E>
 where
     E: Executor,

--- a/integrations/poem/src/subscription.rs
+++ b/integrations/poem/src/subscription.rs
@@ -22,7 +22,7 @@ use poem::{
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct GraphQLProtocol(pub WebSocketProtocols);
 
-#[poem::async_trait]
+#[poem::async_trait(?Send)]
 impl<'a> FromRequest<'a> for GraphQLProtocol {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         req.headers()
@@ -82,7 +82,7 @@ impl<E> GraphQLSubscription<E> {
     }
 }
 
-#[poem::async_trait]
+#[poem::async_trait(?Send)]
 impl<E> Endpoint for GraphQLSubscription<E>
 where
     E: Executor,

--- a/integrations/rocket/src/lib.rs
+++ b/integrations/rocket/src/lib.rs
@@ -47,7 +47,7 @@ impl GraphQLBatchRequest {
     }
 }
 
-#[rocket::async_trait]
+#[rocket::async_trait(?Send)]
 impl<'r> FromData<'r> for GraphQLBatchRequest {
     type Error = ParseRequestError;
 
@@ -156,7 +156,7 @@ impl GraphQLQuery {
     }
 }
 
-#[rocket::async_trait]
+#[rocket::async_trait(?Send)]
 impl<'r> FromData<'r> for GraphQLRequest {
     type Error = ParseRequestError;
 

--- a/integrations/tide/src/lib.rs
+++ b/integrations/tide/src/lib.rs
@@ -71,7 +71,7 @@ impl<E: Executor> Clone for GraphQLEndpoint<E> {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<E, TideState> tide::Endpoint<TideState> for GraphQLEndpoint<E>
 where
     E: Executor,

--- a/integrations/warp/src/subscription.rs
+++ b/integrations/warp/src/subscription.rs
@@ -210,8 +210,8 @@ where
     Sink: futures_util::sink::Sink<Message>,
     Stream: futures_util::stream::Stream<Item = Result<Message, Error>>,
     E: Executor,
-    OnConnInit: FnOnce(serde_json::Value) -> OnConnInitFut + Send + 'static,
-    OnConnInitFut: Future<Output = async_graphql::Result<Data>> + Send + 'static,
+    OnConnInit: FnOnce(serde_json::Value) -> OnConnInitFut + 'static,
+    OnConnInitFut: Future<Output = async_graphql::Result<Data>> + 'static,
 {
     /// Specify the initial subscription context data, usually you can get
     /// something from the incoming request to create it.
@@ -231,8 +231,8 @@ where
         callback: OnConnInit2,
     ) -> GraphQLWebSocket<Sink, Stream, E, OnConnInit2>
     where
-        OnConnInit2: FnOnce(serde_json::Value) -> Fut + Send + 'static,
-        Fut: Future<Output = async_graphql::Result<Data>> + Send + 'static,
+        OnConnInit2: FnOnce(serde_json::Value) -> Fut + 'static,
+        Fut: Future<Output = async_graphql::Result<Data>> + 'static,
     {
         GraphQLWebSocket {
             sink: self.sink,

--- a/src/base.rs
+++ b/src/base.rs
@@ -63,7 +63,7 @@ pub trait InputType: Send + Sync + Sized {
 }
 
 /// Represents a GraphQL output type.
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait OutputType: Send + Sync {
     /// Type the name.
     fn type_name() -> Cow<'static, str>;
@@ -92,7 +92,7 @@ pub trait OutputType: Send + Sync {
     ) -> ServerResult<Value>;
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType + ?Sized> OutputType for &T {
     fn type_name() -> Cow<'static, str> {
         T::type_name()
@@ -112,7 +112,7 @@ impl<T: OutputType + ?Sized> OutputType for &T {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType + Sync, E: Into<Error> + Send + Sync + Clone> OutputType for Result<T, E> {
     fn type_name() -> Cow<'static, str> {
         T::type_name()
@@ -139,13 +139,13 @@ impl<T: OutputType + Sync, E: Into<Error> + Send + Sync + Clone> OutputType for 
 /// A GraphQL object.
 pub trait ObjectType: ContainerType {}
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: ObjectType + ?Sized> ObjectType for &T {}
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: ObjectType + ?Sized> ObjectType for Box<T> {}
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: ObjectType + ?Sized> ObjectType for Arc<T> {}
 
 /// A GraphQL interface.
@@ -160,7 +160,7 @@ pub trait InputObjectType: InputType {}
 /// A GraphQL oneof input object.
 pub trait OneofObjectType: InputObjectType {}
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType + ?Sized> OutputType for Box<T> {
     fn type_name() -> Cow<'static, str> {
         T::type_name()
@@ -180,7 +180,7 @@ impl<T: OutputType + ?Sized> OutputType for Box<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: InputType> InputType for Box<T> {
     type RawValueType = T::RawValueType;
 
@@ -207,7 +207,7 @@ impl<T: InputType> InputType for Box<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType + ?Sized> OutputType for Arc<T> {
     fn type_name() -> Cow<'static, str> {
         T::type_name()
@@ -253,7 +253,7 @@ impl<T: InputType> InputType for Arc<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType + ?Sized> OutputType for Weak<T> {
     fn type_name() -> Cow<'static, str> {
         <Option<Arc<T>> as OutputType>::type_name()
@@ -273,7 +273,7 @@ impl<T: OutputType + ?Sized> OutputType for Weak<T> {
 }
 
 #[doc(hidden)]
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait ComplexObject {
     fn fields(registry: &mut registry::Registry) -> Vec<(String, registry::MetaField)>;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -57,10 +57,10 @@ pub trait DataContext<'a> {
 ///
 /// This is a type map, allowing you to store anything inside it.
 #[derive(Default)]
-pub struct Data(FnvHashMap<TypeId, Box<dyn Any + Sync + Send>>);
+pub struct Data(FnvHashMap<TypeId, Box<dyn Any>>);
 
 impl Deref for Data {
-    type Target = FnvHashMap<TypeId, Box<dyn Any + Sync + Send>>;
+    type Target = FnvHashMap<TypeId, Box<dyn Any>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -69,7 +69,7 @@ impl Deref for Data {
 
 impl Data {
     /// Insert data.
-    pub fn insert<D: Any + Send + Sync>(&mut self, data: D) {
+    pub fn insert<D: Any>(&mut self, data: D) {
         self.0.insert(TypeId::of::<D>(), Box::new(data));
     }
 

--- a/src/custom_directive.rs
+++ b/src/custom_directive.rs
@@ -27,7 +27,7 @@ pub trait TypeDirective {
 }
 
 /// Represents a custom directive.
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 #[allow(unused_variables)]
 pub trait CustomDirective: Sync + Send + 'static {
     /// Called at resolve field.

--- a/src/custom_directive.rs
+++ b/src/custom_directive.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 #[doc(hidden)]
-pub trait CustomDirectiveFactory: Send + Sync + 'static {
+pub trait CustomDirectiveFactory: 'static {
     fn name(&self) -> Cow<'static, str>;
 
     fn register(&self, registry: &mut Registry);

--- a/src/dataloader/mod.rs
+++ b/src/dataloader/mod.rs
@@ -114,7 +114,7 @@ impl<K: Send + Sync + Hash + Eq + Clone + 'static, T: Loader<K>> Requests<K, T> 
 }
 
 /// Trait for batch loading.
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait Loader<K: Send + Sync + Hash + Eq + Clone + 'static>: Send + Sync + 'static {
     /// type of value.
     type Value: Send + Sync + Clone + 'static;
@@ -494,7 +494,7 @@ mod tests {
 
     struct MyLoader;
 
-    #[async_trait::async_trait]
+    #[async_trait::async_trait(?Send)]
     impl Loader<i32> for MyLoader {
         type Value = i32;
         type Error = ();
@@ -505,7 +505,7 @@ mod tests {
         }
     }
 
-    #[async_trait::async_trait]
+    #[async_trait::async_trait(?Send)]
     impl Loader<i64> for MyLoader {
         type Value = i64;
         type Error = ();
@@ -683,7 +683,7 @@ mod tests {
     async fn test_dataloader_dead_lock() {
         struct MyDelayLoader;
 
-        #[async_trait::async_trait]
+        #[async_trait::async_trait(?Send)]
         impl Loader<i32> for MyDelayLoader {
             type Value = i32;
             type Error = ();

--- a/src/docs/directive.md
+++ b/src/docs/directive.md
@@ -37,7 +37,7 @@ struct ConcatDirective {
     value: String,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl CustomDirective for ConcatDirective {
     async fn resolve_field(&self, _ctx: &Context<'_>, resolve: ResolveFut<'_>) -> ServerResult<Option<Value>> {
         resolve.await.map(|value| {

--- a/src/dynamic/resolve.rs
+++ b/src/dynamic/resolve.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, pin::Pin};
 
 use async_graphql_derive::SimpleObject;
 use async_graphql_parser::{types::Field, Positioned};
-use futures_util::{future::BoxFuture, Future, FutureExt};
+use futures_util::{future::LocalBoxFuture, Future, FutureExt};
 use indexmap::IndexMap;
 
 use crate::{
@@ -97,7 +97,7 @@ fn collect_schema_field<'a>(
             .await?;
             Ok((field.node.response_key().node.clone(), value))
         }
-        .boxed(),
+        .boxed_local(),
     );
 }
 
@@ -133,7 +133,7 @@ fn collect_type_field<'a>(
             .await?;
             Ok((field.node.response_key().node.clone(), value))
         }
-        .boxed(),
+        .boxed_local(),
     );
 }
 
@@ -164,7 +164,7 @@ fn collect_service_field<'a>(
 
             Ok((field.node.response_key().node.clone(), output_type))
         }
-        .boxed(),
+        .boxed_local(),
     );
 }
 
@@ -217,7 +217,7 @@ fn collect_entities_field<'a>(
                 .unwrap_or_default();
             Ok((field.node.response_key().node.clone(), value))
         }
-        .boxed(),
+        .boxed_local(),
     );
 }
 
@@ -285,7 +285,7 @@ fn collect_field<'a>(
                 .unwrap_or_default();
             Ok((field.node.response_key().node.clone(), res_value))
         }
-        .boxed(),
+        .boxed_local(),
     );
 }
 
@@ -408,7 +408,7 @@ pub(crate) fn resolve<'a>(
     ctx: &'a Context<'a>,
     type_ref: &'a TypeRef,
     value: Option<&'a FieldValue>,
-) -> BoxFuture<'a, ServerResult<Option<Value>>> {
+) -> LocalBoxFuture<'a, ServerResult<Option<Value>>> {
     async move {
         match (type_ref, value) {
             (TypeRef::Named(type_name), Some(value)) => {
@@ -444,7 +444,7 @@ pub(crate) fn resolve<'a>(
             (TypeRef::List(_), None) => Ok(None),
         }
     }
-    .boxed()
+    .boxed_local()
 }
 
 async fn resolve_list<'a>(

--- a/src/dynamic/resolve.rs
+++ b/src/dynamic/resolve.rs
@@ -24,7 +24,7 @@ struct Service {
     sdl: Option<String>,
 }
 
-type BoxFieldFuture<'a> = Pin<Box<dyn Future<Output = ServerResult<(Name, Value)>> + 'a + Send>>;
+type BoxFieldFuture<'a> = Pin<Box<dyn Future<Output = ServerResult<(Name, Value)>> + 'a>>;
 
 pub(crate) async fn resolve_container(
     schema: &Schema,

--- a/src/dynamic/schema.rs
+++ b/src/dynamic/schema.rs
@@ -443,7 +443,7 @@ impl Schema {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Executor for Schema {
     async fn execute(&self, request: Request) -> Response {
         Schema::execute(self, request).await
@@ -796,7 +796,7 @@ mod tests {
             calls: Arc<Mutex<Vec<&'static str>>>,
         }
 
-        #[async_trait::async_trait]
+        #[async_trait::async_trait(?Send)]
         #[allow(unused_variables)]
         impl Extension for MyExtensionImpl {
             async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -6,7 +6,7 @@ use crate::{BatchRequest, BatchResponse, Data, Request, Response};
 
 /// Represents a GraphQL executor
 #[async_trait::async_trait(?Send)]
-pub trait Executor: Unpin + Clone + Send + Sync + 'static {
+pub trait Executor: Unpin + Clone + 'static {
     /// Execute a GraphQL query.
     async fn execute(&self, request: Request) -> Response;
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use futures_util::{stream::BoxStream, StreamExt};
+use futures_util::{stream::LocalBoxStream, StreamExt};
 
 use crate::{BatchRequest, BatchResponse, Data, Request, Response};
 
 /// Represents a GraphQL executor
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait Executor: Unpin + Clone + Send + Sync + 'static {
     /// Execute a GraphQL query.
     async fn execute(&self, request: Request) -> Response;
@@ -28,5 +28,5 @@ pub trait Executor: Unpin + Clone + Send + Sync + 'static {
         &self,
         request: Request,
         session_data: Option<Arc<Data>>,
-    ) -> BoxStream<'static, Response>;
+    ) -> LocalBoxStream<'static, Response>;
 }

--- a/src/extensions/analyzer.rs
+++ b/src/extensions/analyzer.rs
@@ -24,7 +24,7 @@ struct AnalyzerExtension {
     validation_result: Mutex<Option<ValidationResult>>,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Extension for AnalyzerExtension {
     async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
         let mut resp = next.run(ctx).await;

--- a/src/extensions/apollo_persisted_queries.rs
+++ b/src/extensions/apollo_persisted_queries.rs
@@ -20,7 +20,7 @@ struct PersistedQuery {
 }
 
 /// Cache storage for persisted queries.
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait CacheStorage: Send + Sync + Clone + 'static {
     /// Load the query by `key`.
     async fn get(&self, key: String) -> Option<ExecutableDocument>;
@@ -40,7 +40,7 @@ impl LruCacheStorage {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl CacheStorage for LruCacheStorage {
     async fn get(&self, key: String) -> Option<ExecutableDocument> {
         let mut cache = self.0.lock().await;
@@ -78,7 +78,7 @@ struct ApolloPersistedQueriesExtension<T> {
     storage: T,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: CacheStorage> Extension for ApolloPersistedQueriesExtension<T> {
     async fn prepare_request(
         &self,

--- a/src/extensions/apollo_tracing.rs
+++ b/src/extensions/apollo_tracing.rs
@@ -70,7 +70,7 @@ struct ApolloTracingExtension {
     inner: Mutex<Inner>,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Extension for ApolloTracingExtension {
     async fn execute(
         &self,

--- a/src/extensions/logger.rs
+++ b/src/extensions/logger.rs
@@ -18,7 +18,7 @@ impl ExtensionFactory for Logger {
 
 struct LoggerExtension;
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Extension for LoggerExtension {
     async fn parse_query(
         &self,

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -47,15 +47,15 @@ pub struct ExtensionContext<'a> {
 }
 
 impl<'a> DataContext<'a> for ExtensionContext<'a> {
-    fn data<D: Any + Send + Sync>(&self) -> Result<&'a D> {
+    fn data<D: Any>(&self) -> Result<&'a D> {
         ExtensionContext::data::<D>(self)
     }
 
-    fn data_unchecked<D: Any + Send + Sync>(&self) -> &'a D {
+    fn data_unchecked<D: Any>(&self) -> &'a D {
         ExtensionContext::data_unchecked::<D>(self)
     }
 
-    fn data_opt<D: Any + Send + Sync>(&self) -> Option<&'a D> {
+    fn data_opt<D: Any>(&self) -> Option<&'a D> {
         ExtensionContext::data_opt::<D>(self)
     }
 }
@@ -79,7 +79,7 @@ impl<'a> ExtensionContext<'a> {
     /// # Errors
     ///
     /// Returns a `Error` if the specified type data does not exist.
-    pub fn data<D: Any + Send + Sync>(&self) -> Result<&'a D> {
+    pub fn data<D: Any>(&self) -> Result<&'a D> {
         self.data_opt::<D>().ok_or_else(|| {
             Error::new(format!(
                 "Data `{}` does not exist.",
@@ -93,14 +93,14 @@ impl<'a> ExtensionContext<'a> {
     /// # Panics
     ///
     /// It will panic if the specified data type does not exist.
-    pub fn data_unchecked<D: Any + Send + Sync>(&self) -> &'a D {
+    pub fn data_unchecked<D: Any>(&self) -> &'a D {
         self.data_opt::<D>()
             .unwrap_or_else(|| panic!("Data `{}` does not exist.", std::any::type_name::<D>()))
     }
 
     /// Gets the global data defined in the `Context` or `Schema` or `None` if
     /// the specified type data does not exist.
-    pub fn data_opt<D: Any + Send + Sync>(&self) -> Option<&'a D> {
+    pub fn data_opt<D: Any>(&self) -> Option<&'a D> {
         self.query_data
             .and_then(|query_data| query_data.get(&TypeId::of::<D>()))
             .or_else(|| self.session_data.get(&TypeId::of::<D>()))
@@ -323,7 +323,7 @@ impl<'a> NextResolve<'a> {
 
 /// Represents a GraphQL extension
 #[async_trait::async_trait(?Send)]
-pub trait Extension: Sync + Send + 'static {
+pub trait Extension: 'static {
     /// Called at start query/mutation request.
     async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
         next.run(ctx).await
@@ -393,7 +393,7 @@ pub trait Extension: Sync + Send + 'static {
 /// Extension factory
 ///
 /// Used to create an extension instance.
-pub trait ExtensionFactory: Send + Sync + 'static {
+pub trait ExtensionFactory: 'static {
     /// Create an extended instance.
     fn create(&self) -> Arc<dyn Extension>;
 }

--- a/src/extensions/opentelemetry.rs
+++ b/src/extensions/opentelemetry.rs
@@ -59,7 +59,7 @@ struct OpenTelemetryExtension<T> {
     tracer: Arc<T>,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T> Extension for OpenTelemetryExtension<T>
 where
     T: Tracer + Send + Sync + 'static,

--- a/src/extensions/opentelemetry.rs
+++ b/src/extensions/opentelemetry.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_graphql_parser::types::ExecutableDocument;
 use async_graphql_value::Variables;
-use futures_util::{stream::BoxStream, TryFutureExt};
+use futures_util::{stream::LocalBoxStream, TryFutureExt};
 use opentelemetry::{
     trace::{FutureExt, SpanKind, TraceContextExt, Tracer},
     Context as OpenTelemetryContext, Key,
@@ -79,9 +79,9 @@ where
     fn subscribe<'s>(
         &self,
         ctx: &ExtensionContext<'_>,
-        stream: BoxStream<'s, Response>,
+        stream: LocalBoxStream<'s, Response>,
         next: NextSubscribe<'_>,
-    ) -> BoxStream<'s, Response> {
+    ) -> LocalBoxStream<'s, Response> {
         Box::pin(
             next.run(ctx, stream)
                 .with_context(OpenTelemetryContext::current_with_span(

--- a/src/extensions/tracing.rs
+++ b/src/extensions/tracing.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use futures_util::{stream::BoxStream, TryFutureExt};
+use futures_util::{stream::LocalBoxStream, TryFutureExt};
 use tracing_futures::Instrument;
 use tracinglib::{span, Level};
 
@@ -63,9 +63,9 @@ impl Extension for TracingExtension {
     fn subscribe<'s>(
         &self,
         ctx: &ExtensionContext<'_>,
-        stream: BoxStream<'s, Response>,
+        stream: LocalBoxStream<'s, Response>,
         next: NextSubscribe<'_>,
-    ) -> BoxStream<'s, Response> {
+    ) -> LocalBoxStream<'s, Response> {
         Box::pin(next.run(ctx, stream).instrument(span!(
             target: "async_graphql::graphql",
             Level::INFO,

--- a/src/extensions/tracing.rs
+++ b/src/extensions/tracing.rs
@@ -48,7 +48,7 @@ impl ExtensionFactory for Tracing {
 
 struct TracingExtension;
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Extension for TracingExtension {
     async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {
         next.run(ctx)

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -6,13 +6,13 @@ use crate::{Context, Result};
 ///
 /// Guard is a pre-condition for a field that is resolved if `Ok(())` is
 /// returned, otherwise an error is returned.
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait Guard {
     /// Check whether the guard will allow access to the field.
     async fn check(&self, ctx: &Context<'_>) -> Result<()>;
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T> Guard for T
 where
     T: Fn(&Context<'_>) -> Result<()> + Send + Sync + 'static,
@@ -40,7 +40,7 @@ impl<T: Guard> GuardExt for T {}
 /// Guard for [`GuardExt::and`](trait.GuardExt.html#method.and).
 pub struct And<A: Guard, B: Guard>(A, B);
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<A: Guard + Send + Sync, B: Guard + Send + Sync> Guard for And<A, B> {
     async fn check(&self, ctx: &Context<'_>) -> Result<()> {
         self.0.check(ctx).await?;
@@ -51,7 +51,7 @@ impl<A: Guard + Send + Sync, B: Guard + Send + Sync> Guard for And<A, B> {
 /// Guard for [`GuardExt::or`](trait.GuardExt.html#method.or).
 pub struct Or<A: Guard, B: Guard>(A, B);
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<A: Guard + Send + Sync, B: Guard + Send + Sync> Guard for Or<A, B> {
     async fn check(&self, ctx: &Context<'_>) -> Result<()> {
         if self.0.check(ctx).await.is_ok() {

--- a/src/http/websocket.rs
+++ b/src/http/websocket.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use futures_util::{
-    future::{BoxFuture, Ready},
+    future::{LocalBoxFuture, Ready},
     stream::Stream,
     FutureExt, StreamExt,
 };
@@ -72,7 +72,7 @@ pin_project! {
     /// - [graphql-ws](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md)
     pub struct WebSocket<S, E, OnInit> {
         on_connection_init: Option<OnInit>,
-        init_fut: Option<BoxFuture<'static, Result<Data>>>,
+        init_fut: Option<LocalBoxFuture<'static, Result<Data>>>,
         connection_data: Option<Data>,
         data: Option<Arc<Data>>,
         executor: E,
@@ -151,8 +151,8 @@ where
     #[must_use]
     pub fn on_connection_init<F, R>(self, callback: F) -> WebSocket<S, E, F>
     where
-        F: FnOnce(serde_json::Value) -> R + Send + 'static,
-        R: Future<Output = Result<Data>> + Send + 'static,
+        F: FnOnce(serde_json::Value) -> R + 'static,
+        R: Future<Output = Result<Data>> + 'static,
     {
         WebSocket {
             on_connection_init: Some(callback),
@@ -171,8 +171,8 @@ impl<S, E, OnInit, InitFut> Stream for WebSocket<S, E, OnInit>
 where
     E: Executor,
     S: Stream<Item = serde_json::Result<ClientMessage>>,
-    OnInit: FnOnce(serde_json::Value) -> InitFut + Send + 'static,
-    InitFut: Future<Output = Result<Data>> + Send + 'static,
+    OnInit: FnOnce(serde_json::Value) -> InitFut + 'static,
+    InitFut: Future<Output = Result<Data>> + 'static,
 {
     type Item = WsMessage;
 

--- a/src/http/websocket.rs
+++ b/src/http/websocket.rs
@@ -76,7 +76,7 @@ pin_project! {
         connection_data: Option<Data>,
         data: Option<Arc<Data>>,
         executor: E,
-        streams: HashMap<String, Pin<Box<dyn Stream<Item = Response> + Send>>>,
+        streams: HashMap<String, Pin<Box<dyn Stream<Item = Response> >>>,
         #[pin]
         stream: S,
         protocol: Protocols,

--- a/src/resolver_utils/container.rs
+++ b/src/resolver_utils/container.rs
@@ -12,7 +12,7 @@ use crate::{
 ///
 /// This helper trait allows the type to call `resolve_container` on itself in
 /// its `OutputType::resolve` implementation.
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 pub trait ContainerType: OutputType {
     /// This function returns true of type `EmptyMutation` only.
     #[doc(hidden)]
@@ -50,7 +50,7 @@ pub trait ContainerType: OutputType {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: ContainerType + ?Sized> ContainerType for &T {
     async fn resolve_field(&self, ctx: &Context<'_>) -> ServerResult<Option<Value>> {
         T::resolve_field(*self, ctx).await
@@ -61,7 +61,7 @@ impl<T: ContainerType + ?Sized> ContainerType for &T {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: ContainerType + ?Sized> ContainerType for Arc<T> {
     async fn resolve_field(&self, ctx: &Context<'_>) -> ServerResult<Option<Value>> {
         T::resolve_field(self, ctx).await
@@ -72,7 +72,7 @@ impl<T: ContainerType + ?Sized> ContainerType for Arc<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: ContainerType + ?Sized> ContainerType for Box<T> {
     async fn resolve_field(&self, ctx: &Context<'_>) -> ServerResult<Option<Value>> {
         T::resolve_field(self, ctx).await
@@ -83,7 +83,7 @@ impl<T: ContainerType + ?Sized> ContainerType for Box<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: ContainerType, E: Into<Error> + Send + Sync + Clone> ContainerType for Result<T, E> {
     async fn resolve_field(&self, ctx: &Context<'_>) -> ServerResult<Option<Value>> {
         match self {
@@ -171,7 +171,7 @@ async fn resolve_container_inner<'a, T: ContainerType + ?Sized>(
     Ok(create_value_object(res))
 }
 
-type BoxFieldFuture<'a> = Pin<Box<dyn Future<Output = ServerResult<(Name, Value)>> + 'a + Send>>;
+type BoxFieldFuture<'a> = Pin<Box<dyn Future<Output = ServerResult<(Name, Value)>> + 'a>>;
 
 /// A set of fields on an container that are being selected.
 pub struct Fields<'a>(Vec<BoxFieldFuture<'a>>);
@@ -258,7 +258,7 @@ impl<'a> Fields<'a> {
                                             .unwrap_or_default(),
                                     ))
                                 } else {
-                                    let mut resolve_fut = resolve_fut.boxed();
+                                    let mut resolve_fut = resolve_fut.boxed_local();
 
                                     for directive in &field.node.directives {
                                         if let Some(directive_factory) = ctx

--- a/src/resolver_utils/scalar.rs
+++ b/src/resolver_utils/scalar.rs
@@ -188,7 +188,7 @@ macro_rules! scalar_internal {
             }
         }
 
-        #[$crate::async_trait::async_trait]
+        #[$crate::async_trait::async_trait(?Send)]
         impl $crate::OutputType for $ty {
             fn type_name() -> ::std::borrow::Cow<'static, ::std::primitive::str> {
                 ::std::borrow::Cow::Borrowed($name)

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -144,7 +144,7 @@ impl<Query, Mutation, Subscription> SchemaBuilder<Query, Mutation, Subscription>
     /// Add a global data that can be accessed in the `Schema`. You access it
     /// with `Context::data`.
     #[must_use]
-    pub fn data<D: Any + Send + Sync>(mut self, data: D) -> Self {
+    pub fn data<D: Any>(mut self, data: D) -> Self {
         self.data.insert(data);
         self
     }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// A GraphQL subscription object
-pub trait SubscriptionType: Send + Sync {
+pub trait SubscriptionType {
     /// Type the name.
     fn type_name() -> Cow<'static, str>;
 
@@ -30,10 +30,10 @@ pub trait SubscriptionType: Send + Sync {
     fn create_field_stream<'a>(
         &'a self,
         ctx: &'a Context<'_>,
-    ) -> Option<Pin<Box<dyn Stream<Item = Response> + Send + 'a>>>;
+    ) -> Option<Pin<Box<dyn Stream<Item = Response> + 'a>>>;
 }
 
-pub(crate) type BoxFieldStream<'a> = Pin<Box<dyn Stream<Item = Response> + 'a + Send>>;
+pub(crate) type BoxFieldStream<'a> = Pin<Box<dyn Stream<Item = Response> + 'a>>;
 
 pub(crate) fn collect_subscription_streams<'a, T: SubscriptionType + 'static>(
     ctx: &ContextSelectionSet<'a>,
@@ -76,7 +76,7 @@ impl<T: SubscriptionType> SubscriptionType for &T {
     fn create_field_stream<'a>(
         &'a self,
         ctx: &'a Context<'_>,
-    ) -> Option<Pin<Box<dyn Stream<Item = Response> + Send + 'a>>> {
+    ) -> Option<Pin<Box<dyn Stream<Item = Response> + 'a>>> {
         T::create_field_stream(*self, ctx)
     }
 }

--- a/src/types/empty_mutation.rs
+++ b/src/types/empty_mutation.rs
@@ -30,7 +30,7 @@ use crate::{
 #[derive(Default, Copy, Clone)]
 pub struct EmptyMutation;
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl ContainerType for EmptyMutation {
     fn is_empty() -> bool {
         true
@@ -41,7 +41,7 @@ impl ContainerType for EmptyMutation {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl OutputType for EmptyMutation {
     fn type_name() -> Cow<'static, str> {
         Cow::Borrowed("EmptyMutation")

--- a/src/types/empty_subscription.rs
+++ b/src/types/empty_subscription.rs
@@ -42,7 +42,7 @@ impl SubscriptionType for EmptySubscription {
     fn create_field_stream<'a>(
         &'a self,
         _ctx: &'a Context<'_>,
-    ) -> Option<Pin<Box<dyn Stream<Item = Response> + Send + 'a>>>
+    ) -> Option<Pin<Box<dyn Stream<Item = Response> + 'a>>>
     where
         Self: Send + Sync + 'static + Sized,
     {

--- a/src/types/external/cow.rs
+++ b/src/types/external/cow.rs
@@ -4,7 +4,7 @@ use async_graphql_parser::types::Field;
 
 use crate::{registry, ContextSelectionSet, OutputType, Positioned, ServerResult, Value};
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<'a, T> OutputType for Cow<'a, T>
 where
     T: OutputType + ToOwned + ?Sized,

--- a/src/types/external/json_object/btreemap.rs
+++ b/src/types/external/json_object/btreemap.rs
@@ -70,7 +70,7 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<K, V> OutputType for BTreeMap<K, V>
 where
     K: ToString + Ord + Send + Sync,

--- a/src/types/external/json_object/hashbrown_hashmap.rs
+++ b/src/types/external/json_object/hashbrown_hashmap.rs
@@ -64,7 +64,7 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<K, V> OutputType for HashMap<K, V>
 where
     K: ToString + Eq + Hash + Send + Sync,

--- a/src/types/external/json_object/hashmap.rs
+++ b/src/types/external/json_object/hashmap.rs
@@ -77,7 +77,7 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<K, V, S> OutputType for HashMap<K, V, S>
 where
     K: ToString + Eq + Hash + Send + Sync,

--- a/src/types/external/list/array.rs
+++ b/src/types/external/list/array.rs
@@ -52,7 +52,7 @@ impl<T: InputType, const N: usize> InputType for [T; N] {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType, const N: usize> OutputType for [T; N] {
     fn type_name() -> Cow<'static, str> {
         Cow::Owned(format!("[{}]", T::qualified_type_name()))

--- a/src/types/external/list/btree_set.rs
+++ b/src/types/external/list/btree_set.rs
@@ -45,7 +45,7 @@ impl<T: InputType + Ord> InputType for BTreeSet<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType + Ord> OutputType for BTreeSet<T> {
     fn type_name() -> Cow<'static, str> {
         Cow::Owned(format!("[{}]", T::qualified_type_name()))

--- a/src/types/external/list/hash_set.rs
+++ b/src/types/external/list/hash_set.rs
@@ -45,7 +45,7 @@ impl<T: InputType + Hash + Eq> InputType for HashSet<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType + Hash + Eq> OutputType for HashSet<T> {
     fn type_name() -> Cow<'static, str> {
         Cow::Owned(format!("[{}]", T::qualified_type_name()))

--- a/src/types/external/list/hashbrown_hash_set.rs
+++ b/src/types/external/list/hashbrown_hash_set.rs
@@ -46,7 +46,7 @@ impl<T: InputType + Hash + Eq> InputType for HashSet<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType + Hash + Eq> OutputType for HashSet<T> {
     fn type_name() -> Cow<'static, str> {
         <StdHashSet<T> as OutputType>::type_name()

--- a/src/types/external/list/linked_list.rs
+++ b/src/types/external/list/linked_list.rs
@@ -46,7 +46,7 @@ impl<T: InputType> InputType for LinkedList<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType> OutputType for LinkedList<T> {
     fn type_name() -> Cow<'static, str> {
         Cow::Owned(format!("[{}]", T::qualified_type_name()))

--- a/src/types/external/list/slice.rs
+++ b/src/types/external/list/slice.rs
@@ -5,7 +5,7 @@ use crate::{
     InputValueError, InputValueResult, OutputType, Positioned, ServerResult, Value,
 };
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<'a, T: OutputType + 'a> OutputType for &'a [T] {
     fn type_name() -> Cow<'static, str> {
         Cow::Owned(format!("[{}]", T::qualified_type_name()))
@@ -31,7 +31,7 @@ impl<'a, T: OutputType + 'a> OutputType for &'a [T] {
 
 macro_rules! impl_output_slice_for_smart_ptr {
     ($ty:ty) => {
-        #[async_trait::async_trait]
+        #[async_trait::async_trait(?Send)]
         impl<T: OutputType> OutputType for $ty {
             fn type_name() -> Cow<'static, str> {
                 Cow::Owned(format!("[{}]", T::qualified_type_name()))

--- a/src/types/external/list/vec.rs
+++ b/src/types/external/list/vec.rs
@@ -43,7 +43,7 @@ impl<T: InputType> InputType for Vec<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType> OutputType for Vec<T> {
     fn type_name() -> Cow<'static, str> {
         Cow::Owned(format!("[{}]", T::qualified_type_name()))

--- a/src/types/external/list/vec_deque.rs
+++ b/src/types/external/list/vec_deque.rs
@@ -46,7 +46,7 @@ impl<T: InputType> InputType for VecDeque<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType> OutputType for VecDeque<T> {
     fn type_name() -> Cow<'static, str> {
         Cow::Owned(format!("[{}]", T::qualified_type_name()))

--- a/src/types/external/optional.rs
+++ b/src/types/external/optional.rs
@@ -45,7 +45,7 @@ impl<T: InputType> InputType for Option<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType + Sync> OutputType for Option<T> {
     fn type_name() -> Cow<'static, str> {
         T::type_name()

--- a/src/types/external/string.rs
+++ b/src/types/external/string.rs
@@ -29,7 +29,7 @@ impl ScalarType for String {
 
 macro_rules! impl_input_string_for_smart_ptr {
     ($ty:ty) => {
-        #[async_trait::async_trait]
+        #[async_trait::async_trait(?Send)]
         impl InputType for $ty {
             type RawValueType = Self;
 
@@ -63,7 +63,7 @@ macro_rules! impl_input_string_for_smart_ptr {
 impl_input_string_for_smart_ptr!(Box<str>);
 impl_input_string_for_smart_ptr!(std::sync::Arc<str>);
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl OutputType for str {
     fn type_name() -> Cow<'static, str> {
         Cow::Borrowed("String")

--- a/src/types/external/tokio/sync/mutex.rs
+++ b/src/types/external/tokio/sync/mutex.rs
@@ -5,7 +5,7 @@ use tokio::sync::Mutex;
 
 use crate::{registry, ContextSelectionSet, OutputType, Positioned, ServerResult, Value};
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType> OutputType for Mutex<T> {
     fn type_name() -> Cow<'static, str> {
         T::type_name()

--- a/src/types/external/tokio/sync/rw_lock.rs
+++ b/src/types/external/tokio/sync/rw_lock.rs
@@ -5,7 +5,7 @@ use tokio::sync::RwLock;
 
 use crate::{registry, ContextSelectionSet, OutputType, Positioned, ServerResult, Value};
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: OutputType> OutputType for RwLock<T> {
     fn type_name() -> Cow<'static, str> {
         T::type_name()

--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -73,7 +73,7 @@ impl<T: DeserializeOwned + Serialize + Send + Sync> InputType for Json<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: Serialize + Send + Sync> OutputType for Json<T> {
     fn type_name() -> Cow<'static, str> {
         Cow::Borrowed("JSON")
@@ -134,7 +134,7 @@ impl InputType for serde_json::Value {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl OutputType for serde_json::Value {
     fn type_name() -> Cow<'static, str> {
         Cow::Borrowed("JSON")

--- a/src/types/merged_object.rs
+++ b/src/types/merged_object.rs
@@ -13,7 +13,7 @@ use crate::{
 #[doc(hidden)]
 pub struct MergedObject<A, B>(pub A, pub B);
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<A, B> ContainerType for MergedObject<A, B>
 where
     A: ContainerType,
@@ -36,7 +36,7 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<A, B> OutputType for MergedObject<A, B>
 where
     A: OutputType,
@@ -99,7 +99,7 @@ where
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<A, B> SubscriptionType for MergedObject<A, B>
 where
     A: SubscriptionType,

--- a/src/types/merged_object.rs
+++ b/src/types/merged_object.rs
@@ -156,7 +156,7 @@ where
     fn create_field_stream<'a>(
         &'a self,
         _ctx: &'a Context<'_>,
-    ) -> Option<Pin<Box<dyn Stream<Item = Response> + Send + 'a>>> {
+    ) -> Option<Pin<Box<dyn Stream<Item = Response> + 'a>>> {
         unreachable!()
     }
 }
@@ -193,7 +193,7 @@ impl SubscriptionType for MergedObjectTail {
     fn create_field_stream<'a>(
         &'a self,
         _ctx: &'a Context<'_>,
-    ) -> Option<Pin<Box<dyn Stream<Item = Response> + Send + 'a>>> {
+    ) -> Option<Pin<Box<dyn Stream<Item = Response> + 'a>>> {
         unreachable!()
     }
 }

--- a/src/types/query_root.rs
+++ b/src/types/query_root.rs
@@ -21,7 +21,7 @@ pub(crate) struct QueryRoot<T> {
     pub(crate) inner: T,
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: ObjectType> ContainerType for QueryRoot<T> {
     async fn resolve_field(&self, ctx: &Context<'_>) -> ServerResult<Option<Value>> {
         if matches!(
@@ -103,7 +103,7 @@ impl<T: ObjectType> ContainerType for QueryRoot<T> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<T: ObjectType> OutputType for QueryRoot<T> {
     fn type_name() -> Cow<'static, str> {
         T::type_name()

--- a/src/validation/visitors/complexity.rs
+++ b/src/validation/visitors/complexity.rs
@@ -80,7 +80,7 @@ impl<'ctx, 'a> Visitor<'ctx> for ComplexityCalculate<'ctx, 'a> {
 
 #[cfg(test)]
 mod tests {
-    use futures_util::stream::BoxStream;
+    use futures_util::stream::LocalBoxStream;
 
     use super::*;
     use crate::{
@@ -142,11 +142,11 @@ mod tests {
 
     #[Subscription(internal)]
     impl Subscription {
-        async fn value(&self) -> BoxStream<'static, i32> {
+        async fn value(&self) -> LocalBoxStream<'static, i32> {
             todo!()
         }
 
-        async fn obj(&self) -> BoxStream<'static, MyObj> {
+        async fn obj(&self) -> LocalBoxStream<'static, MyObj> {
             todo!()
         }
 
@@ -155,12 +155,12 @@ mod tests {
         async fn objs(
             &self,
             #[graphql(default_with = "5")] count: usize,
-        ) -> BoxStream<'static, Vec<MyObj>> {
+        ) -> LocalBoxStream<'static, Vec<MyObj>> {
             todo!()
         }
 
         #[graphql(complexity = 3)]
-        async fn d(&self) -> BoxStream<'static, MyObj> {
+        async fn d(&self) -> LocalBoxStream<'static, MyObj> {
             todo!()
         }
     }

--- a/tests/directive.rs
+++ b/tests/directive.rs
@@ -84,7 +84,7 @@ pub async fn test_custom_directive() {
         suffix: String,
     }
 
-    #[async_trait::async_trait]
+    #[async_trait::async_trait(?Send)]
     impl CustomDirective for Concat {
         async fn resolve_field(
             &self,

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -38,7 +38,7 @@ pub async fn test_extension_ctx() {
 
     struct MyExtensionImpl;
 
-    #[async_trait::async_trait]
+    #[async_trait::async_trait(?Send)]
     impl Extension for MyExtensionImpl {
         async fn parse_query(
             &self,
@@ -129,7 +129,7 @@ pub async fn test_extension_call_order() {
         calls: Arc<Mutex<Vec<&'static str>>>,
     }
 
-    #[async_trait::async_trait]
+    #[async_trait::async_trait(?Send)]
     #[allow(unused_variables)]
     impl Extension for MyExtensionImpl {
         async fn request(&self, ctx: &ExtensionContext<'_>, next: NextRequest<'_>) -> Response {

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -5,12 +5,15 @@ use async_graphql::{
         Extension, ExtensionContext, ExtensionFactory, NextExecute, NextParseQuery,
         NextPrepareRequest, NextRequest, NextResolve, NextSubscribe, NextValidation, ResolveInfo,
     },
-    futures_util::stream::BoxStream,
     parser::types::ExecutableDocument,
     *,
 };
 use async_graphql_value::ConstValue;
-use futures_util::{lock::Mutex, stream::Stream, StreamExt};
+use futures_util::{
+    lock::Mutex,
+    stream::{LocalBoxStream, Stream},
+    StreamExt,
+};
 
 #[tokio::test]
 pub async fn test_extension_ctx() {
@@ -142,9 +145,9 @@ pub async fn test_extension_call_order() {
         fn subscribe<'s>(
             &self,
             ctx: &ExtensionContext<'_>,
-            mut stream: BoxStream<'s, Response>,
+            mut stream: LocalBoxStream<'s, Response>,
             next: NextSubscribe<'_>,
-        ) -> BoxStream<'s, Response> {
+        ) -> LocalBoxStream<'s, Response> {
             let calls = self.calls.clone();
             next.run(
                 ctx,

--- a/tests/federation.rs
+++ b/tests/federation.rs
@@ -156,7 +156,7 @@ pub async fn test_federation() {
 pub async fn test_find_entity_with_context() {
     struct MyLoader;
 
-    #[async_trait::async_trait]
+    #[async_trait::async_trait(?Send)]
     impl Loader<ID> for MyLoader {
         type Value = MyObj;
         type Error = Infallible;

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -17,7 +17,7 @@ impl RoleGuard {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl Guard for RoleGuard {
     async fn check(&self, ctx: &Context<'_>) -> Result<()> {
         if ctx.data_opt::<Role>() == Some(&self.role) {
@@ -40,7 +40,7 @@ impl<'a> UserGuard<'a> {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait::async_trait(?Send)]
 impl<'a> Guard for UserGuard<'a> {
     async fn check(&self, ctx: &Context<'_>) -> Result<()> {
         if ctx.data_opt::<Username>().map(|name| name.0.as_str()) == Some(self.username) {
@@ -296,7 +296,7 @@ pub async fn test_guard_use_params() {
         }
     }
 
-    #[async_trait::async_trait]
+    #[async_trait::async_trait(?Send)]
     impl Guard for EqGuard {
         async fn check(&self, _ctx: &Context<'_>) -> Result<()> {
             if self.expect != self.actual {


### PR DESCRIPTION
Per https://github.com/async-graphql/async-graphql/issues/723 it may be useful to have an environment without Send and Sync.

This was a bit of slog, but it wasn't actually that bad. The main things that were needed:
1. use `async_trait::async_trait(?Send)`
2. remove `Send` and `Sync` bounds almost everywhere.
3. use `LocalBoxFuture` instead of `BoxFuture`
4. use `.boxed_local()` instead of `.boxed()`
5. use `tokio::task::spawn_local()` instead of `tokio::spawn()`. Also add some `tokio::task::TaskSet`s where needed.
6. Get rid of a pesky lazy static `TEST_HARNESS`.

Overall it was mostly straightforward. Everything compiles and all tests pass.

If someone can confirm this is actually useful I'm happy to take a second pass and try and make it configurable via a feature flag.