### PR TITLE
Allow non-scalars to be used as directive arguments

### DIFF
--- a/derive/src/type_directive.rs
+++ b/derive/src/type_directive.rs
@@ -108,7 +108,7 @@ pub fn generate(
 
         directive_input_args.push(quote! {
             if let Some(val) = #crate_name::InputType::as_raw_value(&#arg_ident) {
-                args.insert(::std::string::ToString::to_string(#name), #crate_name::ScalarType::to_value(val));
+                args.insert(::std::string::ToString::to_string(#name), #crate_name::InputType::to_value(val));
             };
         });
     }

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -697,7 +697,7 @@ extend schema @link(
 
     #[test]
     fn test_type_directive_sdl_without_federation() {
-        let expected = r#"directive @custom_type_directive on FIELD_DEFINITION | OBJECT
+        let expected = r#"directive @custom_type_directive(optionalWithoutDefault: String, optionalWithDefault: String = "DEFAULT") on FIELD_DEFINITION | OBJECT
 schema {
 	query: Query
 }
@@ -710,7 +710,35 @@ schema {
                 __DirectiveLocation::FIELD_DEFINITION,
                 __DirectiveLocation::OBJECT,
             ],
-            args: Default::default(),
+            args: [
+                (
+                    "optionalWithoutDefault".to_string(),
+                    MetaInputValue {
+                        name: "optionalWithoutDefault".to_string(),
+                        description: None,
+                        ty: "String".to_string(),
+                        default_value: None,
+                        visible: None,
+                        inaccessible: false,
+                        tags: vec![],
+                        is_secret: false,
+                    },
+                ),
+                (
+                    "optionalWithDefault".to_string(),
+                    MetaInputValue {
+                        name: "optionalWithDefault".to_string(),
+                        description: None,
+                        ty: "String".to_string(),
+                        default_value: Some("\"DEFAULT\"".to_string()),
+                        visible: None,
+                        inaccessible: false,
+                        tags: vec![],
+                        is_secret: false,
+                    },
+                ),
+            ]
+            .into(),
             is_repeatable: false,
             visible: None,
             composable: None,

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -713,7 +713,7 @@ impl MetaDirective {
             let args = self
                 .args
                 .values()
-                .map(|value| format!("{}: {}", value.name, value.ty))
+                .map(|value| self.argument_sdl(value))
                 .collect::<Vec<_>>()
                 .join(", ");
             write!(sdl, "({})", args).ok();
@@ -726,6 +726,15 @@ impl MetaDirective {
             .join(" | ");
         write!(sdl, " on {}", locations).ok();
         sdl
+    }
+
+    pub(crate) fn argument_sdl(&self, argument: &MetaInputValue) -> String {
+        let argument_default = match &argument.default_value {
+            Some(default) => format!(" = {default}"),
+            None => "".to_string(),
+        };
+
+        format!("{}: {}{}", argument.name, argument.ty, argument_default)
     }
 }
 


### PR DESCRIPTION
`TypeDirective` argument types seem to be erroneously limited to just scalars. Per the GraphQL spec, [`DirectiveDefinition`](http://spec.graphql.org/June2018/#sec-Type-System.Directives) defines [`ArgumentsDefinition`](http://spec.graphql.org/October2021/#ArgumentsDefinition) as `( InputValueDefinition )`, which allows argument types to be [`NamedType`, `ListType`, or `NonNullType`](http://spec.graphql.org/October2021/#Type).

I _believe_ `InputType` is the appropriate trait to use here, but if it's not please let me know and I can update this PR.

EDIT: I updated this PR to also support default arguments in `TypeDirective`s using the `#[graphql(default)]` attribute.