### PR TITLE
handle null interface items

### DIFF
--- a/src/dynamic/resolve.rs
+++ b/src/dynamic/resolve.rs
@@ -601,6 +601,7 @@ async fn resolve_value(
             )
             .await
         }
+        (Type::Interface(interface), FieldValueInner::Value(Value::Null)) => Ok(None),
         (Type::Interface(interface), _) => Err(ctx.set_error_path(
             Error::new(format!(
                 "internal: invalid value for interface \"{}\", expected \"FieldValue::WithType\"",
@@ -608,7 +609,6 @@ async fn resolve_value(
             ))
             .into_server_error(ctx.item.pos),
         )),
-
         (Type::Union(union), FieldValueInner::WithType { value, ty }) => {
             if !union.possible_types.contains(ty.as_ref()) {
                 return Err(ctx.set_error_path(


### PR DESCRIPTION
It's not currently possible to return `null` for a field returning an interface type in dynamic schemas. It fails since resolution expects a `WithType`.

This PR fixes this, but I haven't added tests / looks at whether this handles all cases correctly. Wanted your thoughts first. If that seems like the right fix, I'm happy to clean this PR up / add tests.