### PR TITLE
feat: Enum implementations for `Interface` + Support Unit Structs for `Interface`

### DIFF
--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -232,6 +232,13 @@ pub struct SimpleObjectField {
     pub directives: Vec<Expr>,
 }
 
+#[derive(FromMeta)]
+pub struct InterfaceImpl {
+    pub interface_type: Type,
+    pub name: SpannedValue<String>,
+    pub ty: Type,
+}
+
 #[derive(FromDeriveInput)]
 #[darling(attributes(graphql), forward_attrs(doc))]
 pub struct SimpleObject {
@@ -266,6 +273,8 @@ pub struct SimpleObject {
     pub interface_object: bool,
     #[darling(default, multiple, rename = "tag")]
     pub tags: Vec<String>,
+    #[darling(default, multiple, rename = "interface_impl")]
+    pub interface_impls: Vec<InterfaceImpl>,
     #[darling(default)]
     pub visible: Option<Visible>,
     #[darling(default, multiple, rename = "concrete")]
@@ -940,6 +949,7 @@ pub struct ComplexObject {
     pub rename_fields: Option<RenameRule>,
     pub rename_args: Option<RenameRule>,
     pub guard: Option<Expr>,
+    pub interface: bool,
 }
 
 #[derive(FromMeta, Default)]

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -237,6 +237,9 @@ pub struct InterfaceImpl {
     pub interface_type: Type,
     pub name: SpannedValue<String>,
     pub ty: Type,
+
+    #[darling(default)]
+    pub method: Option<String>,
 }
 
 #[derive(FromDeriveInput)]

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -171,7 +171,7 @@ pub fn generate(
             });
             if object_args.interface {
                 method.sig.ident = Ident::new(
-                    &format!("{}_interface", method.sig.ident),
+                    &format!("interface_impl_{}", method.sig.ident),
                     method.sig.ident.span(),
                 );
             }

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -144,7 +144,7 @@ pub fn generate(
                 let ty = ty.value_type();
                 let ident = &method.sig.ident;
 
-                schema_fields.push(quote! {
+                register_fields.push(quote! {
                     #crate_name::static_assertions_next::assert_impl_one!(#ty: #crate_name::ObjectType);
                     <#ty>::create_type_info(registry);
                     if let #crate_name::registry::MetaType::Object { fields: obj_fields, .. } =

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -144,7 +144,7 @@ pub fn generate(
                 let ty = ty.value_type();
                 let ident = &method.sig.ident;
 
-                register_fields.push(quote! {
+                schema_fields.push(quote! {
                     #crate_name::static_assertions_next::assert_impl_one!(#ty: #crate_name::ObjectType);
                     <#ty>::create_type_info(registry);
                     if let #crate_name::registry::MetaType::Object { fields: obj_fields, .. } =
@@ -376,7 +376,7 @@ pub fn generate(
                 quote! { ::std::option::Option::None }
             };
 
-            schema_fields.push(quote! {
+            register_fields.push(quote! {
                 if name == #field_name {
                     #(#cfg_attrs)*
                     return (#field_name.to_string(), #crate_name::registry::MetaField {
@@ -404,7 +404,7 @@ pub fn generate(
                 }
             });
 
-            register_fields.push(quote! {
+            schema_fields.push(quote! {
                 fields.push(Self::register_field(registry, #field_name));
             });
 
@@ -465,7 +465,7 @@ pub fn generate(
         impl #generics #crate_name::ComplexObject for #self_ty #where_clause {
             fn fields(registry: &mut #crate_name::registry::Registry) -> ::std::vec::Vec<(::std::string::String, #crate_name::registry::MetaField)> {
                 let mut fields = ::std::vec::Vec::new();
-                #(#register_fields)*
+                #(#schema_fields)*
                 fields
             }
 
@@ -475,7 +475,7 @@ pub fn generate(
             }
 
             fn register_field(registry: &mut #crate_name::registry::Registry, name: &std::primitive::str) -> (::std::string::String, #crate_name::registry::MetaField) {
-                #(#schema_fields)*
+                #(#register_fields)*
                 ::std::panic!("Field not found: {}", name)
             }
         }

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -171,7 +171,7 @@ pub fn generate(
             });
             if object_args.interface {
                 method.sig.ident = Ident::new(
-                    &format!("interface_impl_{}", field_name),
+                    &format!("interface_impl_{}", method.sig.ident),
                     method.sig.ident.span(),
                 );
             }

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -171,7 +171,7 @@ pub fn generate(
             });
             if object_args.interface {
                 method.sig.ident = Ident::new(
-                    &format!("interface_impl_{}", method.sig.ident),
+                    &format!("interface_impl_{}", field_name),
                     method.sig.ident.span(),
                 );
             }

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -84,12 +84,20 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
                 unit_struct_impls.push(quote! {
                     #[derive(::std::clone::Clone, #crate_name::SimpleObject)]
                 });
-                for InterfaceField { name, ty, .. } in &interface_args.fields {
+                for InterfaceField {
+                    name, ty, method, ..
+                } in &interface_args.fields
+                {
                     let name_string = name.to_string();
                     let ty_string = ty.to_token_stream().to_string();
                     let ident_string = ident.to_string();
+                    let method_override = if let Some(method) = method {
+                        quote! { method = #method, }
+                    } else {
+                        quote! {}
+                    };
                     unit_struct_impls.push(quote! {
-                        #[graphql(interface_impl(interface_type = #ident_string, name = #name_string, ty = #ty_string))]
+                        #[graphql(interface_impl(interface_type = #ident_string, name = #name_string, ty = #ty_string, #method_override))]
                     });
                 }
                 unit_struct_impls.push(quote! {

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -3,8 +3,7 @@ use std::collections::HashSet;
 use darling::ast::{Data, Style};
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
-use quote::quote;
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use syn::{visit_mut::VisitMut, Error, Type};
 
 use crate::{

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -114,7 +114,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
     }
 
     for SimpleObjectFieldGenerator { field, derived } in &processed_fields {
-        if field.skip || field.skip_output {
+        if (field.skip || field.skip_output) && derived.is_none() {
             continue;
         }
 

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -295,7 +295,10 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
     for interface_impl in interface_impls {
         let interface_ty = &interface_impl.interface_type;
         let field_name = interface_impl.name.to_string();
-        let method_name = Ident::new_raw(&field_name, Span::call_site());
+        let mut method_name = Ident::new_raw(&field_name, Span::call_site());
+        if let Some(method_override) = &interface_impl.method {
+            method_name = Ident::new_raw(&method_override, Span::call_site());
+        }
         let method_name_interface =
             Ident::new_raw(&format!("interface_impl_{field_name}"), Span::call_site());
         let ty = &interface_impl.ty;

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -297,10 +297,12 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
         let field_name = interface_impl.name.to_string();
         let mut method_name = Ident::new_raw(&field_name, Span::call_site());
         if let Some(method_override) = &interface_impl.method {
-            method_name = Ident::new_raw(&method_override, Span::call_site());
+            method_name = Ident::new_raw(method_override, Span::call_site());
         }
-        let method_name_interface =
-            Ident::new_raw(&format!("interface_impl_{field_name}"), Span::call_site());
+        let method_name_interface = Ident::new_raw(
+            &format!("interface_impl_{}", method_name.unraw()),
+            Span::call_site(),
+        );
         let ty = &interface_impl.ty;
         getters.push(quote! {
             #[inline]

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -297,7 +297,7 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
         let field_name = interface_impl.name.to_string();
         let method_name = Ident::new_raw(&field_name, Span::call_site());
         let method_name_interface =
-            Ident::new_raw(&format!("{field_name}_interface"), Span::call_site());
+            Ident::new_raw(&format!("interface_impl_{field_name}"), Span::call_site());
         let ty = &interface_impl.ty;
         getters.push(quote! {
             #[inline]

--- a/src/base.rs
+++ b/src/base.rs
@@ -269,4 +269,9 @@ pub trait ComplexObject {
         &self,
         ctx: &Context<'_>,
     ) -> impl Future<Output = ServerResult<Option<Value>>> + Send;
+
+    fn register_field(
+        registry: &mut registry::Registry,
+        name: &str,
+    ) -> (String, registry::MetaField);
 }

--- a/src/types/connection/mod.rs
+++ b/src/types/connection/mod.rs
@@ -258,7 +258,7 @@ where
 /// # Examples
 ///
 /// ```rust
-///
+/// 
 /// use async_graphql::*;
 /// use async_graphql::types::connection::*;
 ///

--- a/src/types/connection/mod.rs
+++ b/src/types/connection/mod.rs
@@ -258,7 +258,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// 
+///
 /// use async_graphql::*;
 /// use async_graphql::types::connection::*;
 ///

--- a/tests/interface.rs
+++ b/tests/interface.rs
@@ -757,7 +757,7 @@ pub async fn test_unit_variant() {
 #[tokio::test]
 pub async fn test_interface_impl_with_rename() {
     #[derive(Interface)]
-    #[graphql(field(name = "id", ty = "i32"))]
+    #[graphql(field(name = "foo", ty = "i32", method = "bar"))]
     enum Node {
         NewType(NewType),
         NewTypeUnit(NewTypeUnit),
@@ -766,8 +766,8 @@ pub async fn test_interface_impl_with_rename() {
 
     #[ComplexObject(interface)]
     impl Node {
-        #[graphql(name = "id")]
-        async fn not_id(&self) -> i32 {
+        #[graphql(name = "foo")]
+        async fn bar(&self) -> i32 {
             match self {
                 Node::NewTypeUnit(_) => 2,
                 Node::Unit => 3,
@@ -779,12 +779,12 @@ pub async fn test_interface_impl_with_rename() {
 
     #[derive(SimpleObject)]
     struct NewType {
-        #[graphql(owned)]
-        id: i32,
+        #[graphql(owned, name = "foo")]
+        bar: i32,
     }
 
     #[derive(SimpleObject, Clone)]
-    #[graphql(interface_impl(interface_type = "Node", name = "id", ty = "i32"))]
+    #[graphql(interface_impl(interface_type = "Node", name = "foo", ty = "i32", method = "bar"))]
     struct NewTypeUnit;
 
     struct Query;
@@ -792,7 +792,7 @@ pub async fn test_interface_impl_with_rename() {
     #[Object]
     impl Query {
         async fn new_type(&self) -> Node {
-            Node::NewType(NewType { id: 1 })
+            Node::NewType(NewType { bar: 1 })
         }
 
         async fn new_type_unit(&self) -> Node {
@@ -808,7 +808,7 @@ pub async fn test_interface_impl_with_rename() {
     let query = r"{
         newType {
             __typename
-            id
+            foo
         }
     }";
     assert_eq!(
@@ -816,14 +816,14 @@ pub async fn test_interface_impl_with_rename() {
         value!({
             "newType": {
                 "__typename": "NewType",
-                "id": 1,
+                "foo": 1,
             }
         })
     );
     let query = r"{
         newTypeUnit {
             __typename
-            id
+            foo
         }
     }";
     assert_eq!(
@@ -831,14 +831,14 @@ pub async fn test_interface_impl_with_rename() {
         value!({
             "newTypeUnit": {
                 "__typename": "NewTypeUnit",
-                "id": 2,
+                "foo": 2,
             }
         })
     );
     let query = r"{
         unit {
             __typename
-            id
+            foo
         }
     }";
     assert_eq!(
@@ -846,105 +846,7 @@ pub async fn test_interface_impl_with_rename() {
         value!({
             "unit": {
                 "__typename": "Unit",
-                "id": 3,
-            }
-        })
-    );
-}
-
-#[tokio::test]
-pub async fn test_interface_impl_with_method_override() {
-    #[derive(Interface)]
-    #[graphql(field(name = "id", ty = "i32", method = "not_id"))]
-    enum Node {
-        NewType(NewType),
-        NewTypeUnit(NewTypeUnit),
-        Unit,
-    }
-
-    #[ComplexObject(interface)]
-    impl Node {
-        #[graphql(name = "id")]
-        async fn not_id(&self) -> i32 {
-            match self {
-                Node::NewTypeUnit(_) => 2,
-                Node::Unit => 3,
-                // This will get ignored!
-                Node::NewType(_) => 999,
-            }
-        }
-    }
-
-    #[derive(SimpleObject)]
-    struct NewType {
-        #[graphql(owned, name = "id")]
-        not_id: i32,
-    }
-
-    #[derive(SimpleObject, Clone)]
-    #[graphql(interface_impl(interface_type = "Node", name = "id", ty = "i32", method = "not_id"))]
-    struct NewTypeUnit;
-
-    struct Query;
-
-    #[Object]
-    impl Query {
-        async fn new_type(&self) -> Node {
-            Node::NewType(NewType { not_id: 1 })
-        }
-
-        async fn new_type_unit(&self) -> Node {
-            Node::NewTypeUnit(NewTypeUnit)
-        }
-
-        async fn unit(&self) -> Node {
-            Node::Unit
-        }
-    }
-
-    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
-    let query = r"{
-        newType {
-            __typename
-            id
-        }
-    }";
-    assert_eq!(
-        schema.execute(query).await.into_result().unwrap().data,
-        value!({
-            "newType": {
-                "__typename": "NewType",
-                "id": 1,
-            }
-        })
-    );
-    let query = r"{
-        newTypeUnit {
-            __typename
-            id
-        }
-    }";
-    assert_eq!(
-        schema.execute(query).await.into_result().unwrap().data,
-        value!({
-            "newTypeUnit": {
-                "__typename": "NewTypeUnit",
-                "id": 2,
-            }
-        })
-    );
-    let query = r"{
-        unit {
-            __typename
-            id
-        }
-    }";
-    assert_eq!(
-        schema.execute(query).await.into_result().unwrap().data,
-        value!({
-            "unit": {
-                "__typename": "Unit",
-                "id": 3,
+                "foo": 3,
             }
         })
     );

--- a/tests/interface.rs
+++ b/tests/interface.rs
@@ -753,3 +753,102 @@ pub async fn test_unit_variant() {
         })
     );
 }
+
+#[tokio::test]
+pub async fn test_interface_impl_with_rename() {
+    #[derive(Interface)]
+    #[graphql(field(name = "id", ty = "i32"))]
+    enum Node {
+        NewType(NewType),
+        NewTypeUnit(NewTypeUnit),
+        Unit
+    }
+
+    #[ComplexObject(interface)]
+    impl Node {
+        #[graphql(name = "id")]
+        async fn not_id(&self) -> i32 {
+            match self {
+                Node::NewTypeUnit(_) => 2,
+                Node::Unit => 3,
+                // This will get ignored!
+                Node::NewType(_) => 999,
+            }
+        }
+    }
+
+    #[derive(SimpleObject)]
+    struct NewType {
+        #[graphql(owned)]
+        id: i32,
+    }
+
+    #[derive(SimpleObject, Clone)]
+    #[graphql(interface_impl(interface_type = "Node", name = "id", ty = "i32"))]
+    struct NewTypeUnit;
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn new_type(&self) -> Node {
+            Node::NewType(NewType { id: 1 })
+        }
+
+        async fn new_type_unit(&self) -> Node {
+            Node::NewTypeUnit(NewTypeUnit)
+        }
+
+        async fn unit(&self) -> Node {
+            Node::Unit
+        }
+    }
+
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+    let query = r"{
+        newType {
+            __typename
+            id
+        }
+    }";
+    assert_eq!(
+        schema.execute(query).await.into_result().unwrap().data,
+        value!({
+            "newType": {
+                "__typename": "NewType",
+                "id": 1,
+            }
+        })
+    );
+    let query = r"{
+        newTypeUnit {
+            __typename
+            id
+        }
+    }";
+    assert_eq!(
+        schema.execute(query).await.into_result().unwrap().data,
+        value!({
+            "newTypeUnit": {
+                "__typename": "NewTypeUnit",
+                "id": 2,
+            }
+        })
+    );
+    let query = r"{
+        unit {
+            __typename
+            id
+        }
+    }";
+    assert_eq!(
+        schema.execute(query).await.into_result().unwrap().data,
+        value!({
+            "unit": {
+                "__typename": "Unit",
+                "id": 3,
+            }
+        })
+    );
+
+}

--- a/tests/interface.rs
+++ b/tests/interface.rs
@@ -623,7 +623,12 @@ pub async fn test_interface_impl() {
             }
         }";
     assert_eq!(
-        schema.execute(query_inner_a).await.into_result().unwrap().data,
+        schema
+            .execute(query_inner_a)
+            .await
+            .into_result()
+            .unwrap()
+            .data,
         value!({
             "getA": {
                 "__typename": "NewType",
@@ -659,7 +664,7 @@ pub async fn test_unit_variant() {
     enum Node {
         NewType(NewType),
         NewTypeUnit(NewTypeUnit),
-        Unit
+        Unit,
     }
 
     #[ComplexObject(interface)]
@@ -747,5 +752,4 @@ pub async fn test_unit_variant() {
             }
         })
     );
-
 }


### PR DESCRIPTION
## Enum implementations for `Interface`

I took a jab at #241 

this feature allows using `ComplexObject(interface)` to define enum level implementations of an interface field. An example is shown below
```rs
#[derive(SimpleObject, Clone)]
#[graphql(interface_impl(interface_type = "Node", name = "id", ty = "i32"))]
struct NewType {
    title_a: String,
}

#[derive(SimpleObject, Clone)]
#[graphql(interface_impl(interface_type = "Node", name = "id", ty = "i32"))]
struct NewTypeUnit;

#[derive(Interface)]
#[graphql(field(name = "id", ty = "i32"))]
enum Node {
    NewType(NewType),
    NewTypeUnit(NewTypeUnit),
}

#[ComplexObject(interface)]
impl Node {
    async fn id(&self) -> i32 {
        match self {
            Node::NewType(_) => 1,
            Node::NewTypeUnit(_) => 2,
        }
    }
}
```
The attribute macro will call convert the newtype variant into its parent enum and use it to resolve the field.

note:
- annotating with interface_impl will introduce a new method called interface_impl_{field} so it doesn't collide with the function signature expanded from `graphql(field)`
- Clone is required on structs that use interface_impl in order to perform type conversions
- My initial goal was to be able to implement this without having to do anything to the child newtype structs. However, I found this quite difficult since attribute macros on the enum could only modify the resolver for the enum but not its child types. This would create a logical error when querying in that if the newtype also defined a field with the same name, querying like `query { id }` would return the enum resolver result and querying like `query { ... on NewType { id } }` would return the newtype struct resolver result. So I basically concluded the most pragmatic way without huge changes was to use an attribute macro to change the newtype resolver and still let the enum propagate to the child resolver for consistency
- This could be a breaking change because I added an implementation function to the ComplexObject trait. Although this trait is hidden in the docs, a user could still manually implement this trait for their use case.

## Support Unit Structs for `Interface`
With the feature above implemented, we can now support unit variants of enums. An example is shown below
```rs
#[derive(Interface)]
#[graphql(field(name = "id", ty = "i32"))]
enum Node {
    NewType(NewType),
    NewTypeUnit(NewTypeUnit),
    Unit
}

#[ComplexObject(interface)]
impl Node {
    async fn id(&self) -> i32 {
        match self {
            Node::NewTypeUnit(_) => 2,
            Node::Unit => 3,
            // This will get ignored!
            Node::NewType(_) => 999,
        }
    }
}

#[derive(SimpleObject)]
struct NewType {
    #[graphql(owned)]
    id: i32,
}

#[derive(SimpleObject, Clone)]
#[graphql(interface_impl(interface_type = "Node", name = "id", ty = "i32"))]
struct NewTypeUnit;
```

On macro expansion, a hidden struct `Unit` will get defined and will utilize the Enum implementation for resolving the interface field.

---

Feel free to let me know what you think about this approach and / or suggestions / comments! Would love to explore other ways we can improve the user experience for this library!