### PR TITLE
fix: bump opentelemetry 0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ fast_chemail = { version = "0.9.6", optional = true }
 hashbrown = { version = "0.12.0", optional = true }
 iso8601 = { version = "0.6.0", optional = true }
 log = { version = "0.4.16", optional = true }
-opentelemetry = { version = "0.19.0", optional = true, default-features = false, features = [
+opentelemetry = { version = "0.20.0", optional = true, default-features = false, features = [
   "trace",
 ] }
 rust_decimal = { version = "1.14.3", optional = true }


### PR DESCRIPTION
update open telemetry to 0.20.0 to support Tracer creation via sdktrace