### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -10,10 +10,10 @@ on:
 jobs:
   deploy_en:
     name: Deploy book on gh-pages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install mdBook
         uses: peaceiris/actions-mdbook@v1
       - name: Render book
@@ -25,10 +25,10 @@ jobs:
           mv docs/zh-CN/gh-pages gh-pages/zh-CN
           mv docs/index.html gh-pages
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v2.5.1
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          emptyCommits: true
-          keepFiles: false
+          allow_empty_commit: true
+          keep_files: false
         env:
           ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           PUBLISH_BRANCH: gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { rust: stable, os: ubuntu-20.04 }
+          - { rust: stable, os: ubuntu-22.04 }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt
-          override: true
       - name: Build with all features
         run: cargo build --all-features
       - name: Build
@@ -43,17 +42,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { rust: 1.75.0, os: ubuntu-20.04 }
+          - { rust: 1.75.0, os: ubuntu-22.04 }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt
-          override: true
       - name: Build with all features
         run: cargo build --all-features
       - name: Build
@@ -70,16 +68,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { rust: nightly-2023-09-07, os: ubuntu-20.04 }
+          - { rust: nightly-2023-09-07, os: ubuntu-22.04 }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
           components: rustfmt
       - name: Check format
         run: cargo +${{ matrix.rust }} fmt --all -- --check
@@ -94,36 +91,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { rust: stable, os: ubuntu-20.04 }
+          - { rust: stable, os: ubuntu-22.04 }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
           components: clippy
       - name: Check with clippy
         run: cargo clippy --all
 
   book_examples:
     name: Test book examples
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
       - name: Install mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: "0.4.22"
+          mdbook-version: "0.4.37"
       - name: Build with all features
         run: cargo build --workspace --all-features
       - name: Run book tests for en language
@@ -140,16 +135,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { rust: stable, os: ubuntu-20.04 }
+          - { rust: stable, os: ubuntu-22.04 }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
           components: clippy, rustfmt
       - name: Check examples with clippy
         run: cargo clippy --all
@@ -166,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: AutoCorrect
         uses: huacnlee/autocorrect-action@v2

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run cargo-tarpaulin
-        run: cargo llvm-cov --all-features --avoid-cfg-tarpaulin --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -7,27 +7,29 @@ on:
 
 jobs:
   cover:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    env:
+      CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.75.0
-          override: true
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: "0.18.0"
-          args: --avoid-cfg-tarpaulin --all-features --workspace
+        run: cargo llvm-cov --all-features --avoid-cfg-tarpaulin --workspace --lcov --output-path lcov.info
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
+          files: lcov.info
+          fail_ci_if_error: true
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: cobertura.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -46,12 +46,11 @@ jobs:
             registryName: async-graphql-tide
             path: integrations/tide
     steps:
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: get version
         working-directory: ${{ matrix.package.path }}
         run: echo PACKAGE_VERSION=$(sed -nE 's/^\s*version = "(.*?)"/\1/p' Cargo.toml) >> $GITHUB_ENV


### PR DESCRIPTION
I have updated the following things in the current CI:
- update `ubuntu-20.04` to `ubuntu-22.04`
- update [actions/checkout](https://github.com/actions/checkout) to v4
- update [actions/upload-artifact](https://github.com/actions/upload-artifact) to v4
- update [codecov/codecov-action](https://github.com/codecov/codecov-action) to v4
- update [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages) to v3
- replace unmaintained [actions-rs/tarpaulin](https://github.com/actions-rs/tarpaulin) by [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov)
- replace [unmaintained](https://github.com/actions-rs/toolchain/issues/216) [actions-rs/toolchain](https://github.com/actions-rs/toolchain) by [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain)

> Node 16 has reached its end of life, prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/