### PR TITLE
Remove malicious URL from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,6 @@ Add the extension crate [`async_graphql_apollo_studio_extension`](https://github
 - [Nando's](https://www.nandos.co.uk/)
 - [Prima.it](https://www.prima.it/)
 - [VoxJar](https://voxjar.com/)
-- [Zenly](https://zen.ly/)
-- [Brevz](https://brevz.io/)
-- [thorndyke](https://www.thorndyke.ai/)
 - [My Data My Consent](https://mydatamyconsent.com/)
 
 ## Community Showcase


### PR DESCRIPTION
The link to Thorndyke lead me to a website that claimed Firefox was out of date and tried to get my to download some malware.

The other two are not malicious, but are seemingly both defunct.

![Thorndyke](https://github.com/async-graphql/async-graphql/assets/2770254/34f93f18-c4ef-4814-9ed1-fc4f98899834)
