### PR TITLE
Improve alignment of directive behavior with GraphQL spec

### DIFF
--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -139,8 +139,6 @@ impl Registry {
             writeln!(sdl, "{}", directive.sdl()).ok();
         });
 
-        writeln!(sdl).ok();
-
         if options.federation {
             writeln!(sdl, "extend schema @link(").ok();
             writeln!(sdl, "\turl: \"https://specs.apollo.dev/federation/v2.3\",").ok();

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -95,15 +95,6 @@ impl Registry {
     pub(crate) fn export_sdl(&self, options: SDLExportOptions) -> String {
         let mut sdl = String::new();
 
-        let has_oneof = self
-            .types
-            .values()
-            .any(|ty| matches!(ty, MetaType::InputObject { oneof: true, .. }));
-
-        if has_oneof {
-            sdl.write_str("directive @oneOf on INPUT_OBJECT\n\n").ok();
-        }
-
         for ty in self.types.values() {
             if ty.name().starts_with("__") {
                 continue;

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -95,6 +95,22 @@ impl Registry {
     pub(crate) fn export_sdl(&self, options: SDLExportOptions) -> String {
         let mut sdl = String::new();
 
+        for ty in self.types.values() {
+            if ty.name().starts_with("__") {
+                continue;
+            }
+
+            if options.federation {
+                const FEDERATION_TYPES: &[&str] = &["_Any", "_Entity", "_Service"];
+                if FEDERATION_TYPES.contains(&ty.name()) {
+                    continue;
+                }
+            }
+
+            self.export_type(ty, &mut sdl, &options);
+            writeln!(sdl).ok();
+        }
+
         self.directives.values().for_each(|directive| {
             // Filter out deprecated directive from SDL if it is not used
             if directive.name == "deprecated"
@@ -179,22 +195,6 @@ impl Registry {
                 writeln!(sdl, "\tsubscription: {}", subscription_type).ok();
             }
             writeln!(sdl, "}}").ok();
-        }
-
-        for ty in self.types.values() {
-            if ty.name().starts_with("__") {
-                continue;
-            }
-
-            if options.federation {
-                const FEDERATION_TYPES: &[&str] = &["_Any", "_Entity", "_Service"];
-                if FEDERATION_TYPES.contains(&ty.name()) {
-                    continue;
-                }
-            }
-
-            self.export_type(ty, &mut sdl, &options);
-            writeln!(sdl).ok();
         }
 
         sdl

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -95,25 +95,11 @@ impl Registry {
     pub(crate) fn export_sdl(&self, options: SDLExportOptions) -> String {
         let mut sdl = String::new();
 
-        for ty in self.types.values() {
-            if ty.name().starts_with("__") {
-                continue;
-            }
-
-            if options.federation {
-                const FEDERATION_TYPES: &[&str] = &["_Any", "_Entity", "_Service"];
-                if FEDERATION_TYPES.contains(&ty.name()) {
-                    continue;
-                }
-            }
-
-            self.export_type(ty, &mut sdl, &options);
-            writeln!(sdl).ok();
-        }
-
         self.directives.values().for_each(|directive| {
             writeln!(sdl, "{}", directive.sdl()).ok();
         });
+
+        writeln!(sdl).ok();
 
         if options.federation {
             writeln!(sdl, "extend schema @link(").ok();
@@ -155,6 +141,22 @@ impl Registry {
                 writeln!(sdl, "\tsubscription: {}", subscription_type).ok();
             }
             writeln!(sdl, "}}").ok();
+        }
+
+        for ty in self.types.values() {
+            if ty.name().starts_with("__") {
+                continue;
+            }
+
+            if options.federation {
+                const FEDERATION_TYPES: &[&str] = &["_Any", "_Entity", "_Service"];
+                if FEDERATION_TYPES.contains(&ty.name()) {
+                    continue;
+                }
+            }
+
+            self.export_type(ty, &mut sdl, &options);
+            writeln!(sdl).ok();
         }
 
         sdl

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -824,6 +824,20 @@ impl Registry {
             composable: None,
         });
 
+        self.add_directive(MetaDirective {
+            name: "oneOf".into(),
+            description: Some(
+                "Indicates that an Input Object is a OneOf Input Object (and thus requires
+                        exactly one of its field be provided)"
+                    .to_string(),
+            ),
+            locations: vec![__DirectiveLocation::INPUT_OBJECT],
+            args: Default::default(),
+            is_repeatable: false,
+            visible: None,
+            composable: None,
+        });
+
         // create system scalars
         <bool as InputType>::create_type_info(self);
         <i32 as InputType>::create_type_info(self);

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -827,7 +827,7 @@ impl Registry {
         self.add_directive(MetaDirective {
             name: "deprecated".into(),
             description: Some(
-                "Marks an element of a GraphQL schema as no longer supported.".to_string(),
+                "Marks an element of a GraphQL schema as no longer supported.".into(),
             ),
             locations: vec![
                 __DirectiveLocation::FIELD_DEFINITION,
@@ -838,15 +838,42 @@ impl Registry {
             args: {
                 let mut args = IndexMap::new();
                 args.insert(
-                    "reason".to_string(),
+                    "reason".into(),
                     MetaInputValue {
-                        name: "reason".to_string(),
+                        name: "reason".into(),
                         description: Some(
                             "A reason for why it is deprecated, formatted using Markdown syntax"
-                                .to_string(),
+                                .into(),
                         ),
-                        ty: "String".to_string(),
-                        default_value: Some(r#""No longer supported""#.to_string()),
+                        ty: "String".into(),
+                        default_value: Some(r#""No longer supported""#.into()),
+                        visible: None,
+                        inaccessible: false,
+                        tags: Default::default(),
+                        is_secret: false,
+                        directive_invocations: vec![],
+                    },
+                );
+                args
+            },
+            is_repeatable: false,
+            visible: None,
+            composable: None,
+        });
+
+        self.add_directive(MetaDirective {
+            name: "specifiedBy".into(),
+            description: Some("Provides a scalar specification URL for specifying the behavior of custom scalar types.".into()),
+            locations: vec![__DirectiveLocation::SCALAR],
+            args: {
+                let mut args = IndexMap::new();
+                args.insert(
+                    "url".into(),
+                    MetaInputValue {
+                        name: "url".into(),
+                        description: Some("URL that specifies the behavior of this scalar.".into()),
+                        ty: "String!".into(),
+                        default_value: None,
                         visible: None,
                         inaccessible: false,
                         tags: Default::default(),

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -825,6 +825,43 @@ impl Registry {
         });
 
         self.add_directive(MetaDirective {
+            name: "deprecated".into(),
+            description: Some(
+                "Marks an element of a GraphQL schema as no longer supported.".to_string(),
+            ),
+            locations: vec![
+                __DirectiveLocation::FIELD_DEFINITION,
+                __DirectiveLocation::ARGUMENT_DEFINITION,
+                __DirectiveLocation::INPUT_FIELD_DEFINITION,
+                __DirectiveLocation::ENUM_VALUE,
+            ],
+            args: {
+                let mut args = IndexMap::new();
+                args.insert(
+                    "reason".to_string(),
+                    MetaInputValue {
+                        name: "reason".to_string(),
+                        description: Some(
+                            "A reason for why it is deprecated, formatted using Markdown syntax"
+                                .to_string(),
+                        ),
+                        ty: "String".to_string(),
+                        default_value: Some(r#""No longer supported""#.to_string()),
+                        visible: None,
+                        inaccessible: false,
+                        tags: Default::default(),
+                        is_secret: false,
+                        directive_invocations: vec![],
+                    },
+                );
+                args
+            },
+            is_repeatable: false,
+            visible: None,
+            composable: None,
+        });
+
+        self.add_directive(MetaDirective {
             name: "oneOf".into(),
             description: Some(
                 "Indicates that an Input Object is a OneOf Input Object (and thus requires

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -769,8 +769,8 @@ pub struct Registry {
 impl Registry {
     pub(crate) fn add_system_types(&mut self) {
         self.add_directive(MetaDirective {
-            name: "include".into(),
-            description: Some("Directs the executor to include this field or fragment only when the `if` argument is true.".to_string()),
+            name: "skip".into(),
+            description: Some("Directs the executor to skip this field or fragment when the `if` argument is true.".to_string()),
             locations: vec![
                 __DirectiveLocation::FIELD,
                 __DirectiveLocation::FRAGMENT_SPREAD,
@@ -780,7 +780,7 @@ impl Registry {
                 let mut args = IndexMap::new();
                 args.insert("if".to_string(), MetaInputValue {
                     name: "if".to_string(),
-                    description: Some("Included when true.".to_string()),
+                    description: Some("Skipped when true.".to_string()),
                     ty: "Boolean!".to_string(),
                     default_value: None,
                     visible: None,
@@ -797,8 +797,8 @@ impl Registry {
         });
 
         self.add_directive(MetaDirective {
-            name: "skip".into(),
-            description: Some("Directs the executor to skip this field or fragment when the `if` argument is true.".to_string()),
+            name: "include".into(),
+            description: Some("Directs the executor to include this field or fragment only when the `if` argument is true.".to_string()),
             locations: vec![
                 __DirectiveLocation::FIELD,
                 __DirectiveLocation::FRAGMENT_SPREAD,
@@ -808,7 +808,7 @@ impl Registry {
                 let mut args = IndexMap::new();
                 args.insert("if".to_string(), MetaInputValue {
                     name: "if".to_string(),
-                    description: Some("Skipped when true.".to_string()),
+                    description: Some("Included when true.".to_string()),
                     ty: "Boolean!".to_string(),
                     default_value: None,
                     visible: None,

--- a/tests/schemas/test_fed2_compose_2.schema.graphql
+++ b/tests/schemas/test_fed2_compose_2.schema.graphql
@@ -1,5 +1,3 @@
-directive @oneOf on INPUT_OBJECT
-
 
 
 
@@ -47,6 +45,7 @@ type TestSimpleObject @type_directive_object(description: "This is OBJECT in Sim
 }
 
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @oneOf on INPUT_OBJECT
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @type_directive_argument_definition(description: String!) on ARGUMENT_DEFINITION
 directive @type_directive_enum(description: String!) on ENUM


### PR DESCRIPTION
Before, only the `skip` and `include` directives were included in schema introspection. This PR adds all built-in directives to the introspection result (always), and to the SDL export (only when they are used) to better align with the latest [GraphQL working draft specification](https://spec.graphql.org/draft/#sel-EAHnBPDLAADNC1Br_F).

Fixes #1187.