### PR TITLE
Standardize space between Args, Lists and Binary items

### DIFF
--- a/value/src/lib.rs
+++ b/value/src/lib.rs
@@ -522,7 +522,7 @@ fn write_binary(bytes: &[u8], f: &mut Formatter<'_>) -> fmt::Result {
         value.fmt(f)?;
     }
     for value in iter {
-        f.write_char(',')?;
+        f.write_str(", ")?;
         value.fmt(f)?;
     }
     f.write_char(']')
@@ -535,7 +535,7 @@ fn write_list<T: Display>(list: impl IntoIterator<Item = T>, f: &mut Formatter<'
         item.fmt(f)?;
     }
     for item in iter {
-        f.write_char(',')?;
+        f.write_str(", ")?;
         item.fmt(f)?;
     }
     f.write_char(']')
@@ -551,7 +551,7 @@ fn write_object<K: Display, V: Display>(
         write!(f, "{}: {}", name, value)?;
     }
     for (name, value) in iter {
-        f.write_char(',')?;
+        f.write_str(", ")?;
         write!(f, "{}: {}", name, value)?;
     }
     f.write_char('}')


### PR DESCRIPTION
Older implementation would not insert a whitespace after comma. This is generally quite a standard way to print lists, args and binary in GraphQL. This also works well with existing tools such as [prettier] and IDE's default formatter.

I have created a [playground] to try out prettier with different configurations. 


[playground]:https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAdWBPADnABARQFc4AnDXYdXXAMwgiVwG0AxegXVwAEALGGLAAosAQxg9GqEAHo6EKQEpuASygAbVXGFiJzKSKkAaKQAYjUgEZT2CqrXqNWHbnwHbxkmXMUr1m97pMwCKMAIyG1LgWYQC+Nugx6CCGIBBYMMrQAM7IoCIkJBAA7gAK+Qg5KCJqRSIYOSkWJCJgANZwMADKIgC2cAAymsg01Vlwjc1tHZ2iYKoA5sOj4yBwPRZwACabW-0iUPOEIvNwbCQ9YhkHyCAihDAQySB8PWoA6jzK8FmzcJ0VX2UADcvhgbmAsg0QKoxiQYCVmvMLks1GMUgArLIAD06CzUcCIEHgKLRIFEJFhN3mzSwPAAjmonlgSKoYG9lJtxMgABwmFLMiBjN40m7VWr1J50whEuAItKVW5ZAC0UDgWy2TxIcClyi1COOyKQI1RKzGPWUyBgJGIKSyeLgAEF+CyLPdZaRBqqSab7YTiUblikYCILOzOTxkAAmIPNZQaA4AYQgPUNtzUjJShDGABUQ5VjaSgcQAJJQHawTpgFnpB1lzowDD470xGJAA