### PR TITLE
Support raw values from serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ dynamic-schema = []
 graphiql = ["handlebars"]
 altair = ["handlebars", "schemars"]
 playground = []
+raw_value = ["async-graphql-value/raw_value"]
 
 [[bench]]
 harness = false

--- a/value/Cargo.toml
+++ b/value/Cargo.toml
@@ -16,3 +16,6 @@ serde_json.workspace = true
 serde.workspace = true
 bytes.workspace = true
 indexmap.workspace = true
+
+[features]
+raw_value = ["serde_json/raw_value"]

--- a/value/src/lib.rs
+++ b/value/src/lib.rs
@@ -27,6 +27,9 @@ pub use serde_json::Number;
 pub use serializer::{to_value, SerializerError};
 pub use variables::Variables;
 
+#[cfg(feature = "raw_value")]
+pub use value_serde::RAW_VALUE_TOKEN;
+
 /// A GraphQL name.
 ///
 /// [Reference](https://spec.graphql.org/June2018/#Name).


### PR DESCRIPTION
The motivation here is the same as the one for `raw_value` in `serde_json`:

https://docs.rs/serde_json/latest/serde_json/value/struct.RawValue.html

Namely, in case of large payloads that do not have to be processed but just forwarded further, it becomes very CPU and memory intensive to have them parsed into `ConstValue` and then serialized back to JSON. Please see the test for an illustration.