### PR TITLE
Fix #[derive(OneofObject)] rejecting enums where the type comes from a macro subsitution

### DIFF
--- a/derive/src/oneof_object.rs
+++ b/derive/src/oneof_object.rs
@@ -85,6 +85,13 @@ pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream>
             }
         };
 
+        // Type may be wrapped in `Type::Group` if the type comes from a macro
+        // substitution, so unwrap it.
+        let ty = match ty {
+            Type::Group(tg) => &*tg.elem,
+            ty => ty,
+        };
+
         if let Type::Path(_) = ty {
             enum_names.push(enum_name);
 

--- a/tests/proc_macro_in_macro_rules.rs
+++ b/tests/proc_macro_in_macro_rules.rs
@@ -68,3 +68,28 @@ pub async fn test_scalar() {
 
     test_data!(A);
 }
+
+#[tokio::test]
+pub async fn test_oneof_object_type() {
+    macro_rules! test_data {
+        ($test_name:ident, $type1:ty, $type2:ty) => {
+            #[derive(async_graphql::OneofObject)]
+            enum $test_name {
+                Type1($type1),
+                Type2($type2),
+            }
+        };
+    }
+
+    #[derive(async_graphql::InputObject)]
+    struct A {
+        a: i32,
+    }
+
+    #[derive(async_graphql::InputObject)]
+    struct B {
+        b: i32,
+    }
+
+    test_data!(C, A, B);
+}


### PR DESCRIPTION
The added test case demonstrates the issue. In cases where the enum type comes from a `$macro` substitution, syn wraps the `Type::Path` in a `Type::Group` object. This patch unwraps the Group wrapper if present so that the macro can work.