### PR TITLE
Include `@composeDirective` in Federation's `_service` field and document `#[TypeDirective]`

### DIFF
--- a/docs/en/src/apollo_federation.md
+++ b/docs/en/src/apollo_federation.md
@@ -493,4 +493,28 @@ struct User {
 }
 ```
 
+## `@composeDirective`
+
+The [`@composeDirective` directive](https://www.apollographql.com/docs/federation/federation-spec/#composedirective) is used to add a custom type system directive to the supergraph schema. Without `@composeDirective`, and [custom type system directives](./custom_directive#type-system-directives) are omitted from the composed supergraph schema. To include a custom type system directive as a composed directive, just add the `composable` attribute to the `#[TypeDirective]` macro:
+
+```rust
+# extern crate async_graphql;
+# use async_graphql::*;
+#[TypeDirective(
+    location = "Object",
+    composable = "https://custom.spec.dev/extension/v1.0",
+)]
+fn custom() {}
+```
+
+In addition to the [normal type system directive behavior](./custom_directive#type-system-directives), this will add the following bits to the output schema:
+
+```graphql
+extend schema @link(
+	url: "https://custom.spec.dev/extension/v1.0"
+	import: ["@custom"]
+)
+	@composeDirective(name: "@custom")
+```
+
 [`@key`]: https://www.apollographql.com/docs/federation/entities#1-define-a-key

--- a/docs/en/src/custom_directive.md
+++ b/docs/en/src/custom_directive.md
@@ -1,11 +1,13 @@
 # Custom directive
 
-`Async-graphql` can easily customize directives, which can extend the behavior of GraphQL.
+There are two types of directives in GraphQL: executable and type system. Executable directives are used by the client within an operation to modify the behavior (like the built-in `@include` and `@skip` directives). Type system directives provide additional information about the types, potentially modifying how the server behaves (like `@deprecated` and `@oneOf`). `async-graphql` allows you to declare both types of custom directives, with different limitations on each. 
 
-To create a custom directive, you need to implement the `CustomDirective` trait, and then use the `Directive` macro to 
+## Executable directives
+
+To create a custom executable directive, you need to implement the `CustomDirective` trait, and then use the `Directive` macro to 
 generate a factory function that receives the parameters of the directive and returns an instance of the directive.
 
-Currently `Async-graphql` only supports directive located at `FIELD`.
+Currently `async-graphql` only supports custom executable directives located at `FIELD`.
 
 ```rust
 # extern crate async_graphql;
@@ -51,3 +53,46 @@ let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
     .directive(concat)
     .finish();
 ```
+
+## Type system directives
+
+To create a custom type system directive, you can use the `#[TypeDirective]` macro on a function:
+
+```rust
+# extern crate async_graphql;
+# use async_graphql::*;
+#[TypeDirective(
+    location = "FieldDefinition",
+    location = "Object",
+)]
+fn testDirective(scope: String, input: u32, opt: Option<u64>) {}
+```
+
+Current only the `FieldDefinition` and `Object` locations are supported, you can select one or both. After declaring the directive, you can apply it to a relevant location (after importing the function) like this:
+
+```rust
+# extern crate async_graphql;
+# use async_graphql::*;
+#[derive(SimpleObject)]
+#[graphql(
+    directive = testDirective::apply("simple object type".to_string(), 1, Some(3))
+)]
+struct SimpleValue {
+    #[graphql(
+        directive = testDirective::apply("field and param with \" symbol".to_string(), 2, Some(3))
+    )]
+    some_data: String,
+}
+```
+
+This example produces a schema like this:
+
+```graphql
+type SimpleValue @testDirective(scope: "simple object type", input: 1, opt: 3) {
+	someData: String! @testDirective(scope: "field and param with \" symbol", input: 2, opt: 3)
+}
+
+directive @testDirective(scope: String!, input: Int!, opt: Int) on FIELD_DEFINITION | OBJECT
+```
+
+Note: To use a type-system directive with Apollo Federation's `@composeDirective`, see [the federation docs](./apollo_federation#composeDirective)

--- a/docs/en/src/custom_directive.md
+++ b/docs/en/src/custom_directive.md
@@ -73,6 +73,11 @@ Current only the `FieldDefinition` and `Object` locations are supported, you can
 ```rust
 # extern crate async_graphql;
 # use async_graphql::*;
+# #[TypeDirective(
+# location = "FieldDefinition",
+# location = "Object",
+# )]
+# fn testDirective(scope: String, input: u32, opt: Option<u64>) {}
 #[derive(SimpleObject)]
 #[graphql(
     directive = testDirective::apply("simple object type".to_string(), 1, Some(3))

--- a/src/dynamic/resolve.rs
+++ b/src/dynamic/resolve.rs
@@ -154,7 +154,7 @@ fn collect_service_field<'a>(
                     sdl: Some(
                         ctx.schema_env
                             .registry
-                            .export_sdl(SDLExportOptions::new().federation()),
+                            .export_sdl(SDLExportOptions::new().federation().compose_directive()),
                     ),
                 },
                 &ctx_obj,

--- a/src/types/query_root.rs
+++ b/src/types/query_root.rs
@@ -86,9 +86,9 @@ impl<T: ObjectType> ContainerType for QueryRoot<T> {
                 return OutputType::resolve(
                     &Service {
                         sdl: Some(
-                            ctx.schema_env
-                                .registry
-                                .export_sdl(SDLExportOptions::new().federation()),
+                            ctx.schema_env.registry.export_sdl(
+                                SDLExportOptions::new().federation().compose_directive(),
+                            ),
                         ),
                     },
                     &ctx_obj,


### PR DESCRIPTION
Required in order to get subgraph compatibility tests passing so `async-graphql` will show as supporting `@composeDirective` in [Apollo's docs](https://www.apollographql.com/docs/federation/building-supergraphs/supported-subgraphs#rust)