### PR TITLE
Fix #1508: Reads data from extension context in prepare_request

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -779,10 +779,11 @@ pub(crate) async fn prepare_request(
     complexity: Option<usize>,
     depth: Option<usize>,
 ) -> Result<(QueryEnv, CacheControl), Vec<ServerError>> {
-    let mut request = extensions.prepare_request(request).await?;
+    let mut request = request;
     let query_data = Arc::new(std::mem::take(&mut request.data));
     extensions.attach_query_data(query_data.clone());
 
+    let mut request = extensions.prepare_request(request).await?;
     let mut document = {
         let query = &request.query;
         let parsed_doc = request.parsed_query.take();

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -43,6 +43,17 @@ pub async fn test_extension_ctx() {
 
     #[async_trait::async_trait]
     impl Extension for MyExtensionImpl {
+        async fn prepare_request(
+            &self,
+            ctx: &ExtensionContext<'_>,
+            request: Request,
+            next: NextPrepareRequest<'_>,
+        ) -> ServerResult<Request> {
+            let data = ctx.data::<MyData>();
+            assert!(data.is_ok());
+            next.run(ctx, request).await
+        }
+
         async fn parse_query(
             &self,
             ctx: &ExtensionContext<'_>,


### PR DESCRIPTION
This PR primarily addresses the issue by reverting the error portion to its previously working implementation and adds a test.

Closes #1508.