### PR TITLE
Bump opentelemetry 0.23 > 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ fast_chemail = { version = "0.9.6", optional = true }
 hashbrown = { version = "0.14.3", optional = true }
 iso8601 = { version = "0.6.1", optional = true }
 log = { version = "0.4.21", optional = true }
-opentelemetry = { version = "0.23.0", optional = true, default-features = false, features = [
+opentelemetry = { version = "0.24.0", optional = true, default-features = false, features = [
   "trace",
 ] }
 rust_decimal = { version = "1.35.0", optional = true }


### PR DESCRIPTION
Bump otel to 0.24 which is using http 1.0. No code changes required.
