### PR TITLE
feat: Allow `skip` and `derived` together to support proxy types.

### DIFF
--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -114,7 +114,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
     }
 
     for SimpleObjectFieldGenerator { field, derived } in &processed_fields {
-        if field.skip || field.skip_output {
+        if (field.skip || field.skip_output) && derived.is_none() {
             continue;
         }
 


### PR DESCRIPTION
Right now, when the field skip is enabled, derived fields all get ignored. This change aims to allow derived fields while using skip simultatenously to be able to use a proxy type for graphql queries.

Partially Fixes #1490

Note:
- Does not provide support for complex object (IMHO I don't really see a use case for using skip on user defined resolvers since they are graphql exclusive don't have to be compatible with other structs per se)
- Does not provide support for InputObject