### PR TITLE
Per-message hooks: one runs before the resolvers, one after. 

### DIFF
--- a/integrations/actix-web/src/handler.rs
+++ b/integrations/actix-web/src/handler.rs
@@ -38,7 +38,7 @@ impl<E: Executor> Handler<(HttpRequest, GraphQLRequest)> for GraphQL<E> {
                 .unwrap_or_default();
 
             if is_accept_multipart_mixed {
-                let stream = executor.execute_stream(graphql_req.0, None);
+                let stream = executor.execute_stream(graphql_req.0, None, None, None);
                 let interval = Box::pin(async_stream::stream! {
                     let mut interval = actix_web::rt::time::interval(Duration::from_secs(30));
                     loop {

--- a/integrations/axum/src/query.rs
+++ b/integrations/axum/src/query.rs
@@ -67,7 +67,7 @@ where
                     Ok(req) => req,
                     Err(err) => return Ok(err.into_response()),
                 };
-                let stream = executor.execute_stream(req.0, None);
+                let stream = executor.execute_stream(req.0, None, None, None);
                 let body = Body::from_stream(
                     create_multipart_mixed_stream(
                         stream,

--- a/integrations/axum/src/subscription.rs
+++ b/integrations/axum/src/subscription.rs
@@ -1,9 +1,9 @@
-use std::{borrow::Cow, convert::Infallible, future::Future, str::FromStr};
+use std::{borrow::Cow, convert::Infallible, future::Future, str::FromStr, sync::Arc};
 
 use async_graphql::{
     futures_util::task::{Context, Poll},
     http::{WebSocketProtocols, WsMessage, ALL_WEBSOCKET_PROTOCOLS},
-    Data, Executor, Result,
+    Data, Executor, PerMessagePostHook, PerMessagePreHook, Result,
 };
 use axum::{
     body::{Body, HttpBody},
@@ -131,6 +131,8 @@ pub struct GraphQLWebSocket<Sink, Stream, E, OnConnInit> {
     data: Data,
     on_connection_init: OnConnInit,
     protocol: GraphQLProtocol,
+    per_message_pre_hook: Option<Arc<PerMessagePreHook>>,
+    per_message_post_hook: Option<Arc<PerMessagePostHook>>,
 }
 
 impl<S, E> GraphQLWebSocket<SplitSink<S, Message>, SplitStream<S>, E, DefaultOnConnInitType>
@@ -165,6 +167,8 @@ where
             data: Data::default(),
             on_connection_init: default_on_connection_init,
             protocol,
+            per_message_pre_hook: None,
+            per_message_post_hook: None,
         }
     }
 }
@@ -205,6 +209,51 @@ where
             data: self.data,
             on_connection_init: callback,
             protocol: self.protocol,
+            per_message_pre_hook: self.per_message_pre_hook,
+            per_message_post_hook: self.per_message_post_hook,
+        }
+    }
+
+    /// Specify a per-message pre-hook.
+    ///
+    /// This hook will run for each message that the subscription stream emits, before running
+    /// the resolvers. It can be used for starting a transaction, that all resolvers will use.
+    #[must_use]
+    pub fn per_message_pre_hook<F, Fut>(self, hook: F) -> Self
+    where
+        Fut: Future<Output = Result<Option<Data>>> + Send + 'static,
+        F: Fn() -> Fut + Send + Sync + 'static,
+    {
+        GraphQLWebSocket {
+            sink: self.sink,
+            stream: self.stream,
+            executor: self.executor,
+            data: self.data,
+            on_connection_init: self.on_connection_init,
+            protocol: self.protocol,
+            per_message_pre_hook: Some(Arc::new(move || Box::pin(hook()))),
+            per_message_post_hook: self.per_message_post_hook,
+        }
+    }
+
+    /// Specify a per-message post-hook.
+    ///
+    /// This hook will run for each message that the subscription stream emits, after running
+    /// the resolvers. It can be used for committing a transaction, that all resolvers will use.
+    #[must_use]
+    pub fn per_message_post_hook<F>(self, hook: F) -> Self
+    where
+        F: for<'a> Fn(&'a Data) -> BoxFuture<'a, Result<()>> + Send + Sync + 'static,
+    {
+        GraphQLWebSocket {
+            sink: self.sink,
+            stream: self.stream,
+            executor: self.executor,
+            data: self.data,
+            on_connection_init: self.on_connection_init,
+            protocol: self.protocol,
+            per_message_pre_hook: self.per_message_pre_hook,
+            per_message_post_hook: Some(Arc::new(hook)),
         }
     }
 
@@ -225,6 +274,8 @@ where
 
         let stream =
             async_graphql::http::WebSocket::new(self.executor.clone(), input, self.protocol.0)
+                .per_message_pre_hook(self.per_message_pre_hook)
+                .per_message_post_hook(self.per_message_post_hook)
                 .connection_data(self.data)
                 .on_connection_init(self.on_connection_init)
                 .map(|msg| match msg {

--- a/integrations/poem/src/query.rs
+++ b/integrations/poem/src/query.rs
@@ -59,7 +59,7 @@ where
         if is_accept_multipart_mixed {
             let (req, mut body) = req.split();
             let req = GraphQLRequest::from_request(&req, &mut body).await?;
-            let stream = self.executor.execute_stream(req.0, None);
+            let stream = self.executor.execute_stream(req.0, None, None, None);
             Ok(Response::builder()
                 .header("content-type", "multipart/mixed; boundary=graphql")
                 .body(Body::from_bytes_stream(

--- a/integrations/poem/src/subscription.rs
+++ b/integrations/poem/src/subscription.rs
@@ -1,11 +1,11 @@
-use std::{io::Error as IoError, str::FromStr};
+use std::{io::Error as IoError, str::FromStr, sync::Arc};
 
 use async_graphql::{
     http::{WebSocketProtocols, WsMessage, ALL_WEBSOCKET_PROTOCOLS},
-    Data, Executor,
+    Data, Executor, PerMessagePostHook, PerMessagePreHook,
 };
 use futures_util::{
-    future::{self, Ready},
+    future::{self, BoxFuture, Ready},
     stream::{SplitSink, SplitStream},
     Future, Sink, SinkExt, Stream, StreamExt,
 };
@@ -117,6 +117,8 @@ pub struct GraphQLWebSocket<Sink, Stream, E, OnConnInit> {
     data: Data,
     on_connection_init: OnConnInit,
     protocol: GraphQLProtocol,
+    per_message_pre_hook: Option<Arc<PerMessagePreHook>>,
+    per_message_post_hook: Option<Arc<PerMessagePostHook>>,
 }
 
 impl<S, E> GraphQLWebSocket<SplitSink<S, Message>, SplitStream<S>, E, DefaultOnConnInitType>
@@ -151,6 +153,8 @@ where
             data: Data::default(),
             on_connection_init: default_on_connection_init,
             protocol,
+            per_message_pre_hook: None,
+            per_message_post_hook: None,
         }
     }
 }
@@ -191,6 +195,51 @@ where
             data: self.data,
             on_connection_init: callback,
             protocol: self.protocol,
+            per_message_pre_hook: self.per_message_pre_hook,
+            per_message_post_hook: self.per_message_post_hook,
+        }
+    }
+
+    /// Specify a per-message pre-hook.
+    ///
+    /// This hook will run for each message that the subscription stream emits, before running
+    /// the resolvers. It can be used for starting a transaction, that all resolvers will use.
+    #[must_use]
+    pub fn per_message_pre_hook<F, Fut>(self, hook: F) -> Self
+    where
+        Fut: Future<Output = async_graphql::Result<Option<Data>>> + Send + 'static,
+        F: Fn() -> Fut + Send + Sync + 'static,
+    {
+        GraphQLWebSocket {
+            sink: self.sink,
+            stream: self.stream,
+            executor: self.executor,
+            data: self.data,
+            on_connection_init: self.on_connection_init,
+            protocol: self.protocol,
+            per_message_pre_hook: Some(Arc::new(move || Box::pin(hook()))),
+            per_message_post_hook: self.per_message_post_hook,
+        }
+    }
+
+    /// Specify a per-message post-hook.
+    ///
+    /// This hook will run for each message that the subscription stream emits, after running
+    /// the resolvers. It can be used for committing a transaction, that all resolvers will use.
+    #[must_use]
+    pub fn per_message_post_hook<F>(self, hook: F) -> Self
+    where
+        F: for<'a> Fn(&'a Data) -> BoxFuture<'a, async_graphql::Result<()>> + Send + Sync + 'static,
+    {
+        GraphQLWebSocket {
+            sink: self.sink,
+            stream: self.stream,
+            executor: self.executor,
+            data: self.data,
+            on_connection_init: self.on_connection_init,
+            protocol: self.protocol,
+            per_message_pre_hook: self.per_message_pre_hook,
+            per_message_post_hook: Some(Arc::new(hook)),
         }
     }
 
@@ -213,6 +262,8 @@ where
             async_graphql::http::WebSocket::new(self.executor.clone(), stream, self.protocol.0)
                 .connection_data(self.data)
                 .on_connection_init(self.on_connection_init)
+                .per_message_pre_hook(self.per_message_pre_hook)
+                .per_message_post_hook(self.per_message_post_hook)
                 .map(|msg| match msg {
                     WsMessage::Text(text) => Message::text(text),
                     WsMessage::Close(code, status) => Message::close_with(code, status),

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use futures_util::stream::{BoxStream, FuturesOrdered, StreamExt};
 
-use crate::{BatchRequest, BatchResponse, Data, Request, Response};
+use crate::{
+    BatchRequest, BatchResponse, Data, PerMessagePostHook, PerMessagePreHook, Request, Response,
+};
 
 /// Represents a GraphQL executor
 #[async_trait::async_trait]
@@ -29,5 +31,7 @@ pub trait Executor: Unpin + Clone + Send + Sync + 'static {
         &self,
         request: Request,
         session_data: Option<Arc<Data>>,
+        per_message_pre_hook: Option<Arc<PerMessagePreHook>>,
+        per_message_post_hook: Option<Arc<PerMessagePostHook>>,
     ) -> BoxStream<'static, Response>;
 }

--- a/src/resolver_utils/container.rs
+++ b/src/resolver_utils/container.rs
@@ -273,6 +273,7 @@ impl<'a> Fields<'a> {
                                                 item: directive,
                                                 schema_env: ctx_field.schema_env,
                                                 query_env: ctx_field.query_env,
+                                                message_data: ctx_field.message_data,
                                             };
                                             let directive_instance = directive_factory
                                                 .create(&ctx_directive, &directive.node)?;

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -113,6 +113,8 @@ pub async fn test_extension_ctx() {
         let mut stream = schema.execute_stream_with_session_data(
             Request::new("subscription { value }"),
             Arc::new(data),
+            None,
+            None,
         );
         assert_eq!(
             stream.next().await.unwrap().into_result().unwrap().data,


### PR DESCRIPTION
This is useful for making sure that all resolvers for a message emitted in subscription context run in the same transaction.
Closes [this issue](https://github.com/async-graphql/async-graphql/issues/1279).