### PR TITLE
Sort schema fields & enums if required, fix #1254

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -220,6 +220,34 @@ impl<Query, Mutation, Subscription> SchemaBuilder<Query, Mutation, Subscription>
         self
     }
 
+    pub fn with_sorted_fields(mut self) -> Self {
+        use crate::registry::MetaType;
+        for (_, ty) in &mut self.registry.types {
+            match ty {
+                MetaType::Object { fields, .. } | MetaType::Interface { fields, .. } => {
+                    fields.sort_keys();
+                }
+                MetaType::InputObject { input_fields, .. } => {
+                    input_fields.sort_keys();
+                }
+                MetaType::Scalar { .. } | MetaType::Enum { .. } | MetaType::Union { .. } => {
+                    // have no fields
+                }
+            }
+        }
+        self
+    }
+
+    pub fn with_sorted_enums(mut self) -> Self {
+        use crate::registry::MetaType;
+        for (_, ty) in &mut self.registry.types {
+            if let MetaType::Enum { enum_values, .. } = ty {
+                enum_values.sort_keys();
+            }
+        }
+        self
+    }
+
     /// Consumes this builder and returns a schema.
     pub fn finish(mut self) -> Schema<Query, Mutation, Subscription> {
         // federation


### PR DESCRIPTION
I haven't added any tests yet, but performed manual testing (see spoilers below).

<details><summary>Unsorted vs Sorted enums</summary>
<img width="175" alt="image" src="https://github.com/async-graphql/async-graphql/assets/4586392/3ab2485a-7a1d-4035-8957-3f6d75bb0ec5"> <img width="247" alt="image" src="https://github.com/async-graphql/async-graphql/assets/4586392/465d0235-ec24-4b49-b1d4-d5b2681b72ac"></details>

<details><summary>Unsorted vs Sorted fields</summary>
<img height="400" alt="image" src="https://github.com/async-graphql/async-graphql/assets/4586392/36a4f612-ff09-4358-9d91-f60dec527f08"> <img height="400" alt="image" src="https://github.com/async-graphql/async-graphql/assets/4586392/478ecc5c-631d-48cb-97d0-2e46dcf94365"></details>
