### PR TITLE
Updated crate time to 3.36, as it fixes a compilation error in rust 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ rust_decimal = { version = "1.35.0", optional = true }
 bigdecimal = { version = ">=0.3.0, <0.5.0", optional = true }
 secrecy = { version = "0.8.0", optional = true }
 smol_str = { version = "0.2.1", optional = true }
-time = { version = "0.3.34", optional = true, features = [
+time = { version = "0.3.36", optional = true, features = [
   "parsing",
   "formatting",
   "macros",


### PR DESCRIPTION
The error was caused when using the parsing, formatting and macros features