### PR TITLE
fix: add `description` to `__schema` introspection result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { rust: nightly-2022-11-02, os: ubuntu-20.04 }
+          - { rust: nightly-2023-09-07, os: ubuntu-20.04 }
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/src/model/schema.rs
+++ b/src/model/schema.rs
@@ -24,7 +24,8 @@ impl<'a> __Schema<'a> {
 /// points for query, mutation, and subscription operations.
 #[Object(internal, name = "__Schema")]
 impl<'a> __Schema<'a> {
-    /// description of __Schema for newer graphiql introspection schema requirements
+    /// description of __Schema for newer graphiql introspection schema
+    /// requirements
     async fn description(&self) -> String {
         String::from("A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.")
     }

--- a/src/model/schema.rs
+++ b/src/model/schema.rs
@@ -24,6 +24,11 @@ impl<'a> __Schema<'a> {
 /// points for query, mutation, and subscription operations.
 #[Object(internal, name = "__Schema")]
 impl<'a> __Schema<'a> {
+    /// description of __Schema for newer graphiql introspection schema requirements
+    async fn description(&self) -> String {
+        String::from("A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.")
+    }
+
     /// A list of all types supported by this server.
     async fn types(&self) -> Vec<__Type<'a>> {
         let mut types: Vec<_> = self


### PR DESCRIPTION
Newer Graphiql versions' introspection queries include `description` to the `__schema` as the following:

```graphql
query IntrospectionQuery {
  __schema {
    description <------ required
    queryType {
      name
    }
    mutationType {
      name
    }
    subscriptionType {
      name
    }
    types {
      ...FullType
    }
    directives {
      ...
    }
  }
}
...
```

Introspection queries through newer versions of graphiql result in:
```sh
“Unknown field \“description\” on type \“__Schema\“. Did you mean \“subscriptionType\“?”
```

Official implementation reference:
https://github.com/graphql/graphql-js/blob/main/src/type/introspection.ts