### PR TITLE
Added support for deploying to wasm targets with axum - (without subscriptions)

### DIFF
--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -15,7 +15,6 @@ version = "7.0.3"
 async-graphql.workspace = true
 
 async-trait.workspace = true
-axum = { version = "0.7.0", features = ["ws"] }
 bytes.workspace = true
 futures-util.workspace = true
 serde_json.workspace = true
@@ -26,3 +25,9 @@ tokio-util = { workspace = true, default-features = false, features = [
 ] }
 tokio-stream = "0.1.14"
 tower-service = "0.3"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+axum = { version = "0.7.0", default_features = false }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+axum = { version = "0.7.0", features = ["ws"] }

--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -6,9 +6,11 @@
 mod extract;
 mod query;
 mod response;
+#[cfg(not(target_arch = "wasm32"))]
 mod subscription;
 
 pub use extract::{GraphQLBatchRequest, GraphQLRequest};
 pub use query::GraphQL;
 pub use response::GraphQLResponse;
+#[cfg(not(target_arch = "wasm32"))]
 pub use subscription::{GraphQLProtocol, GraphQLSubscription, GraphQLWebSocket};


### PR DESCRIPTION
Added support for wasm targets, although at the expense of subscriptions support.

The reason is that there is a nested dependency in the axum implementation of websockets that requires mio and mio for now doesn't compile for wasm.

Nevertheless, its functional without subscriptions and allows developing a platform specific version of the subscriptions.