### PR TITLE
added reset delay on load for dataloader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ apollo_tracing = ["chrono"]
 email-validator = ["fast_chemail"]
 cbor = ["serde_cbor"]
 chrono-duration = ["chrono", "iso8601"]
-dataloader = ["futures-timer", "futures-channel", "lru"]
+dataloader = ["futures-timer", "futures-channel", "lru", "tokio", "tokio-util"]
 decimal = ["rust_decimal"]
 default = ["email-validator", "tempfile", "playground", "graphiql"]
 password-strength-validator = ["zxcvbn"]
@@ -104,6 +104,7 @@ uuid08 = { version = "0.8", package = "uuid", optional = true, features = [
   "serde",
 ] }
 tempfile = { version = "3.2.0", optional = true }
+tokio-util = { version = "0.7.8", optional = true }
 
 # Non-feature optional dependencies
 blocking = { version = "1.0.2", optional = true }

--- a/src/dataloader/mod.rs
+++ b/src/dataloader/mod.rs
@@ -461,7 +461,9 @@ impl<T, C: CacheFactory> DataLoader<T, C> {
                     }
                 };
                 #[cfg(feature = "tracing")]
-                let task = task.instrument(info_span!("start_fetch")).in_current_span();
+                let task = task
+                    .instrument(info_span!("restart_fetch"))
+                    .in_current_span();
                 (self.spawner)(Box::pin(task))
             }
             Action::Delay => {}


### PR DESCRIPTION
This change allows the behavior of the dataloader delay to be changed. Instead of waiting for `delay` after the first new load (either at cold start or after all requested loads have been fulfilled), the timer is reset every time a load is requested. In my case, this has helped in a major way when a lot of loads are happening in succession (loading a huge number of objects). Previously, the batches would become very small with a short delay, while a longer delay risked waiting too long, especially when a smaller number of objects was requested instead.

The change is opt-in, requiring `reset_delay_on_load` to be set to `true`. Therefore, it shouldn't affect dataloader functionality for anyone who was using an older version of `async_graphql` or doesn't want this feature to be enabled.

All tests in `dataloader.rs` passed. I was unable to build the tests in the `tests` directory due to broken dependencies.

Feedback would be much appreciated as I'm still somewhat of a beginner in Rust, both language and ecosystem.