### PR TITLE
Address axum integration compilation error with non-Sync body

### DIFF
--- a/integrations/axum/src/extract.rs
+++ b/integrations/axum/src/extract.rs
@@ -99,7 +99,8 @@ where
     type Rejection = R;
 
     async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
-        if let (&Method::GET, uri) = (req.method(), req.uri()) {
+        if req.method() == Method::GET {
+            let uri = req.uri();
             let res = async_graphql::http::parse_query_string(uri.query().unwrap_or_default())
                 .map_err(|err| {
                     ParseRequestError::Io(std::io::Error::new(


### PR DESCRIPTION
This fixes an error I'm seeing when compiling a project that uses `async-graphql-axum` with axum 0.7. The issue and fix was brought up in https://github.com/async-graphql/async-graphql/pull/1431#pullrequestreview-1758338145 but not implemented.

Without this change, we get the following when running `cargo clippy --package async-graphql-axum`:
```
    Checking async-graphql-axum v7.0.0 (/home/alden/async-graphql/integrations/axum)
error: future cannot be sent between threads safely
   --> integrations/axum/src/extract.rs:101:86
    |
101 |       async fn from_request(req: Request, _state: &S) -> Result<Self, Self::Rejection> {
    |  ______________________________________________________________________________________^
102 | |         if let (&Method::GET, uri) = (req.method(), req.uri()) {
103 | |             let res = async_graphql::http::parse_query_string(uri.query().unwrap_or_default())
104 | |                 .map_err(|err| {
...   |
131 | |         }
132 | |     }
    | |_____^ future created by async block is not `Send`
    |
    = help: the trait `std::marker::Sync` is not implemented for `(dyn axum::body::HttpBody<Data = bytes::Bytes, Error = axum::Error> + std::marker::Send + 'static)`
note: future is not `Send` as this value is used across an await
   --> integrations/axum/src/extract.rs:128:18
    |
102 |         if let (&Method::GET, uri) = (req.method(), req.uri()) {
    |                                       --- has type `&axum::http::Request<axum::body::Body>` which is not `Send`
...
128 |                 .await?,
    |                  ^^^^^ await occurs here, with `req` maybe used later
...
132 |     }
    |     - `req` is later dropped here
help: consider moving this into a `let` binding to create a shorter lived borrow
   --> integrations/axum/src/extract.rs:102:39
    |
102 |         if let (&Method::GET, uri) = (req.method(), req.uri()) {
    |                                       ^^^^^^^^^^^^
    = note: required for the cast from `std::pin::Pin<std::boxed::Box<[async block@integrations/axum/src/extract.rs:101:86: 132:6]>>` to `std::pin::Pin<std::boxed::Box<(dyn futures_util::Future<Output = std::result::Result<extract::GraphQLBatchRequest<R>, R>> + std::marker::Send + 'async_trait)>>`

error: could not compile `async-graphql-axum` (lib) due to previous error
```

After the change, this is no longer a problem.

Separately, I'm not entirely sure why it is not being flagged in CI.