### PR TITLE
chore: Make Extensions nullable

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -175,6 +175,7 @@ pub async fn receive_batch_cbor(body: impl AsyncRead) -> Result<BatchRequest, Pa
 
 #[cfg(test)]
 mod tests {
+    use async_graphql_value::Extensions;
     use std::collections::HashMap;
 
     use super::*;
@@ -191,7 +192,7 @@ mod tests {
                 "sha256Hash": "cde5de0a350a19c59f8ddcd9646e5f260b2a7d5649ff6be8e63e9462934542c3",
                 "version": 1,
             }));
-            extensions
+            Extensions(extensions)
         });
 
         let request = parse_query_string("query={a}&variables=%7B%22a%22%3A10%7D").unwrap();

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -175,8 +175,9 @@ pub async fn receive_batch_cbor(body: impl AsyncRead) -> Result<BatchRequest, Pa
 
 #[cfg(test)]
 mod tests {
-    use async_graphql_value::Extensions;
     use std::collections::HashMap;
+
+    use async_graphql_value::Extensions;
 
     use super::*;
     use crate::{value, Variables};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ pub mod registry;
 
 pub use async_graphql_parser as parser;
 pub use async_graphql_value::{
-    from_value, to_value, value, ConstValue as Value, DeserializerError, Name, Number,
+    from_value, to_value, value, ConstValue as Value, DeserializerError, Extensions, Name, Number,
     SerializerError, Variables,
 };
 #[doc(hidden)]

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,6 +1,5 @@
 use std::{
     any::Any,
-    collections::HashMap,
     fmt::{self, Debug, Formatter},
 };
 
@@ -9,7 +8,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use crate::{
     parser::{parse_query, types::ExecutableDocument},
     schema::IntrospectionMode,
-    Data, ParseRequestError, ServerError, UploadValue, Value, Variables,
+    Data, Extensions, ParseRequestError, ServerError, UploadValue, Value, Variables,
 };
 
 /// GraphQL request.
@@ -45,7 +44,7 @@ pub struct Request {
 
     /// The extensions config of the request.
     #[serde(default)]
-    pub extensions: HashMap<String, Value>,
+    pub extensions: Extensions,
 
     #[serde(skip)]
     pub(crate) parsed_query: Option<ExecutableDocument>,

--- a/value/src/extensions.rs
+++ b/value/src/extensions.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
+
+/// Extensions of a query.
+#[derive(Debug, Clone, Default, Serialize, Eq, PartialEq)]
+#[serde(transparent)]
+pub struct Extensions(pub HashMap<String, crate::ConstValue>);
+
+impl<'de> Deserialize<'de> for Extensions {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self(
+            <Option<HashMap<_, _>>>::deserialize(deserializer)?.unwrap_or_default(),
+        ))
+    }
+}
+
+impl Deref for Extensions {
+    type Target = HashMap<String, crate::ConstValue>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Extensions {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/value/src/extensions.rs
+++ b/value/src/extensions.rs
@@ -1,6 +1,9 @@
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+};
+
 use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
 
 /// Extensions of a query.
 #[derive(Debug, Clone, Default, Serialize, Eq, PartialEq)]

--- a/value/src/lib.rs
+++ b/value/src/lib.rs
@@ -5,6 +5,7 @@
 #![forbid(unsafe_code)]
 
 mod deserializer;
+mod extensions;
 mod macros;
 mod serializer;
 mod value_serde;
@@ -19,6 +20,7 @@ use std::{
 
 use bytes::Bytes;
 pub use deserializer::{from_value, DeserializerError};
+pub use extensions::Extensions;
 #[doc(hidden)]
 pub use indexmap;
 use indexmap::IndexMap;


### PR DESCRIPTION
Currently `extensions` in `GraphQLRequest` are just HashMap of String, Value, so for the sample query:

```gql
{
   "query": "{ foo }",
   "extensions": null
}
```

deserialization will fail because of the null value

to avoid that, I added the `Extensions` struct which handles deserialization properly with minimal change.