### PR TITLE
Support `TypeDirective` for `ArgumentDefinition`, `Enum`, `EnumValue`, `InputFieldDefinition`, `InputObject`, `Interface`

### DIFF
--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -299,6 +299,8 @@ pub struct Argument {
     #[darling(multiple, rename = "tag")]
     pub tags: Vec<String>,
     pub secret: bool,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromMeta, Default)]
@@ -390,6 +392,8 @@ pub struct Enum {
     pub inaccessible: bool,
     #[darling(default, multiple, rename = "tag")]
     pub tags: Vec<String>,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromVariant)]
@@ -409,6 +413,8 @@ pub struct EnumItem {
     pub inaccessible: bool,
     #[darling(default, multiple, rename = "tag")]
     pub tags: Vec<String>,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromDeriveInput)]
@@ -487,6 +493,8 @@ pub struct InputObjectField {
     pub secret: bool,
     #[darling(default)]
     pub shareable: bool,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromDeriveInput)]
@@ -522,6 +530,8 @@ pub struct InputObject {
     pub complex: bool,
     #[darling(default)]
     pub shareable: bool,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromVariant)]
@@ -543,6 +553,8 @@ pub struct OneofObjectField {
     pub tags: Vec<String>,
     #[darling(default)]
     pub secret: bool,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromDeriveInput)]
@@ -571,6 +583,8 @@ pub struct OneofObject {
     pub tags: Vec<String>,
     #[darling(default, multiple, rename = "concrete")]
     pub concretes: Vec<ConcreteType>,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromMeta)]
@@ -591,6 +605,8 @@ pub struct InterfaceFieldArgument {
     pub tags: Vec<String>,
     #[darling(default)]
     pub secret: bool,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromMeta)]
@@ -621,6 +637,8 @@ pub struct InterfaceField {
     pub shareable: bool,
     #[darling(default)]
     pub override_from: Option<String>,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromVariant)]
@@ -657,6 +675,8 @@ pub struct Interface {
     pub inaccessible: bool,
     #[darling(default, multiple, rename = "tag")]
     pub tags: Vec<String>,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
 }
 
 #[derive(FromMeta, Default)]
@@ -978,8 +998,14 @@ pub struct TypeDirective {
 #[darling(rename_all = "PascalCase")]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum TypeDirectiveLocation {
+    ArgumentDefinition,
+    Enum,
+    EnumValue,
     FieldDefinition,
+    InputFieldDefinition,
     Object,
+    InputObject,
+    Interface,
 }
 
 impl TypeDirectiveLocation {

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -8,6 +8,8 @@ use syn::{
     ReturnType, Token, Type, TypeReference,
 };
 
+use crate::args::TypeDirectiveLocation;
+use crate::utils::gen_directive_calls;
 use crate::{
     args::{self, RenameRuleExt, RenameTarget},
     output_type::OutputType,
@@ -231,6 +233,7 @@ pub fn generate(
                     inaccessible,
                     tags,
                     secret,
+                    directives,
                     ..
                 },
             ) in &args
@@ -261,6 +264,8 @@ pub fn generate(
                     .iter()
                     .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
                     .collect::<Vec<_>>();
+                let directives =
+                    gen_directive_calls(&directives, TypeDirectiveLocation::ArgumentDefinition);
                 schema_args.push(quote! {
                         args.insert(::std::borrow::ToOwned::to_owned(#name), #crate_name::registry::MetaInputValue {
                             name: ::std::string::ToString::to_string(#name),
@@ -271,6 +276,7 @@ pub fn generate(
                             inaccessible: #inaccessible,
                             tags: ::std::vec![ #(#tags),* ],
                             is_secret: #secret,
+                            directive_invocations: ::std::vec![ #(#directives),* ],
                         });
                     });
 

--- a/derive/src/directive.rs
+++ b/derive/src/directive.rs
@@ -62,6 +62,7 @@ pub fn generate(
             validator,
             visible,
             secret,
+            directives,
             ..
         } = parse_graphql_attrs::<args::Argument>(&arg_attrs)?.unwrap_or_default();
 
@@ -97,6 +98,7 @@ pub fn generate(
                 inaccessible: false,
                 tags: ::std::default::Default::default(),
                 is_secret: #secret,
+                directive_invocations: ::std::vec![ #(#directives),* ],
             });
         });
 

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -399,6 +399,7 @@ pub fn generate(
                         secret,
                         inaccessible,
                         tags,
+                        directives,
                         ..
                     },
                 ) in &args
@@ -429,6 +430,8 @@ pub fn generate(
                         .iter()
                         .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
                         .collect::<Vec<_>>();
+                    let directives =
+                        gen_directive_calls(&directives, TypeDirectiveLocation::ArgumentDefinition);
 
                     schema_args.push(quote! {
                             args.insert(::std::borrow::ToOwned::to_owned(#name), #crate_name::registry::MetaInputValue {
@@ -440,6 +443,7 @@ pub fn generate(
                                 inaccessible: #inaccessible,
                                 tags: ::std::vec![ #(#tags),* ],
                                 is_secret: #secret,
+                                directive_invocations: ::std::vec![ #(#directives),* ],
                             });
                         });
 

--- a/derive/src/oneof_object.rs
+++ b/derive/src/oneof_object.rs
@@ -8,6 +8,8 @@ use crate::{
     args::{RenameRuleExt, RenameTarget},
     utils::{get_crate_name, get_rustdoc, visible_fn, GeneratorResult},
 };
+use crate::args::TypeDirectiveLocation;
+use crate::utils::gen_directive_calls;
 
 pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream> {
     let crate_name = get_crate_name(object_args.internal);
@@ -22,6 +24,7 @@ pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream>
         .iter()
         .map(|tag| quote!(::std::string::ToString::to_string(#tag)))
         .collect::<Vec<_>>();
+    let directives = gen_directive_calls(&object_args.directives, TypeDirectiveLocation::InputObject);
     let gql_typename = if !object_args.name_type {
         let name = object_args
             .input_name
@@ -91,6 +94,8 @@ pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream>
             Type::Group(tg) => &*tg.elem,
             ty => ty,
         };
+        
+        let directives = gen_directive_calls(&variant.directives, TypeDirectiveLocation::InputFieldDefinition);
 
         if let Type::Path(_) = ty {
             enum_names.push(enum_name);
@@ -108,6 +113,7 @@ pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream>
                     inaccessible: #inaccessible,
                     tags: ::std::vec![ #(#tags),* ],
                     is_secret: #secret,
+                    directive_invocations: ::std::vec![ #(#directives),* ],
                 });
             });
 
@@ -163,6 +169,7 @@ pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream>
                         tags: ::std::vec![ #(#tags),* ],
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
                         oneof: true,
+                        directive_invocations: ::std::vec![ #(#directives),* ],
                     })
                 }
 
@@ -215,6 +222,7 @@ pub fn generate(object_args: &args::OneofObject) -> GeneratorResult<TokenStream>
                         tags: ::std::vec![ #(#tags),* ],
                         rust_typename: ::std::option::Option::Some(::std::any::type_name::<Self>()),
                         oneof: true,
+                        directive_invocations: ::std::vec![ #(#directives),* ],
                     })
                 }
 

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -127,6 +127,7 @@ pub fn generate(
                             inaccessible: false,
                             tags: ::std::default::Default::default(),
                             is_secret: #secret,
+                            directive_invocations: ::std::vec![],
                         });
                     });
 

--- a/derive/src/type_directive.rs
+++ b/derive/src/type_directive.rs
@@ -66,6 +66,7 @@ pub fn generate(
             default_with,
             visible,
             secret,
+            directives,
             ..
         } = parse_graphql_attrs::<args::Argument>(&arg_attrs)?.unwrap_or_default();
 
@@ -101,6 +102,7 @@ pub fn generate(
                 inaccessible: false,
                 tags: ::std::default::Default::default(),
                 is_secret: #secret,
+                directive_invocations: ::std::vec![ #(#directives),* ],
             });
         });
 

--- a/src/dynamic/input_object.rs
+++ b/src/dynamic/input_object.rs
@@ -4,6 +4,7 @@ use crate::{
     dynamic::InputValue,
     registry::{MetaInputValue, MetaType, Registry},
 };
+use crate::registry::MetaDirectiveInvocation;
 
 /// A GraphQL input object type
 ///
@@ -57,6 +58,7 @@ pub struct InputObject {
     pub(crate) oneof: bool,
     inaccessible: bool,
     tags: Vec<String>,
+    directive_invocations: Vec<MetaDirectiveInvocation>,
 }
 
 impl InputObject {
@@ -70,6 +72,7 @@ impl InputObject {
             oneof: false,
             inaccessible: false,
             tags: Vec::new(),
+            directive_invocations: Vec::new(),
         }
     }
 
@@ -118,6 +121,7 @@ impl InputObject {
                     inaccessible: self.inaccessible,
                     tags: self.tags.clone(),
                     is_secret: false,
+                    directive_invocations: field.directive_invocations.clone(),
                 },
             );
         }
@@ -133,6 +137,7 @@ impl InputObject {
                 tags: self.tags.clone(),
                 rust_typename: None,
                 oneof: self.oneof,
+                directive_invocations: self.directive_invocations.clone(),
             },
         );
 

--- a/src/dynamic/input_value.rs
+++ b/src/dynamic/input_value.rs
@@ -1,3 +1,4 @@
+use crate::registry::MetaDirectiveInvocation;
 use crate::{dynamic::TypeRef, registry::MetaInputValue, Value};
 
 /// A GraphQL input value type
@@ -9,6 +10,7 @@ pub struct InputValue {
     pub(crate) default_value: Option<Value>,
     pub(crate) inaccessible: bool,
     pub(crate) tags: Vec<String>,
+    pub(crate) directive_invocations: Vec<MetaDirectiveInvocation>,
 }
 
 impl InputValue {
@@ -22,6 +24,7 @@ impl InputValue {
             default_value: None,
             inaccessible: false,
             tags: Vec::new(),
+            directive_invocations: vec![],
         }
     }
 
@@ -51,6 +54,7 @@ impl InputValue {
             inaccessible: self.inaccessible,
             tags: self.tags.clone(),
             is_secret: false,
+            directive_invocations: self.directive_invocations.clone(),
         }
     }
 }

--- a/src/model/directive.rs
+++ b/src/model/directive.rs
@@ -79,6 +79,30 @@ pub mod location_traits {
     pub trait Directive_At_OBJECT {
         fn check() {}
     }
+
+    pub trait Directive_At_INPUT_FIELD_DEFINITION {
+        fn check() {}
+    }
+
+    pub trait Directive_At_ARGUMENT_DEFINITION {
+        fn check() {}
+    }
+
+    pub trait Directive_At_INPUT_OBJECT {
+        fn check() {}
+    }
+
+    pub trait Directive_At_INTERFACE {
+        fn check() {}
+    }
+    
+    pub trait Directive_At_ENUM {
+        fn check() {}
+    }
+    
+    pub trait Directive_At_ENUM_VALUE {
+        fn check() {}
+    }
 }
 
 pub struct __Directive<'a> {

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -230,6 +230,12 @@ impl Registry {
                     }
                 }
 
+                for (_, meta_input_value) in &field.args {
+                    for directive in &meta_input_value.directive_invocations {
+                        write!(sdl, " {}", directive.sdl()).ok();
+                    }
+                }
+
                 if need_multiline {
                     sdl.push_str("\n\t");
                 }
@@ -406,6 +412,7 @@ impl Registry {
                 description,
                 inaccessible,
                 tags,
+                directive_invocations,
                 ..
             } => {
                 if let Some(description) = description {
@@ -431,6 +438,11 @@ impl Registry {
                         write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                     }
                 }
+                
+                for directive in directive_invocations {
+                    write!(sdl, " {}", directive.sdl()).ok();
+                }
+                
                 self.write_implements(sdl, name);
 
                 writeln!(sdl, " {{").ok();
@@ -443,6 +455,7 @@ impl Registry {
                 description,
                 inaccessible,
                 tags,
+                directive_invocations,
                 ..
             } => {
                 if let Some(description) = description {
@@ -458,6 +471,11 @@ impl Registry {
                         write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                     }
                 }
+                
+                for directive in directive_invocations {
+                    write!(sdl, " {}", directive.sdl()).ok();
+                }
+                
                 writeln!(sdl, " {{").ok();
 
                 let mut values = enum_values.values().collect::<Vec<_>>();
@@ -481,6 +499,11 @@ impl Registry {
                             write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                         }
                     }
+
+                    for directive in &value.directive_invocations {
+                        write!(sdl, " {}", directive.sdl()).ok();
+                    }
+
                     writeln!(sdl).ok();
                 }
 
@@ -493,6 +516,7 @@ impl Registry {
                 inaccessible,
                 tags,
                 oneof,
+                directive_invocations: raw_directives,
                 ..
             } => {
                 if let Some(description) = description {
@@ -512,6 +536,11 @@ impl Registry {
                         write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                     }
                 }
+                
+                for directive in raw_directives {
+                    write!(sdl, " {}", directive.sdl()).ok();
+                }
+                
                 writeln!(sdl, " {{").ok();
 
                 let mut fields = input_fields.values().collect::<Vec<_>>();
@@ -531,6 +560,9 @@ impl Registry {
                         for tag in &field.tags {
                             write!(sdl, " @tag(name: \"{}\")", tag.replace('"', "\\\"")).ok();
                         }
+                    }
+                    for directive in &field.directive_invocations {
+                        write!(sdl, " {}", directive.sdl()).ok();
                     }
                     writeln!(sdl).ok();
                 }
@@ -722,6 +754,7 @@ schema {
                         inaccessible: false,
                         tags: vec![],
                         is_secret: false,
+                        directive_invocations: vec![],
                     },
                 ),
                 (
@@ -735,6 +768,7 @@ schema {
                         inaccessible: false,
                         tags: vec![],
                         is_secret: false,
+                        directive_invocations: vec![],
                     },
                 ),
             ]

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -107,7 +107,7 @@ impl<'a> MetaTypeName<'a> {
 }
 
 /// actual directive invocation on SDL definitions
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MetaDirectiveInvocation {
     /// name of directive to invoke
     pub name: String,
@@ -155,6 +155,8 @@ pub struct MetaInputValue {
     pub tags: Vec<String>,
     /// Indicate that an input obnject is secret
     pub is_secret: bool,
+    /// Custom directive invocations
+    pub directive_invocations: Vec<MetaDirectiveInvocation>,
 }
 
 type ComputeComplexityFn = fn(
@@ -244,6 +246,7 @@ pub struct MetaEnumValue {
     pub visible: Option<MetaVisibleFn>,
     pub inaccessible: bool,
     pub tags: Vec<String>,
+    pub directive_invocations: Vec<MetaDirectiveInvocation>,
 }
 
 type MetaVisibleFn = fn(&Context<'_>) -> bool;
@@ -298,6 +301,7 @@ impl MetaTypeId {
                 keys: None,
                 visible: None,
                 rust_typename: Some(rust_typename),
+                directive_invocations: vec![],
             },
             MetaTypeId::Union => MetaType::Union {
                 name: "".to_string(),
@@ -316,6 +320,7 @@ impl MetaTypeId {
                 inaccessible: false,
                 tags: vec![],
                 rust_typename: Some(rust_typename),
+                directive_invocations: vec![],
             },
             MetaTypeId::InputObject => MetaType::InputObject {
                 name: "".to_string(),
@@ -326,6 +331,7 @@ impl MetaTypeId {
                 tags: vec![],
                 rust_typename: Some(rust_typename),
                 oneof: false,
+                directive_invocations: vec![],
             },
         }
     }
@@ -484,6 +490,8 @@ pub enum MetaType {
         tags: Vec<String>,
         /// The Rust typename corresponding to the interface
         rust_typename: Option<&'static str>,
+        /// custom directive invocations
+        directive_invocations: Vec<MetaDirectiveInvocation>,
     },
     /// Union
     ///
@@ -536,6 +544,8 @@ pub enum MetaType {
         tags: Vec<String>,
         /// The Rust typename corresponding to the enum
         rust_typename: Option<&'static str>,
+        /// custom directive invocations
+        directive_invocations: Vec<MetaDirectiveInvocation>,
     },
     /// Input object
     ///
@@ -566,6 +576,8 @@ pub enum MetaType {
         ///
         /// Reference: <https://github.com/graphql/graphql-spec/pull/825>
         oneof: bool,
+        /// custom directive invocations
+        directive_invocations: Vec<MetaDirectiveInvocation>,
     },
 }
 
@@ -775,6 +787,7 @@ impl Registry {
                     inaccessible: false,
                     tags: Default::default(),
                     is_secret: false,
+                    directive_invocations: vec![]
                 });
                 args
             },
@@ -802,6 +815,7 @@ impl Registry {
                     inaccessible: false,
                     tags: Default::default(),
                     is_secret: false,
+                    directive_invocations: vec![]
                 });
                 args
             },
@@ -1059,6 +1073,7 @@ impl Registry {
                                     inaccessible: false,
                                     tags: Default::default(),
                                     is_secret: false,
+                                    directive_invocations: vec![],
                                 },
                             );
                             args
@@ -1126,6 +1141,7 @@ impl Registry {
                                 inaccessible: false,
                                 tags: Default::default(),
                                 is_secret: false,
+                                directive_invocations: vec![],
                             },
                         );
                         args

--- a/tests/schemas/test_fed2_compose_2.schema.graphql
+++ b/tests/schemas/test_fed2_compose_2.schema.graphql
@@ -1,0 +1,61 @@
+directive @oneOf on INPUT_OBJECT
+
+
+
+
+
+type Query {
+	testArgument(arg: String! @type_directive_argument_definition(description: "This is ARGUMENT_DEFINITION in Object")): String!
+	testInputObject(arg: TestInput!): String!
+	testComplexObject: TestComplexObject!
+	testSimpleObject: TestSimpleObject!
+	testOneOfObject(arg: TestOneOfObject!): String!
+	testEnum(arg: TestEnum!): String!
+	testInterface: TestObjectForInterface!
+}
+
+
+type TestComplexObject @type_directive_object(description: "This is OBJECT in (Complex / Simple)Object") {
+	field: String! @type_directive_field_definition(description: "This is FIELD_DEFINITION in (Complex / Simple)Object")
+	test(arg: String! @type_directive_argument_definition(description: "This is ARGUMENT_DEFINITION in ComplexObject")): String!
+}
+
+enum TestEnum @type_directive_enum(description: "This is ENUM in Enum") {
+	FOO @type_directive_enum_value(description: "This is ENUM_VALUE in Enum")
+	BAR @type_directive_enum_value(description: "This is ENUM_VALUE in Enum")
+}
+
+input TestInput @type_directive_input_object(description: "This is INPUT_OBJECT in InputObject") {
+	field: String! @type_directive_input_field_definition(description: "This is INPUT_FIELD_DEFINITION")
+}
+
+interface TestInterface @type_directive_interface(description: "This is INTERFACE in Interface") {
+	field(arg: String! @type_directive_argument_definition(description: "This is ARGUMENT_DEFINITION in Interface")): String! @type_directive_field_definition(description: "This is INTERFACE in Interface")
+}
+
+type TestObjectForInterface implements TestInterface {
+	field(arg: String! @type_directive_argument_definition(description: "This is ARGUMENT_DEFINITION in Interface")): String!
+}
+
+input TestOneOfObject @oneOf @type_directive_input_object(description: "This is INPUT_OBJECT in OneofObject") {
+	foo: String @type_directive_input_field_definition(description: "This is INPUT_FIELD_DEFINITION in OneofObject")
+	bar: Int @type_directive_input_field_definition(description: "This is INPUT_FIELD_DEFINITION in OneofObject")
+}
+
+type TestSimpleObject @type_directive_object(description: "This is OBJECT in SimpleObject") {
+	field: String! @type_directive_field_definition(description: "This is FIELD_DEFINITION in SimpleObject")
+}
+
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @type_directive_argument_definition(description: String!) on ARGUMENT_DEFINITION
+directive @type_directive_enum(description: String!) on ENUM
+directive @type_directive_enum_value(description: String!) on ENUM_VALUE
+directive @type_directive_field_definition(description: String!) on FIELD_DEFINITION
+directive @type_directive_input_field_definition(description: String!) on INPUT_FIELD_DEFINITION
+directive @type_directive_input_object(description: String!) on INPUT_OBJECT
+directive @type_directive_interface(description: String!) on INTERFACE
+directive @type_directive_object(description: String!) on OBJECT
+schema {
+	query: Query
+}


### PR DESCRIPTION
# Purpose
Up until now, `TypeDirective` was only supported for `FIELD_DEFINITION` and `OBJECT`.
However, this was insufficient, so I have made adjustments to allow the implementation of `TypeDirective` for `ArgumentDefinition`, `Enum`, `EnumValue`, `InputFieldDefinition`, `InputObject`, and `Interface` as well.
I have attached the complete sample code and the outputted GraphQL schema below for your review. 
I would appreciate it if you could take a look.

# Sample Code
### Rust
```rust
#[TypeDirective(location = "FieldDefinition")]
fn type_directive_field_definition(description: String) {}

#[TypeDirective(location = "ArgumentDefinition")]
fn type_directive_argument_definition(description: String) {}

#[TypeDirective(location = "InputFieldDefinition")]
fn type_directive_input_field_definition(description: String) {}

#[TypeDirective(location = "Object")]
fn type_directive_object(description: String) {}

#[TypeDirective(location = "InputObject")]
fn type_directive_input_object(description: String) {}

#[TypeDirective(location = "Enum")]
fn type_directive_enum(description: String) {}

#[TypeDirective(location = "EnumValue")]
fn type_directive_enum_value(description: String) {}

#[TypeDirective(location = "Interface")]
fn type_directive_interface(description: String) {}

#[derive(InputObject)]
#[graphql(directive = type_directive_input_object::apply("This is INPUT_OBJECT in InputObject".to_string()))]
struct TestInput {
    #[graphql(directive = type_directive_input_field_definition::apply("This is INPUT_FIELD_DEFINITION".to_string()))]
    field: String,
}

#[derive(OneofObject)]
#[graphql(directive = type_directive_input_object::apply("This is INPUT_OBJECT in OneofObject".to_string()))]
enum TestOneOfObject {
    #[graphql(directive = type_directive_input_field_definition::apply("This is INPUT_FIELD_DEFINITION in OneofObject".to_string()))]
    Foo(String),
    #[graphql(directive = type_directive_input_field_definition::apply("This is INPUT_FIELD_DEFINITION in OneofObject".to_string()))]
    Bar(i32),
}

#[derive(SimpleObject)]
#[graphql(directive = type_directive_object::apply("This is OBJECT in SimpleObject".to_string()))]
struct TestSimpleObject {
    #[graphql(directive = type_directive_field_definition::apply("This is FIELD_DEFINITION in SimpleObject".to_string()))]
    field: String,
}

#[derive(SimpleObject)]
#[graphql(complex, directive = type_directive_object::apply("This is OBJECT in (Complex / Simple)Object".to_string()))]
struct TestComplexObject {
    #[graphql(directive = type_directive_field_definition::apply("This is FIELD_DEFINITION in (Complex / Simple)Object".to_string()))]
    field: String,
}

#[ComplexObject]
impl TestComplexObject {
    async fn test(
        &self,
        #[graphql(directive = type_directive_argument_definition::apply("This is ARGUMENT_DEFINITION in ComplexObject".to_string()))]
        _arg: String,
    ) -> &'static str {
        "test"
    }
}

#[derive(Enum, Copy, Clone, PartialEq, Eq)]
#[graphql(directive = type_directive_enum::apply("This is ENUM in Enum".to_string()))]
enum TestEnum {
    #[graphql(directive = type_directive_enum_value::apply("This is ENUM_VALUE in Enum".to_string()))]
    Foo,
    #[graphql(directive = type_directive_enum_value::apply("This is ENUM_VALUE in Enum".to_string()))]
    Bar,
}

struct TestObjectForInterface;

#[Object]
impl TestObjectForInterface {
    async fn field(
        &self,
        #[graphql(directive = type_directive_argument_definition::apply("This is ARGUMENT_DEFINITION in Interface".to_string()))]
        _arg: String
    ) -> &'static str {
        "hello"
    }
}
#[derive(Interface)]
#[graphql(
    field(
        name = "field",
        ty = "String",
        directive = type_directive_field_definition::apply("This is INTERFACE in Interface".to_string()),
        arg(
            name = "_arg",
            ty = "String",
            directive = type_directive_argument_definition::apply("This is ARGUMENT_DEFINITION in Interface".to_string())
        )
    ),
    directive = type_directive_interface::apply("This is INTERFACE in Interface".to_string())
)]
enum TestInterface {
    TestSimpleObjectForInterface(TestObjectForInterface),
}

struct Query;

#[Object]
impl Query {
    pub async fn test_argument(
        &self,
        #[graphql(directive = type_directive_argument_definition::apply("This is ARGUMENT_DEFINITION in Object".to_string()))]
        _arg: String,
    ) -> &'static str {
        "hello"
    }

    pub async fn test_input_object(&self, _arg: TestInput) -> &'static str {
        "hello"
    }

    pub async fn test_complex_object(&self) -> TestComplexObject {
        TestComplexObject {
            field: "hello".to_string(),
        }
    }

    pub async fn test_simple_object(&self) -> TestSimpleObject {
        TestSimpleObject {
            field: "hello".to_string(),
        }
    }

    pub async fn test_one_of_object(&self, _arg: TestOneOfObject) -> &'static str {
        "hello"
    }

    pub async fn test_enum(&self, _arg: TestEnum) -> &'static str {
        "hello"
    }

    pub async fn test_interface(&self) -> TestObjectForInterface {
        TestObjectForInterface
    }
}

let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
    .register_output_type::<TestInterface>()
    .finish();
let sdl = schema.sdl();
let expected = include_str!("schemas/test_fed2_compose_2.schema.graphql");
assert_eq!(expected, sdl);
```

### Generated GraphQL
```graphql
directive @oneOf on INPUT_OBJECT





type Query {
	testArgument(arg: String! @type_directive_argument_definition(description: "This is ARGUMENT_DEFINITION in Object")): String!
	testInputObject(arg: TestInput!): String!
	testComplexObject: TestComplexObject!
	testSimpleObject: TestSimpleObject!
	testOneOfObject(arg: TestOneOfObject!): String!
	testEnum(arg: TestEnum!): String!
	testInterface: TestObjectForInterface!
}


type TestComplexObject @type_directive_object(description: "This is OBJECT in (Complex / Simple)Object") {
	field: String! @type_directive_field_definition(description: "This is FIELD_DEFINITION in (Complex / Simple)Object")
	test(arg: String! @type_directive_argument_definition(description: "This is ARGUMENT_DEFINITION in ComplexObject")): String!
}

enum TestEnum @type_directive_enum(description: "This is ENUM in Enum") {
	FOO @type_directive_enum_value(description: "This is ENUM_VALUE in Enum")
	BAR @type_directive_enum_value(description: "This is ENUM_VALUE in Enum")
}

input TestInput @type_directive_input_object(description: "This is INPUT_OBJECT in InputObject") {
	field: String! @type_directive_input_field_definition(description: "This is INPUT_FIELD_DEFINITION")
}

interface TestInterface @type_directive_interface(description: "This is INTERFACE in Interface") {
	field(arg: String! @type_directive_argument_definition(description: "This is ARGUMENT_DEFINITION in Interface")): String! @type_directive_field_definition(description: "This is INTERFACE in Interface")
}

type TestObjectForInterface implements TestInterface {
	field(arg: String! @type_directive_argument_definition(description: "This is ARGUMENT_DEFINITION in Interface")): String!
}

input TestOneOfObject @oneOf @type_directive_input_object(description: "This is INPUT_OBJECT in OneofObject") {
	foo: String @type_directive_input_field_definition(description: "This is INPUT_FIELD_DEFINITION in OneofObject")
	bar: Int @type_directive_input_field_definition(description: "This is INPUT_FIELD_DEFINITION in OneofObject")
}

type TestSimpleObject @type_directive_object(description: "This is OBJECT in SimpleObject") {
	field: String! @type_directive_field_definition(description: "This is FIELD_DEFINITION in SimpleObject")
}

directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
directive @type_directive_argument_definition(description: String!) on ARGUMENT_DEFINITION
directive @type_directive_enum(description: String!) on ENUM
directive @type_directive_enum_value(description: String!) on ENUM_VALUE
directive @type_directive_field_definition(description: String!) on FIELD_DEFINITION
directive @type_directive_input_field_definition(description: String!) on INPUT_FIELD_DEFINITION
directive @type_directive_input_object(description: String!) on INPUT_OBJECT
directive @type_directive_interface(description: String!) on INTERFACE
directive @type_directive_object(description: String!) on OBJECT
schema {
	query: Query
}

```