### PR TITLE
Update axum and http

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ futures-util = { workspace = true, features = [
   "async-await",
   "async-await-macro",
 ] }
-http = "1.0"
 indexmap.workspace = true
 mime = "0.3.15"
 multer = "2.0.0"
@@ -64,6 +63,7 @@ static_assertions = "1.1.0"
 thiserror.workspace = true
 base64 = "0.13.0"
 serde_urlencoded = "0.7.0"
+http1.workspace = true
 
 # Feature optional dependencies
 bson = { version = "2.4.0", optional = true, features = [
@@ -114,6 +114,7 @@ serde_cbor = { version = "0.11.1", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 zxcvbn = { version = "2.1.2", optional = true }
 handlebars = { version = "4.3.6", optional = true }
+http02 = { package = "http", version = "0.2.10", optional = true }
 
 [dev-dependencies]
 futures-channel = "0.3.13"
@@ -158,3 +159,4 @@ thiserror = "1.0.24"
 async-trait = "0.1.51"
 futures-util = { version = "0.3.0", default-features = false }
 tokio-util = { version = "0.7.1", default-features = false }
+http1 = { package = "http", version = "1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ futures-util = { workspace = true, features = [
 ] }
 indexmap.workspace = true
 mime = "0.3.15"
-multer = "2.0.0"
+multer = "3.0.0"
 num-traits = "0.2.14"
 once_cell = "1.7.2"
 pin-project-lite = "0.2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures-util = { workspace = true, features = [
   "async-await",
   "async-await-macro",
 ] }
-http = "0.2.3"
+http = "1.0"
 indexmap.workspace = true
 mime = "0.3.15"
 multer = "2.0.0"

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ This crate offers the following features. Most are not activated by default, exc
 | **`dynamic-schema`**           | Support dynamic schema                                                                                                                                                                        |
 | **`graphiql`**                 | Enables the [GraphiQL IDE](https://github.com/graphql/graphiql) integration                                                                                                                   |
 | **`playground`**               | Enables the [GraphQL playground IDE](https://github.com/graphql/graphql-playground) integration                                                                                               |
+| **`http02`**                   | Integrate with the [`http 0.2` crate](https://docs.rs/http/0.2.11/http/index.html).                                                                                                           |
 
 ### Observability
 

--- a/integrations/actix-web/Cargo.toml
+++ b/integrations/actix-web/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "6.0.11"
 
 [dependencies]
-async-graphql = { workspace = true, features = ["playground"] }
+async-graphql = { workspace = true, features = ["playground", "http02"] }
 
 actix = "0.13.0"
 actix-http = "3.1.0"

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "6.0.11"
 
 [dependencies]
-async-graphql = { workspace = true }
+async-graphql.workspace = true
 
 async-trait.workspace = true
 axum = { version = "0.7.0", features = ["ws"] }

--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -15,7 +15,7 @@ version = "6.0.11"
 async-graphql = { workspace = true }
 
 async-trait.workspace = true
-axum = { version = "0.6.0", features = ["ws", "headers"] }
+axum = { version = "0.7.0", features = ["ws"] }
 bytes.workspace = true
 futures-util.workspace = true
 serde_json.workspace = true

--- a/integrations/axum/src/extract.rs
+++ b/integrations/axum/src/extract.rs
@@ -2,13 +2,10 @@ use std::{io::ErrorKind, marker::PhantomData};
 
 use async_graphql::{futures_util::TryStreamExt, http::MultipartOptions, ParseRequestError};
 use axum::{
-    body::HttpBody,
-    extract::{BodyStream, FromRequest},
-    http::{self, Method, Request},
+    extract::{FromRequest, Request},
+    http::{self, Method},
     response::IntoResponse,
-    BoxError,
 };
-use bytes::Bytes;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 
 /// Extractor for GraphQL request.
@@ -29,25 +26,25 @@ impl<R> GraphQLRequest<R> {
 pub mod rejection {
     use async_graphql::ParseRequestError;
     use axum::{
-        body::{boxed, Body, BoxBody},
+        body::Body,
         http,
         http::StatusCode,
-        response::IntoResponse,
+        response::{IntoResponse, Response},
     };
 
     /// Rejection used for [`GraphQLRequest`](GraphQLRequest).
     pub struct GraphQLRejection(pub ParseRequestError);
 
     impl IntoResponse for GraphQLRejection {
-        fn into_response(self) -> http::Response<BoxBody> {
+        fn into_response(self) -> Response {
             match self.0 {
                 ParseRequestError::PayloadTooLarge => http::Response::builder()
                     .status(StatusCode::PAYLOAD_TOO_LARGE)
-                    .body(boxed(Body::empty()))
+                    .body(Body::empty())
                     .unwrap(),
                 bad_request => http::Response::builder()
                     .status(StatusCode::BAD_REQUEST)
-                    .body(boxed(Body::from(format!("{:?}", bad_request))))
+                    .body(Body::from(format!("{:?}", bad_request)))
                     .unwrap(),
             }
         }
@@ -61,17 +58,14 @@ pub mod rejection {
 }
 
 #[async_trait::async_trait]
-impl<S, B, R> FromRequest<S, B> for GraphQLRequest<R>
+impl<S, R> FromRequest<S> for GraphQLRequest<R>
 where
-    B: HttpBody + Send + Sync + 'static,
-    B::Data: Into<Bytes>,
-    B::Error: Into<BoxError>,
     S: Send + Sync,
     R: IntoResponse + From<ParseRequestError>,
 {
     type Rejection = R;
 
-    async fn from_request(req: Request<B>, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         Ok(GraphQLRequest(
             GraphQLBatchRequest::<R>::from_request(req, state)
                 .await?
@@ -97,17 +91,14 @@ impl<R> GraphQLBatchRequest<R> {
 }
 
 #[async_trait::async_trait]
-impl<S, B, R> FromRequest<S, B> for GraphQLBatchRequest<R>
+impl<S, R> FromRequest<S> for GraphQLBatchRequest<R>
 where
-    B: HttpBody + Send + Sync + 'static,
-    B::Data: Into<Bytes>,
-    B::Error: Into<BoxError>,
     S: Send + Sync,
     R: IntoResponse + From<ParseRequestError>,
 {
     type Rejection = R;
 
-    async fn from_request(req: Request<B>, state: &S) -> Result<Self, Self::Rejection> {
+    async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
         if let (&Method::GET, uri) = (req.method(), req.uri()) {
             let res = async_graphql::http::parse_query_string(uri.query().unwrap_or_default())
                 .map_err(|err| {
@@ -123,14 +114,9 @@ where
                 .get(http::header::CONTENT_TYPE)
                 .and_then(|value| value.to_str().ok())
                 .map(ToString::to_string);
-            let body_stream = BodyStream::from_request(req, state)
-                .await
-                .map_err(|_| {
-                    ParseRequestError::Io(std::io::Error::new(
-                        ErrorKind::Other,
-                        "body has been taken by another extractor".to_string(),
-                    ))
-                })?
+            let body_stream = req
+                .into_body()
+                .into_data_stream()
                 .map_err(|err| std::io::Error::new(ErrorKind::Other, err.to_string()));
             let body_reader = tokio_util::io::StreamReader::new(body_stream).compat();
             Ok(Self(

--- a/integrations/axum/src/query.rs
+++ b/integrations/axum/src/query.rs
@@ -9,7 +9,7 @@ use async_graphql::{
     Executor,
 };
 use axum::{
-    body::{HttpBody, Body},
+    body::{Body, HttpBody},
     extract::FromRequest,
     http::{Request as HttpRequest, Response as HttpResponse},
     response::IntoResponse,

--- a/integrations/axum/src/query.rs
+++ b/integrations/axum/src/query.rs
@@ -38,7 +38,7 @@ impl<E> GraphQL<E> {
 
 impl<B, E> Service<HttpRequest<B>> for GraphQL<E>
 where
-    B: HttpBody<Data = Bytes> + Send + Sync + 'static,
+    B: HttpBody<Data = Bytes> + Send + 'static,
     B::Data: Into<Bytes>,
     B::Error: Into<BoxError>,
     E: Executor,

--- a/integrations/axum/src/response.rs
+++ b/integrations/axum/src/response.rs
@@ -1,8 +1,8 @@
 use axum::{
-    body::{boxed, Body, BoxBody},
+    body::Body,
     http,
-    http::{HeaderValue, Response},
-    response::IntoResponse,
+    http::HeaderValue,
+    response::{IntoResponse, Response},
 };
 
 /// Responder for a GraphQL response.
@@ -24,9 +24,9 @@ impl From<async_graphql::BatchResponse> for GraphQLResponse {
 }
 
 impl IntoResponse for GraphQLResponse {
-    fn into_response(self) -> Response<BoxBody> {
+    fn into_response(self) -> Response {
         let body: Body = serde_json::to_string(&self.0).unwrap().into();
-        let mut resp = Response::new(boxed(body));
+        let mut resp = Response::new(body);
         resp.headers_mut().insert(
             http::header::CONTENT_TYPE,
             HeaderValue::from_static("application/json"),

--- a/integrations/axum/src/subscription.rs
+++ b/integrations/axum/src/subscription.rs
@@ -6,7 +6,7 @@ use async_graphql::{
     Data, Executor, Result,
 };
 use axum::{
-    body::{HttpBody, Body},
+    body::{Body, HttpBody},
     extract::{
         ws::{CloseFrame, Message},
         FromRequestParts, WebSocketUpgrade,

--- a/integrations/axum/src/subscription.rs
+++ b/integrations/axum/src/subscription.rs
@@ -6,7 +6,7 @@ use async_graphql::{
     Data, Executor, Result,
 };
 use axum::{
-    body::{boxed, BoxBody, HttpBody},
+    body::{HttpBody, Body},
     extract::{
         ws::{CloseFrame, Message},
         FromRequestParts, WebSocketUpgrade,
@@ -82,7 +82,7 @@ where
     B: HttpBody + Send + 'static,
     E: Executor,
 {
-    type Response = Response<BoxBody>;
+    type Response = Response<Body>;
     type Error = Infallible;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -98,11 +98,11 @@ where
 
             let protocol = match GraphQLProtocol::from_request_parts(&mut parts, &()).await {
                 Ok(protocol) => protocol,
-                Err(err) => return Ok(err.into_response().map(boxed)),
+                Err(err) => return Ok(err.into_response()),
             };
             let upgrade = match WebSocketUpgrade::from_request_parts(&mut parts, &()).await {
                 Ok(protocol) => protocol,
-                Err(err) => return Ok(err.into_response().map(boxed)),
+                Err(err) => return Ok(err.into_response()),
             };
 
             let executor = executor.clone();
@@ -112,7 +112,7 @@ where
                 .on_upgrade(move |stream| {
                     GraphQLWebSocket::new(stream, executor, protocol).serve()
                 });
-            Ok(resp.into_response().map(boxed))
+            Ok(resp.into_response())
         })
     }
 }

--- a/integrations/poem/Cargo.toml
+++ b/integrations/poem/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "6.0.11"
 
 [dependencies]
-async-graphql = { workspace = true }
+async-graphql = { workspace = true, features = ["http02"] }
 
 futures-util = { workspace = true, default-features = false }
 poem = { version = "1.3.48", features = ["websocket"] }

--- a/integrations/warp/Cargo.toml
+++ b/integrations/warp/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/async-graphql/async-graphql"
 version = "6.0.11"
 
 [dependencies]
-async-graphql = { workspace = true }
+async-graphql = { workspace = true, features = ["http02"] }
 
 futures-util = { workspace = true, default-features = false, features = [
   "sink",

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,10 +10,10 @@ use std::{
 
 use async_graphql_value::{Value as InputValue, Variables};
 use fnv::FnvHashMap;
-use http::{
-    header::{AsHeaderName, HeaderMap, IntoHeaderName},
-    HeaderValue,
-};
+#[cfg(feature = "http02")]
+use http02 as http;
+#[cfg(not(feature = "http02"))]
+use http1 as http;
 use serde::{
     ser::{SerializeSeq, Serializer},
     Serialize,
@@ -257,7 +257,7 @@ pub struct QueryEnvInner {
     pub session_data: Arc<Data>,
     pub ctx_data: Arc<Data>,
     pub extension_data: Arc<Data>,
-    pub http_headers: Mutex<HeaderMap>,
+    pub http_headers: Mutex<http::HeaderMap>,
     pub introspection_mode: IntrospectionMode,
     pub errors: Mutex<Vec<ServerError>>,
 }
@@ -432,7 +432,7 @@ impl<'a, T> ContextBase<'a, T> {
     ///     }
     /// }
     /// ```
-    pub fn http_header_contains(&self, key: impl AsHeaderName) -> bool {
+    pub fn http_header_contains(&self, key: impl http::header::AsHeaderName) -> bool {
         self.query_env
             .http_headers
             .lock()
@@ -483,9 +483,9 @@ impl<'a, T> ContextBase<'a, T> {
     /// ```
     pub fn insert_http_header(
         &self,
-        name: impl IntoHeaderName,
-        value: impl TryInto<HeaderValue>,
-    ) -> Option<HeaderValue> {
+        name: impl http::header::IntoHeaderName,
+        value: impl TryInto<http::HeaderValue>,
+    ) -> Option<http::HeaderValue> {
         if let Ok(value) = value.try_into() {
             self.query_env
                 .http_headers
@@ -534,8 +534,8 @@ impl<'a, T> ContextBase<'a, T> {
     /// ```
     pub fn append_http_header(
         &self,
-        name: impl IntoHeaderName,
-        value: impl TryInto<HeaderValue>,
+        name: impl http::header::IntoHeaderName,
+        value: impl TryInto<http::HeaderValue>,
     ) -> bool {
         if let Ok(value) = value.try_into() {
             self.query_env

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,11 @@
 //! - `fast_chemail`: Integrate with the [`fast_chemail` crate](https://crates.io/crates/fast_chemail).
 //! - `tempfile`: Save the uploaded content in the temporary file.
 //! - `dynamic-schema`: Support dynamic schema.
+//! - `graphiql`: Enables the [GraphiQL IDE](https://github.com/graphql/graphiql)
+//!   integration
+//! - `playground`: Enables the [GraphQL playground IDE](https://github.com/graphql/graphql-playground)
+//!   integration
+//! - `http02`: Integrate with the [`http 0.2` crate](https://docs.rs/http/0.2.11/http/index.html).
 //!
 //! ## Integrations
 //!

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
-use http::{
-    header::{HeaderMap, HeaderName},
-    HeaderValue,
-};
+#[cfg(feature = "http02")]
+use http02 as http;
+#[cfg(not(feature = "http02"))]
+use http1 as http;
 use serde::{Deserialize, Serialize};
 
 use crate::{CacheControl, Result, ServerError, Value};
@@ -30,7 +30,7 @@ pub struct Response {
 
     /// HTTP headers
     #[serde(skip)]
-    pub http_headers: HeaderMap,
+    pub http_headers: http::HeaderMap,
 }
 
 impl Response {
@@ -61,7 +61,7 @@ impl Response {
 
     /// Set the http headers of the response.
     #[must_use]
-    pub fn http_headers(self, http_headers: HeaderMap) -> Self {
+    pub fn http_headers(self, http_headers: http::HeaderMap) -> Self {
         Self {
             http_headers,
             ..self
@@ -133,18 +133,20 @@ impl BatchResponse {
     }
 
     /// Returns HTTP headers map.
-    pub fn http_headers(&self) -> HeaderMap {
+    pub fn http_headers(&self) -> http::HeaderMap {
         match self {
             BatchResponse::Single(resp) => resp.http_headers.clone(),
-            BatchResponse::Batch(resp) => resp.iter().fold(HeaderMap::new(), |mut acc, resp| {
-                acc.extend(resp.http_headers.clone());
-                acc
-            }),
+            BatchResponse::Batch(resp) => {
+                resp.iter().fold(http::HeaderMap::new(), |mut acc, resp| {
+                    acc.extend(resp.http_headers.clone());
+                    acc
+                })
+            }
         }
     }
 
     /// Returns HTTP headers iterator.
-    pub fn http_headers_iter(&self) -> impl Iterator<Item = (HeaderName, HeaderValue)> {
+    pub fn http_headers_iter(&self) -> impl Iterator<Item = (http::HeaderName, http::HeaderValue)> {
         let headers = self.http_headers();
 
         let mut current_name = None;

--- a/src/validators/url.rs
+++ b/src/validators/url.rs
@@ -1,5 +1,10 @@
 use std::str::FromStr;
 
+#[cfg(feature = "http02")]
+use http02 as http;
+#[cfg(not(feature = "http02"))]
+use http1 as http;
+
 use crate::{InputType, InputValueError};
 
 pub fn url<T: AsRef<str> + InputType>(value: &T) -> Result<(), InputValueError<T>> {


### PR DESCRIPTION
Updates to axum 0.7 and http 1.0.

Note that this is a breaking change because http is a public dependency of async-graphql.

Some integrations, such as warp, can't be updated yet because they don't support http 1.0. Might also get issues with actix-web which appears to use http 0.2 🤔 

Fixes https://github.com/async-graphql/async-graphql/issues/1430