### PR TITLE
test(variables): empty object passes but empty array fails

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -339,6 +339,27 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_request_with_empty_object_variables() {
+        let request: Request = from_value(value! ({
+            "query": "{ a b c }",
+            "variables": {}
+        }))
+        .unwrap();
+        assert!(request.operation_name.is_none());
+        assert!(request.variables.is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_request_with_empty_array_variables() {
+        let error: DeserializerError = from_value::<Request>(value! ({
+            "query": "{ a b c }",
+            "variables": []
+        }))
+        .unwrap_err();
+        assert_eq!(error.to_string(), "invalid type: sequence, expected a map");
+    }
+
+    #[test]
     fn test_deserialize_request_with_null_variables() {
         let request: Request = from_value(value! ({
             "query": "{ a b c }",


### PR DESCRIPTION
## What
- Add tests to document the current behavior of passing the following JSON values in a request:
    - `"variables": {}` ✅ 
    - `"variables": []` ❌

## Why
- Because passing `"variables": []` works fine when using https://github.com/overblog/GraphQLBundle (PHP / Symfony graphql implementation)... So I had a breaking change when I migrated my PHP API to my Rust API (the full error message was: `InvalidRequest(Error("data did not match any variant of untagged enum BatchRequest", line: 0, column: 0))` so it was not so easy to understand what was wrong)