### PR TITLE
expose rejection in async_graphql_axum

### DIFF
--- a/integrations/axum/src/lib.rs
+++ b/integrations/axum/src/lib.rs
@@ -9,7 +9,7 @@ mod response;
 #[cfg(not(target_arch = "wasm32"))]
 mod subscription;
 
-pub use extract::{GraphQLBatchRequest, GraphQLRequest};
+pub use extract::{rejection, GraphQLBatchRequest, GraphQLRequest};
 pub use query::GraphQL;
 pub use response::GraphQLResponse;
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
this adds the rejection module to the pub use in the aysnc_graphql_axum lib. This is very useful when implementing custom services.