### PR TITLE
Fix #1541: Support for JSON extended representations of BSON ObjectId and Uuid

### DIFF
--- a/src/types/external/bson.rs
+++ b/src/types/external/bson.rs
@@ -95,7 +95,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_uuid() {
+    fn test_parse_bson_uuid() {
         let id = Uuid::new();
         let bson_value = bson::bson!(id);
         let extended_json_value = json!(bson_value);
@@ -103,6 +103,18 @@ mod tests {
         assert_eq!(
             id,
             <Uuid as ScalarType>::parse(gql_value).expect("parsing succeeds")
+        );
+    }
+
+    #[test]
+    fn test_parse_bson_object_id() {
+        let id = ObjectId::from_bytes([42; 12]);
+        let bson_value = bson::bson!(id);
+        let extended_json_value = json!(bson_value);
+        let gql_value = Value::from_json(extended_json_value).expect("valid json");
+        assert_eq!(
+            id,
+            <ObjectId as ScalarType>::parse(gql_value).expect("parsing succeeds")
         );
     }
 }

--- a/src/types/external/bson.rs
+++ b/src/types/external/bson.rs
@@ -5,26 +5,18 @@ use bson::{oid::ObjectId, Bson, Document, Uuid};
 use chrono::{DateTime, Utc};
 
 use crate::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
-use base64::Engine;
 
 #[Scalar(internal)]
 impl ScalarType for ObjectId {
     fn parse(value: Value) -> InputValueResult<Self> {
         match value {
             Value::String(s) => Ok(ObjectId::parse_str(s)?),
-            Value::Object(mut o) => {
-                if o.len() > 1 {
-                    return Err(InputValueError::custom(
-                        "too many keys to be extended json representation of a BSON ObjectId",
-                    ));
-                }
-                let Some(v) = o.shift_remove("$oid") else {
-                    return Err(InputValueError::custom("missing field \"$oid\""));
-                };
-                let Value::String(s) = v else {
-                    return Err(InputValueError::expected_type(v));
-                };
-                Ok(ObjectId::parse_str(s)?)
+            Value::Object(o) => {
+                let json = Value::Object(o).into_json()?;
+                let bson = Bson::try_from(json)?;
+                bson.as_object_id().ok_or(InputValueError::custom(
+                    "could not parse the value as a BSON ObjectId",
+                ))
             }
             _ => Err(InputValueError::expected_type(value)),
         }
@@ -40,59 +32,16 @@ impl ScalarType for Uuid {
     fn parse(value: Value) -> InputValueResult<Self> {
         match value {
             Value::String(s) => Ok(Uuid::parse_str(s)?),
-            Value::Object(mut o) => {
-                if o.len() > 1 {
+            Value::Object(o) => {
+                let json = Value::Object(o).into_json()?;
+                let Bson::Binary(binary) = Bson::try_from(json)? else {
                     return Err(InputValueError::custom(
-                        "too many keys to be extended json representation of a BSON Uuid",
-                    ));
-                }
-                let Some(v) = o.shift_remove("$binary") else {
-                    return Err(InputValueError::custom("missing field \"$binary\""));
-                };
-                let Value::Object(mut o) = v else {
-                    return Err(InputValueError::expected_type(v));
-                };
-                if o.len() > 2 {
-                    return Err(InputValueError::custom(
-                        "too many keys to be extended json representation of a BSON Uuid",
-                    ));
-                }
-                let Some(t) = o.shift_remove("subType") else {
-                    return Err(InputValueError::custom("missing field \"subType\""));
-                };
-                let Value::String(t) = t else {
-                    return Err(InputValueError::expected_type(t));
-                };
-                let Ok(t) = u8::from_str_radix(&t, 16) else {
-                    return Err(InputValueError::custom(
-                        "could not decode subType from hex string",
+                        "could not parse the value as BSON Binary",
                     ));
                 };
-                if t != <bson::spec::BinarySubtype as Into<u8>>::into(
-                    bson::spec::BinarySubtype::Uuid,
-                ) || t
-                    != <bson::spec::BinarySubtype as Into<u8>>::into(
-                        bson::spec::BinarySubtype::UuidOld,
-                    )
-                {
-                    return Err(InputValueError::custom(
-                        "wrong BSON binary subtype to be a BSON Uuid",
-                    ));
-                }
-                let Some(payload) = o.shift_remove("base64") else {
-                    return Err(InputValueError::custom("missing field \"base64\""));
-                };
-                let Value::String(s) = payload else {
-                    return Err(InputValueError::expected_type(payload));
-                };
-                let Ok(payload_bytes) = base64::prelude::BASE64_STANDARD.decode(&s) else {
-                    return Err(InputValueError::custom("could not decode payload"));
-                };
-                let Ok(payload_bytes) = <Vec<u8> as TryInto<[u8; 16]>>::try_into(payload_bytes)
-                else {
-                    return Err(InputValueError::custom("wrong number of payload bytes"));
-                };
-                Ok(Uuid::from_bytes(payload_bytes))
+                binary.to_uuid().map_err(|_| {
+                    InputValueError::custom("could not deserialize BSON Binary to Uuid")
+                })
             }
             _ => Err(InputValueError::expected_type(value)),
         }

--- a/src/types/external/bson.rs
+++ b/src/types/external/bson.rs
@@ -5,12 +5,27 @@ use bson::{oid::ObjectId, Bson, Document, Uuid};
 use chrono::{DateTime, Utc};
 
 use crate::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
+use base64::Engine;
 
 #[Scalar(internal)]
 impl ScalarType for ObjectId {
     fn parse(value: Value) -> InputValueResult<Self> {
         match value {
             Value::String(s) => Ok(ObjectId::parse_str(s)?),
+            Value::Object(mut o) => {
+                if o.len() > 1 {
+                    return Err(InputValueError::custom(
+                        "too many keys to be extended json representation of a BSON ObjectId",
+                    ));
+                }
+                let Some(v) = o.shift_remove("$oid") else {
+                    return Err(InputValueError::custom("missing field \"$oid\""));
+                };
+                let Value::String(s) = v else {
+                    return Err(InputValueError::expected_type(v));
+                };
+                Ok(ObjectId::parse_str(s)?)
+            }
             _ => Err(InputValueError::expected_type(value)),
         }
     }
@@ -25,6 +40,60 @@ impl ScalarType for Uuid {
     fn parse(value: Value) -> InputValueResult<Self> {
         match value {
             Value::String(s) => Ok(Uuid::parse_str(s)?),
+            Value::Object(mut o) => {
+                if o.len() > 1 {
+                    return Err(InputValueError::custom(
+                        "too many keys to be extended json representation of a BSON Uuid",
+                    ));
+                }
+                let Some(v) = o.shift_remove("$binary") else {
+                    return Err(InputValueError::custom("missing field \"$binary\""));
+                };
+                let Value::Object(mut o) = v else {
+                    return Err(InputValueError::expected_type(v));
+                };
+                if o.len() > 2 {
+                    return Err(InputValueError::custom(
+                        "too many keys to be extended json representation of a BSON Uuid",
+                    ));
+                }
+                let Some(t) = o.shift_remove("subType") else {
+                    return Err(InputValueError::custom("missing field \"subType\""));
+                };
+                let Value::String(t) = t else {
+                    return Err(InputValueError::expected_type(t));
+                };
+                let Ok(t) = u8::from_str_radix(&t, 16) else {
+                    return Err(InputValueError::custom(
+                        "could not decode subType from hex string",
+                    ));
+                };
+                if t != <bson::spec::BinarySubtype as Into<u8>>::into(
+                    bson::spec::BinarySubtype::Uuid,
+                ) || t
+                    != <bson::spec::BinarySubtype as Into<u8>>::into(
+                        bson::spec::BinarySubtype::UuidOld,
+                    )
+                {
+                    return Err(InputValueError::custom(
+                        "wrong BSON binary subtype to be a BSON Uuid",
+                    ));
+                }
+                let Some(payload) = o.shift_remove("base64") else {
+                    return Err(InputValueError::custom("missing field \"base64\""));
+                };
+                let Value::String(s) = payload else {
+                    return Err(InputValueError::expected_type(payload));
+                };
+                let Ok(payload_bytes) = base64::prelude::BASE64_STANDARD.decode(&s) else {
+                    return Err(InputValueError::custom("could not decode payload"));
+                };
+                let Ok(payload_bytes) = <Vec<u8> as TryInto<[u8; 16]>>::try_into(payload_bytes)
+                else {
+                    return Err(InputValueError::custom("wrong number of payload bytes"));
+                };
+                Ok(Uuid::from_bytes(payload_bytes))
+            }
             _ => Err(InputValueError::expected_type(value)),
         }
     }
@@ -67,5 +136,24 @@ impl ScalarType for Document {
 
     fn to_value(&self) -> Value {
         bson::from_document(self.clone()).unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn parse_uuid() {
+        let id = Uuid::new();
+        let bson_value = bson::bson!(id);
+        let extended_json_value = json!(bson_value);
+        let gql_value = Value::from_json(extended_json_value).expect("valid json");
+        assert_eq!(
+            id,
+            <Uuid as ScalarType>::parse(gql_value).expect("parsing succeeds")
+        );
     }
 }


### PR DESCRIPTION
closes #1541

---
Unfortunately due to errors, I was not able to test the code yet. When running 
```sh
cargo test parse_uuid
```
I get 
```
error[E0432]: unresolved import `chrono`
 --> tests/introspection.rs:5:5
  |
5 | use chrono::{NaiveDate, NaiveDateTime};
  |     ^^^^^^ use of undeclared crate or module `chrono`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `async-graphql` (test "introspection") due to 1 previous error
```