### PR TITLE
chore: skip serializing if Response data is default

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -9,7 +9,7 @@ use crate::{CacheControl, Result, ServerError, Value};
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Response {
     /// Data of query result
-    #[serde(default)]
+    #[serde(skip_serializing_if = "is_default", default)]
     pub data: Value,
 
     /// Extensions result
@@ -27,6 +27,10 @@ pub struct Response {
     /// HTTP headers
     #[serde(skip)]
     pub http_headers: http::HeaderMap,
+}
+
+fn is_default<T: Default + PartialEq>(v: &T) -> bool {
+    T::default().eq(v)
 }
 
 impl Response {

--- a/tests/batch_request.rs
+++ b/tests/batch_request.rs
@@ -24,7 +24,7 @@ pub async fn test_batch_request() {
         serde_json::json!([
             {"data": { "value": 30 }},
             {"data": { "value": 70 }},
-            {"data": null, "errors": [{
+            {"errors": [{
                 "message": r#"Unknown field "value1" on type "Query". Did you mean "value"?"#,
                 "locations": [{"line": 1, "column": 3}]
             }]},

--- a/tests/error_ext.rs
+++ b/tests/error_ext.rs
@@ -38,7 +38,6 @@ pub async fn test_error_extensions() {
     assert_eq!(
         serde_json::to_value(&schema.execute("{ extendErr }").await).unwrap(),
         serde_json::json!({
-            "data": null,
             "errors": [{
                 "message": "my error",
                 "locations": [{
@@ -58,7 +57,6 @@ pub async fn test_error_extensions() {
     assert_eq!(
         serde_json::to_value(&schema.execute("{ extendResult }").await).unwrap(),
         serde_json::json!({
-            "data": null,
             "errors": [{
                 "message": "my error",
                 "locations": [{

--- a/tests/subscription_websocket_graphql_ws.rs
+++ b/tests/subscription_websocket_graphql_ws.rs
@@ -315,7 +315,6 @@ pub async fn test_subscription_ws_transport_error() {
             "type": "next",
             "id": "1",
             "payload": {
-                "data": null,
                 "errors": [{
                     "message": "TestError",
                     "locations": [{"line": 1, "column": 25}],

--- a/tests/subscription_websocket_subscriptions_transport_ws.rs
+++ b/tests/subscription_websocket_subscriptions_transport_ws.rs
@@ -255,7 +255,6 @@ pub async fn test_subscription_ws_transport_error() {
             "type": "data",
             "id": "1",
             "payload": {
-                "data": null,
                 "errors": [{
                     "message": "TestError",
                     "locations": [{"line": 1, "column": 25}],


### PR DESCRIPTION
Currently response data is serialized to `null` but according to GraphQL Over HTTP rules, it should be skipped.