### PR TITLE
feat: add registry method in `dynamic::Registry`

### DIFF
--- a/src/dynamic/schema.rs
+++ b/src/dynamic/schema.rs
@@ -448,6 +448,9 @@ impl Schema {
     ) -> impl Stream<Item = Response> + Send + Unpin {
         self.execute_stream_with_session_data(request, Default::default())
     }
+    pub fn registry(&self) -> &Registry {
+        &self.0.env.registry
+    }
 }
 
 impl Executor for Schema {


### PR DESCRIPTION
A registry is used to implement check on functionality but it is private currently. Adding a `registry` method in dynamic::Schema will return a reference to registry instance which can be used for the same 