### PR TITLE
feat: Add support for using `Interface` and `OneofObject` on the same struct

### DIFF
--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -587,6 +587,9 @@ pub struct OneofObject {
     pub concretes: Vec<ConcreteType>,
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
+    // for Interface
+    #[darling(default, multiple, rename = "field")]
+    pub fields: Vec<InterfaceField>,
 }
 
 #[derive(FromMeta)]
@@ -679,6 +682,9 @@ pub struct Interface {
     pub tags: Vec<String>,
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
+    // for OneofObject
+    #[darling(default)]
+    pub input_name: Option<String>,
 }
 
 #[derive(FromMeta, Default)]


### PR DESCRIPTION
Currently there is support for defining `Union` and `OneofObject` on the same struct thanks to https://github.com/async-graphql/async-graphql/commit/7f70c7e765682ea1c31b1d1d68650695f2775af7

This PR aims to support defining `Interface` and `OneofObject`.

Note: This doesn't enable support for using user-defined resolvers for the fields. The interface fields must exist on the Object struct