### PR TITLE
Add an "on ping" callback

### DIFF
--- a/integrations/axum/src/subscription.rs
+++ b/integrations/axum/src/subscription.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, convert::Infallible, future::Future, str::FromStr};
 
 use async_graphql::{
     futures_util::task::{Context, Poll},
-    http::{WebSocketProtocols, WsMessage, ALL_WEBSOCKET_PROTOCOLS},
+    http::{DefaultOnPingType, WebSocketProtocols, WsMessage, ALL_WEBSOCKET_PROTOCOLS},
     Data, Executor, Result,
 };
 use axum::{
@@ -124,16 +124,24 @@ fn default_on_connection_init(_: serde_json::Value) -> Ready<async_graphql::Resu
 }
 
 /// A Websocket connection for GraphQL subscription.
-pub struct GraphQLWebSocket<Sink, Stream, E, OnConnInit> {
+pub struct GraphQLWebSocket<Sink, Stream, E, OnConnInit, OnPing> {
     sink: Sink,
     stream: Stream,
     executor: E,
     data: Data,
     on_connection_init: OnConnInit,
+    on_ping: Option<OnPing>,
     protocol: GraphQLProtocol,
 }
 
-impl<S, E> GraphQLWebSocket<SplitSink<S, Message>, SplitStream<S>, E, DefaultOnConnInitType>
+impl<S, E>
+    GraphQLWebSocket<
+        SplitSink<S, Message>,
+        SplitStream<S>,
+        E,
+        DefaultOnConnInitType,
+        DefaultOnPingType,
+    >
 where
     S: Stream<Item = Result<Message, Error>> + Sink<Message>,
     E: Executor,
@@ -145,7 +153,7 @@ where
     }
 }
 
-impl<Sink, Stream, E> GraphQLWebSocket<Sink, Stream, E, DefaultOnConnInitType>
+impl<Sink, Stream, E> GraphQLWebSocket<Sink, Stream, E, DefaultOnConnInitType, DefaultOnPingType>
 where
     Sink: futures_util::sink::Sink<Message>,
     Stream: futures_util::stream::Stream<Item = Result<Message, Error>>,
@@ -164,18 +172,21 @@ where
             executor,
             data: Data::default(),
             on_connection_init: default_on_connection_init,
+            on_ping: None,
             protocol,
         }
     }
 }
 
-impl<Sink, Stream, E, OnConnInit, OnConnInitFut> GraphQLWebSocket<Sink, Stream, E, OnConnInit>
+impl<Sink, Stream, E, OnConnInit, OnConnInitFut, OnPing>
+    GraphQLWebSocket<Sink, Stream, E, OnConnInit, OnPing>
 where
     Sink: futures_util::sink::Sink<Message>,
     Stream: futures_util::stream::Stream<Item = Result<Message, Error>>,
     E: Executor,
     OnConnInit: FnOnce(serde_json::Value) -> OnConnInitFut + Send + 'static,
     OnConnInitFut: Future<Output = async_graphql::Result<Data>> + Send + 'static,
+    OnPing: Fn(Option<serde_json::Value>) -> (),
 {
     /// Specify the initial subscription context data, usually you can get
     /// something from the incoming request to create it.
@@ -193,7 +204,7 @@ where
     pub fn on_connection_init<OnConnInit2, Fut>(
         self,
         callback: OnConnInit2,
-    ) -> GraphQLWebSocket<Sink, Stream, E, OnConnInit2>
+    ) -> GraphQLWebSocket<Sink, Stream, E, OnConnInit2, OnPing>
     where
         OnConnInit2: FnOnce(serde_json::Value) -> Fut + Send + 'static,
         Fut: Future<Output = async_graphql::Result<Data>> + Send + 'static,
@@ -204,6 +215,26 @@ where
             executor: self.executor,
             data: self.data,
             on_connection_init: callback,
+            on_ping: self.on_ping,
+            protocol: self.protocol,
+        }
+    }
+
+    /// Specify a callback function to be called when the connection receives a ping message.
+    pub fn on_ping<OnPing2>(
+        self,
+        callback: OnPing2,
+    ) -> GraphQLWebSocket<Sink, Stream, E, OnConnInit, OnPing2>
+    where
+        OnPing2: Fn(Option<serde_json::Value>) -> (),
+    {
+        GraphQLWebSocket {
+            sink: self.sink,
+            stream: self.stream,
+            executor: self.executor,
+            data: self.data,
+            on_connection_init: self.on_connection_init,
+            on_ping: Some(callback),
             protocol: self.protocol,
         }
     }
@@ -227,6 +258,7 @@ where
             async_graphql::http::WebSocket::new(self.executor.clone(), input, self.protocol.0)
                 .connection_data(self.data)
                 .on_connection_init(self.on_connection_init)
+                .on_ping(self.on_ping)
                 .map(|msg| match msg {
                     WsMessage::Text(text) => Message::Text(text),
                     WsMessage::Close(code, status) => Message::Close(Some(CloseFrame {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -31,7 +31,8 @@ pub use multipart_subscribe::{create_multipart_mixed_stream, is_accept_multipart
 pub use playground_source::{playground_source, GraphQLPlaygroundConfig};
 use serde::Deserialize;
 pub use websocket::{
-    ClientMessage, Protocols as WebSocketProtocols, WebSocket, WsMessage, ALL_WEBSOCKET_PROTOCOLS,
+    ClientMessage, DefaultOnPingType, Protocols as WebSocketProtocols, WebSocket, WsMessage,
+    ALL_WEBSOCKET_PROTOCOLS,
 };
 
 use crate::{BatchRequest, ParseRequestError, Request};


### PR DESCRIPTION
This PR works but probaby is not ready to be merged. Sending this PR out to see if @sunli829 thinks this is the right approach (it's very bare-bones). 

Our application needs to react to subscription disconnections. This PR adds an `on_ping` callback which can help with that. We rely on the client sending pings at some fixed interval. In the `on_ping` callback the server could repeatedly restart a timer, upon expiry of which the server could declare the connection to be dead and do something. 


### Rough edges

- The `on_ping` callback is NOT an async function, but it is invoked by the loop in `serve`. This means it's a potential footgun. If the user accidentally blocks here, the subscription might not react in time to necessary events. In practice, most of the users would probably invoke a `send` method on `broadcast::Sender` from that call. The corresponding `Receiver` needs to be passed as data to the context, and thus accessed by the subscription stream.
- Relying on the user sending pings at a certain interval (as opposed to server sending the pings and awaiting the pongs) requires coordination between the client and the server on what that ping duration is. This approach was chosen for its simplicity.

If this approach is approved I can add tests and extend other integrations. 

### Alternatives 

##### Async callback 

We could have been accepting an async function as a callback and calling `tokio::spawn`. Rejected because introduces a dependency on the `tokio` crate and is not zero-cost. 

##### Ping stream

Instead of an `on_ping` callback, we could have allowed the user to supply a `Stream` that produces pings, and an `on_pong` callback. Rejected because it's more complex. 


