### PR TITLE
fix: pass default vals to `ResolverContext`

### DIFF
--- a/src/dynamic/resolve.rs
+++ b/src/dynamic/resolve.rs
@@ -234,26 +234,24 @@ fn collect_field<'a>(
     fields.push(
         async move {
             let ctx_field = ctx.with_field(field);
-            let arguments = ObjectAccessor(Cow::Owned(
-                {
-                    let mut args = field
-                        .node
-                        .arguments
-                        .iter()
-                        .map(|(name, value)| {
-                            ctx_field
-                                .resolve_input_value(value.clone())
-                                .map(|value| (name.node.clone(), value))
-                        })
-                        .collect::<ServerResult<IndexMap<Name, Value>>>()?;
-                    field_def.arguments.iter().for_each(|(name, arg)| {
-                        if let Some(def) = &arg.default_value {
-                            args.entry(Name::new(name)).or_insert(def.clone());
-                        }
-                    });
-                    args
-                }
-            ));
+            let arguments = ObjectAccessor(Cow::Owned({
+                let mut args = field
+                    .node
+                    .arguments
+                    .iter()
+                    .map(|(name, value)| {
+                        ctx_field
+                            .resolve_input_value(value.clone())
+                            .map(|value| (name.node.clone(), value))
+                    })
+                    .collect::<ServerResult<IndexMap<Name, Value>>>()?;
+                field_def.arguments.iter().for_each(|(name, arg)| {
+                    if let Some(def) = &arg.default_value {
+                        args.entry(Name::new(name)).or_insert(def.clone());
+                    }
+                });
+                args
+            }));
 
             let resolve_info = ResolveInfo {
                 path_node: ctx_field.path_node.as_ref().unwrap(),


### PR DESCRIPTION
**Issue Reference**
fixes: #1526

**Performace issue**
This will reduce performance because of merging maps and clones. Additionally, it is a hot code so I don't know if this solution is good enough.