### PR TITLE
fix: date cursor precision string format

### DIFF
--- a/src/types/connection/cursor.rs
+++ b/src/types/connection/cursor.rs
@@ -125,7 +125,7 @@ impl CursorType for chrono::DateTime<chrono::Utc> {
     }
 
     fn encode_cursor(&self) -> String {
-        self.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+        self.to_rfc3339_opts(chrono::SecondsFormat::Micros, true)
     }
 }
 


### PR DESCRIPTION
Sql databases (pg/mysql) timestamp [precision is 6 subseconds digits max](https://www.postgresql.org/docs/16/datatype-datetime.html#DATATYPE-DATETIME-INPUT) `2024-01-09T22:03:07.195000Z`, which is also a default. 

Using 3 subseconds digits precision for cursor date->string conversion will not match `2024-01-09T22:03:07.195Z != 2024-01-09T22:03:07.195000Z` on database level which may result in shifted/incorrect pagination for some cases.