### PR TITLE
Support `#[doc = include_str!(...)]` in generated documentation

### DIFF
--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -59,29 +59,48 @@ pub fn generate_guards(
     })
 }
 
-pub fn get_rustdoc(attrs: &[Attribute]) -> GeneratorResult<Option<String>> {
-    let mut full_docs = String::new();
+pub fn get_rustdoc(attrs: &[Attribute]) -> GeneratorResult<Option<TokenStream>> {
+    let mut full_docs: Vec<TokenStream> = vec![];
+    let mut combined_docs_literal = String::new();
     for attr in attrs {
         if let Meta::NameValue(nv) = &attr.meta {
             if nv.path.is_ident("doc") {
-                if let Expr::Lit(ExprLit {
-                    lit: Lit::Str(doc), ..
-                }) = &nv.value
-                {
-                    let doc = doc.value();
-                    let doc_str = doc.trim();
-                    if !full_docs.is_empty() {
-                        full_docs += "\n";
+                match &nv.value {
+                    Expr::Lit(ExprLit {
+                        lit: Lit::Str(doc), ..
+                    }) => {
+                        let doc = doc.value();
+                        let doc_str = doc.trim();
+                        if !combined_docs_literal.is_empty() {
+                            combined_docs_literal += "\n";
+                        }
+                        combined_docs_literal += doc_str;
                     }
-                    full_docs += doc_str;
+                    Expr::Macro(include_macro) => {
+                        if !combined_docs_literal.is_empty() {
+                            combined_docs_literal += "\n";
+                            let lit = LitStr::new(&combined_docs_literal, Span::call_site());
+                            full_docs.push(quote!( #lit ));
+                            combined_docs_literal.clear();
+                        }
+                        full_docs.push(quote!( #include_macro ));
+                    }
+                    _ => (),
                 }
             }
         }
     }
+
+    if !combined_docs_literal.is_empty() {
+        let lit = LitStr::new(&combined_docs_literal, Span::call_site());
+        full_docs.push(quote!( #lit ));
+        combined_docs_literal.clear();
+    }
+
     Ok(if full_docs.is_empty() {
         None
     } else {
-        Some(full_docs)
+        Some(quote!(::std::concat!( #( #full_docs ),* )))
     })
 }
 


### PR DESCRIPTION
```rust
#[Object]
impl AccountMutation {
    /// Create a new account object.
    ///
    #[doc = include_str!(concat!(env!("OUT_DIR"),"/",stringify!(ItemCreationError),".md"))]
    //      ^^^^^^^^^^^: `include_str!(...)` contents will be included in the graphql description
    async fn create_account(
        &self,
        ctx: &Context<'_>,
        common_name: String,
    ) -> Result<dtos::ObjectCreated, dtos::ItemCreationError> { todo!() }
}
```

Custom macros like `#[doc = include_error_doc!(ItemCreationError)]` (this macro does the same as the example) are also supported.


https://wavestore.atlassian.net/browse/HT-725