### PR TITLE
Support scraping `#[doc = ...]` attributes when generating descriptions

### DIFF
--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -71,9 +71,7 @@ pub fn get_rustdoc(attrs: &[Attribute]) -> GeneratorResult<Option<TokenStream>> 
                     }) => {
                         let doc = doc.value();
                         let doc_str = doc.trim();
-                        if !combined_docs_literal.is_empty() {
-                            combined_docs_literal += "\n";
-                        }
+                        combined_docs_literal += "\n";
                         combined_docs_literal += doc_str;
                     }
                     Expr::Macro(include_macro) => {
@@ -100,7 +98,9 @@ pub fn get_rustdoc(attrs: &[Attribute]) -> GeneratorResult<Option<TokenStream>> 
     Ok(if full_docs.is_empty() {
         None
     } else {
-        Some(quote!(::std::concat!( #( #full_docs ),* )))
+        Some(quote!(::core::primitive::str::trim(
+            ::std::concat!( #( #full_docs ),* )
+        )))
     })
 }
 

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -59,29 +59,48 @@ pub fn generate_guards(
     })
 }
 
-pub fn get_rustdoc(attrs: &[Attribute]) -> GeneratorResult<Option<String>> {
-    let mut full_docs = String::new();
+pub fn get_rustdoc(attrs: &[Attribute]) -> GeneratorResult<Option<TokenStream>> {
+    let mut full_docs: Vec<TokenStream> = vec![];
+    let mut combined_docs_literal = String::new();
     for attr in attrs {
         if let Meta::NameValue(nv) = &attr.meta {
             if nv.path.is_ident("doc") {
-                if let Expr::Lit(ExprLit {
-                    lit: Lit::Str(doc), ..
-                }) = &nv.value
-                {
-                    let doc = doc.value();
-                    let doc_str = doc.trim();
-                    if !full_docs.is_empty() {
-                        full_docs += "\n";
+                match &nv.value {
+                    Expr::Lit(ExprLit {
+                        lit: Lit::Str(doc), ..
+                    }) => {
+                        let doc = doc.value();
+                        let doc_str = doc.trim();
+                        if !combined_docs_literal.is_empty() {
+                            combined_docs_literal += "\n";
+                        }
+                        combined_docs_literal += doc_str;
                     }
-                    full_docs += doc_str;
+                    Expr::Macro(include_macro) => {
+                        if !combined_docs_literal.is_empty() {
+                            combined_docs_literal += "\n";
+                            let lit = LitStr::new(&combined_docs_literal, Span::call_site());
+                            full_docs.push(quote!( #lit ));
+                            combined_docs_literal.clear();
+                        }
+                        full_docs.push(quote!( #include_macro ));
+                    }
+                    _ => (),
                 }
             }
         }
     }
+
+    if !combined_docs_literal.is_empty() {
+        let lit = LitStr::new(&combined_docs_literal, Span::call_site());
+        full_docs.push(quote!( #lit ));
+        combined_docs_literal.clear();
+    }
+
     Ok(if full_docs.is_empty() {
         None
     } else {
-        Some(full_docs)
+        Some(quote!(::std::concat!( #( #full_docs ),* )))
     })
 }
 

--- a/tests/description.rs
+++ b/tests/description.rs
@@ -1,0 +1,156 @@
+use async_graphql::*;
+
+#[tokio::test]
+pub async fn test_use_type_description() {
+    /// Haha
+    #[doc = "next line"]
+    #[derive(Description, Default)]
+    struct MyObj;
+
+    #[Object(use_type_description)]
+    impl MyObj {
+        async fn value(&self) -> i32 {
+            100
+        }
+    }
+
+    #[derive(SimpleObject, Default)]
+    struct Query {
+        obj: MyObj,
+    }
+
+    let schema = Schema::new(Query::default(), EmptyMutation, EmptySubscription);
+    assert_eq!(
+        schema
+            .execute(r#"{ __type(name: "MyObj") { description } }"#)
+            .await
+            .data,
+        value!({
+            "__type": { "description": "Haha\nnext line" }
+        })
+    );
+}
+
+#[tokio::test]
+pub async fn test_use_type_external() {
+    /// Wow
+    #[doc = include_str!("external_descriptions/desc1.md")]
+    /// More
+    #[derive(Description, Default)]
+    struct MyObj<'a>(&'a str);
+
+    #[Object(use_type_description)]
+    impl<'a> MyObj<'a> {
+        async fn value(&self) -> &str {
+            self.0
+        }
+    }
+
+    struct Query;
+
+    #[Object]
+    #[allow(unreachable_code)]
+    impl Query {
+        async fn obj(&self) -> MyObj<'_> {
+            todo!()
+        }
+    }
+
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+    assert_eq!(
+        schema
+            .execute(r#"{ __type(name: "MyObj") { description } }"#)
+            .await
+            .data,
+        value!({
+            "__type": { "description": "Wow\nextern 1\n\nextern 2\nMore" }
+        })
+    );
+}
+
+#[tokio::test]
+pub async fn test_use_type_external_macro() {
+    macro_rules! external_doc {
+        ($ident:ident) => {
+            include_str!(concat!("external_descriptions/", stringify!($ident), ".md"))
+        };
+    }
+
+    /// Wow
+    // Simple declarative macros also work
+    #[doc = external_doc!(desc1)]
+    ///
+    /// More
+    #[derive(Description, Default)]
+    struct MyObj<'a>(&'a str);
+
+    #[Object(use_type_description)]
+    impl<'a> MyObj<'a> {
+        async fn value(&self) -> &str {
+            self.0
+        }
+    }
+
+    struct Query;
+
+    #[Object]
+    #[allow(unreachable_code)]
+    impl Query {
+        async fn obj(&self) -> MyObj<'_> {
+            todo!()
+        }
+    }
+
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+    assert_eq!(
+        schema
+            .execute(r#"{ __type(name: "MyObj") { description } }"#)
+            .await
+            .data,
+        value!({
+            "__type": { "description": "Wow\nextern 1\n\nextern 2\n\nMore" }
+        })
+    );
+}
+
+#[tokio::test]
+pub async fn test_fields() {
+    #[derive(SimpleObject, Default)]
+    #[graphql(complex)]
+    struct Obj {
+        #[doc = include_str!("external_descriptions/desc1.md")]
+        obj: String,
+    }
+
+    #[ComplexObject]
+    impl Obj {
+        #[doc = "line 1"]
+        #[doc = ""]
+        ///
+        #[doc = "line 2"]
+        ///
+        #[doc = include_str!("external_descriptions/desc2.md")]
+        // Make sure trailing whitespace is removed
+        ///
+        #[doc = ""]
+        async fn obj2(&self) -> i32 {
+            0
+        }
+    }
+
+    let schema = Schema::new(Obj::default(), EmptyMutation, EmptySubscription);
+    assert_eq!(
+        schema
+            .execute(r#"{ __type(name: "Obj") { fields { name, description } } }"#)
+            .await
+            .data,
+        value!({
+            "__type": {
+                "fields": [
+                    {"name": "obj", "description": "extern 1\n\nextern 2"},
+                    {"name": "obj2", "description": "line 1\n\n\nline 2\n\nexternal"}
+                ]
+            }
+        })
+    );
+}

--- a/tests/external_descriptions/desc1.md
+++ b/tests/external_descriptions/desc1.md
@@ -1,0 +1,3 @@
+extern 1
+
+extern 2

--- a/tests/external_descriptions/desc2.md
+++ b/tests/external_descriptions/desc2.md
@@ -1,0 +1,1 @@
+external


### PR DESCRIPTION
This modifies the Rust doc scraping function used by all `async-graphql` macros to start scrape `#[doc = ...]` attributes and adding them to the GraphQL description of the related type. This is particularly useful for including external documentation using an attribute like `#[doc = include_str!("external_doc.md")]`. Previously `#[doc]` attributes were ignored. Using the `#[doc]` attribute should be supported by all `async-graphql` macros after this change as far as I can tell.

Example:
```rust
use async_graphql::*;

struct MyObject;

#[Object]
impl MyObject {
    /// Return a value
    ///
    #[doc = include_str!("external_doc.md")] // <--- This will be included in the GraphQL description.
    ///
    /// You can also include text down here.
    async fn value(&self) -> String {
        "Some text".to_string()
    }
}
```