### PR TITLE
Optimize object proc-macro codegen

### DIFF
--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -59,6 +59,7 @@ pub fn generate(
             .unwrap_or_else(|| quote!(::std::option::Option::None))
     };
 
+    let mut flattened_resolvers = Vec::new();
     let mut resolvers = Vec::new();
     let mut schema_fields = Vec::new();
     let mut find_entities = Vec::new();
@@ -308,7 +309,7 @@ pub fn generate(
                         }
                     });
 
-                    resolvers.push(quote! {
+                    flattened_resolvers.push(quote! {
                         #(#cfg_attrs)*
                         if let ::std::option::Option::Some(value) = #crate_name::ContainerType::resolve_field(&self.#ident(ctx).await, ctx).await? {
                             return ::std::result::Result::Ok(std::option::Option::Some(value));
@@ -627,6 +628,7 @@ pub fn generate(
             impl #impl_generics #crate_name::resolver_utils::ContainerType for #self_ty #where_clause {
                 async fn resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::Value>> {
                     #(#resolvers)*
+                    #(#flattened_resolvers)*
                     ::std::result::Result::Ok(::std::option::Option::None)
                 }
 
@@ -728,6 +730,7 @@ pub fn generate(
 
                 async fn __internal_resolve_field(&self, ctx: &#crate_name::Context<'_>) -> #crate_name::ServerResult<::std::option::Option<#crate_name::Value>> where Self: #crate_name::ContainerType {
                     #(#resolvers)*
+                    #(#flattened_resolvers)*
                     ::std::result::Result::Ok(::std::option::Option::None)
                 }
 

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -497,9 +497,9 @@ pub fn generate(
                         }
                     }
                     quote! {
-                        Some(|__ctx, __variables_definition, __field, child_complexity| {
+                        ::std::option::Option::Some(|__ctx, __variables_definition, __field, child_complexity| {
                             #(#parse_args)*
-                            Ok(#expr)
+                            ::std::result::Result::Ok(#expr)
                         })
                     }
                 } else {


### PR DESCRIPTION
While investigating a stack overflow in our debug builds, we noticed that the generated `resolve_field` async function is rather large with a lot of await points. In our case, we have ~100 mutations in the mutation root container which results in a function with over 7k lines of code.
The current code generates per field (mutation): one if statement, one capturing async closure with at least 1 async call, and three glue calls.
Large functions are bad for LLVM and can slow down compilations substantially. LLVM optimization takes quadratic time in function length (according to @jyn514), see https://github.com/GREsau/schemars/issues/246

This PR changes things a bit up. This is currently limited to the object macro, but we can bring these improvements to other macros as well.

Differences:
* Enum field matcher. The idea is taken from serde. Instead of doing string comparisons in each if statement, a new `enum` is generated with a variant for each field. The field variant is matched at the beginning. The aim of this optimization is improved matching speeds. 
* Split out functions. The inlined blocks of the current if statements are moved into separate functions. This saves the most lines of code. We hoped this would reduce the size of the generated type for the `resolve_field` function, but we can't prove that right now.
* Added some tests that are not covered currently, and hinder other optimizations I tried, but failed for our production code.

The lines of code of a typical `resolve_field` are now more than 4 times less than before at the cost of a function call.

The generated type for the `resolve_field` still has N `Suspend` variants (one for each field), and while the await context is packed for each variant, we still want to try to reduce the `Suspend` variants because there is only ever one that is really used. This PR is basically a building block to further experiments with different optimizations. For example, reducing the `await` points by moving the glue function into the generated `enum` variants and removing the huge `match` block in `resolve_field`.

We can hide this behind a feature flag to make this opt-in before making it stable, if you like.

Also, I took the liberty to split out some codegen functions to have a better split between IR and output TokenStream. This makes it easier to debug and work with the macro.