### PR TITLE
Make From<T> for Error set source

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -319,11 +319,11 @@ impl Error {
     }
 }
 
-impl<T: Display + Send + Sync> From<T> for Error {
+impl<T: Display + Send + Sync + 'static> From<T> for Error {
     fn from(e: T) -> Self {
         Self {
             message: e.to_string(),
-            source: None,
+            source: Some(Arc::new(e)),
             extensions: None,
         }
     }


### PR DESCRIPTION
Hi

It would be really nice if `from(e)` would set source. Is this something that could be added? Maybe in a future major release (since adding `'static` as a bound is a breaking change)?