### PR TITLE
fix: extensions should be optional

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -185,7 +185,7 @@ mod tests {
         let request = parse_query_string("variables=%7B%7D&extensions=%7B%22persistedQuery%22%3A%7B%22sha256Hash%22%3A%22cde5de0a350a19c59f8ddcd9646e5f260b2a7d5649ff6be8e63e9462934542c3%22%2C%22version%22%3A1%7D%7D").unwrap();
         assert_eq!(request.query.as_str(), "");
         assert_eq!(request.variables, Variables::default());
-        assert_eq!(request.extensions, {
+        assert_eq!(request.extensions.unwrap(), {
             let mut extensions = HashMap::new();
             extensions.insert("persistedQuery".to_string(), value!({
                 "sha256Hash": "cde5de0a350a19c59f8ddcd9646e5f260b2a7d5649ff6be8e63e9462934542c3",

--- a/src/request.rs
+++ b/src/request.rs
@@ -45,7 +45,7 @@ pub struct Request {
 
     /// The extensions config of the request.
     #[serde(default)]
-    pub extensions: HashMap<String, Value>,
+    pub extensions: Option<HashMap<String, Value>>,
 
     #[serde(skip)]
     pub(crate) parsed_query: Option<ExecutableDocument>,


### PR DESCRIPTION
According to graphql-over-http the extension option should be optional. I adjusted the code to mitigate this issue.

> extensions - (Optional, map): This entry is reserved for implementors to extend the protocol however they see fit.

== Source ==
https://graphql.github.io/graphql-over-http/draft/#sel-FALFFHDAAACD8Cokd