### PR TITLE
Add `shareable` Attribute To InputObject To Avoid Errors

### DIFF
--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -485,6 +485,8 @@ pub struct InputObject {
     // for SimpleObject
     #[darling(default)]
     pub complex: bool,
+    #[darling(default)]
+    pub shareable: bool,
 }
 
 #[derive(FromVariant)]


### PR DESCRIPTION
Closes #1419