### PR TITLE
Impl Debug for dynamic::FieldValue & Improve error messages for its methods

### DIFF
--- a/src/dynamic/field.rs
+++ b/src/dynamic/field.rs
@@ -21,9 +21,11 @@ pub(crate) enum FieldValueInner<'a> {
     /// Const value
     Value(Value),
     /// Borrowed any value
-    BorrowedAny(&'a (dyn Any + Send + Sync)),
+    /// The first item is the [`std::any::type_name`] of the value used for debugging.
+    BorrowedAny(Cow<'static, str>, &'a (dyn Any + Send + Sync)),
     /// Owned any value
-    OwnedAny(Box<dyn Any + Send + Sync>),
+    /// The first item is the [`std::any::type_name`] of the value used for debugging.
+    OwnedAny(Cow<'static, str>, Box<dyn Any + Send + Sync>),
     /// A list
     List(Vec<FieldValue<'a>>),
     /// A typed Field value
@@ -33,6 +35,25 @@ pub(crate) enum FieldValueInner<'a> {
         /// Object name
         ty: Cow<'static, str>,
     },
+}
+
+impl<'a> Debug for FieldValue<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            FieldValueInner::Value(v) => write!(f, "{}", v),
+            FieldValueInner::BorrowedAny(ty, _)
+            | FieldValueInner::OwnedAny(ty, _)
+            | FieldValueInner::WithType { ty, .. } => write!(f, "{}", ty),
+            FieldValueInner::List(list) => match list.first() {
+                Some(v) => {
+                    write!(f, "[{}, ...]", format!("{:?}", v))
+                }
+                None => {
+                    write!(f, "[()]")
+                }
+            },
+        }
+    }
 }
 
 impl<'a> From<()> for FieldValue<'a> {
@@ -90,20 +111,29 @@ impl<'a> FieldValue<'a> {
 
     /// Create a FieldValue from owned any value
     #[inline]
-    pub fn owned_any(obj: impl Any + Send + Sync) -> Self {
-        Self(FieldValueInner::OwnedAny(Box::new(obj)))
+    pub fn owned_any<T: Any + Send + Sync>(obj: T) -> Self {
+        Self(FieldValueInner::OwnedAny(
+            std::any::type_name::<T>().into(),
+            Box::new(obj),
+        ))
     }
 
     /// Create a FieldValue from unsized any value
     #[inline]
-    pub fn boxed_any(obj: Box<dyn Any + Send + Sync>) -> Self {
-        Self(FieldValueInner::OwnedAny(obj))
+    pub fn boxed_any<T: Any + Send + Sync>(obj: Box<T>) -> Self {
+        Self(FieldValueInner::OwnedAny(
+            std::any::type_name::<T>().into(),
+            obj,
+        ))
     }
 
     /// Create a FieldValue from owned any value
     #[inline]
-    pub fn borrowed_any(obj: &'a (dyn Any + Send + Sync)) -> Self {
-        Self(FieldValueInner::BorrowedAny(obj))
+    pub fn borrowed_any<T: Any + Send + Sync>(obj: &'a T) -> Self {
+        Self(FieldValueInner::BorrowedAny(
+            std::any::type_name::<T>().into(),
+            obj,
+        ))
     }
 
     /// Create a FieldValue from list
@@ -216,8 +246,8 @@ impl<'a> FieldValue<'a> {
     #[inline]
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
         match &self.0 {
-            FieldValueInner::BorrowedAny(value) => value.downcast_ref::<T>(),
-            FieldValueInner::OwnedAny(value) => value.downcast_ref::<T>(),
+            FieldValueInner::BorrowedAny(_, value) => value.downcast_ref::<T>(),
+            FieldValueInner::OwnedAny(_, value) => value.downcast_ref::<T>(),
             _ => None,
         }
     }

--- a/src/dynamic/field.rs
+++ b/src/dynamic/field.rs
@@ -221,7 +221,7 @@ impl<'a> FieldValue<'a> {
     #[inline]
     pub fn try_to_value(&self) -> Result<&Value> {
         self.as_value()
-            .ok_or_else(|| Error::new("internal: not a Value"))
+            .ok_or_else(|| Error::new(format!("internal: \"{:?}\" not a Value", self)))
     }
 
     /// If the FieldValue is a list, returns the associated
@@ -238,7 +238,7 @@ impl<'a> FieldValue<'a> {
     #[inline]
     pub fn try_to_list(&self) -> Result<&[FieldValue]> {
         self.as_list()
-            .ok_or_else(|| Error::new("internal: not a list"))
+            .ok_or_else(|| Error::new(format!("internal: \"{:?}\" not a List", self)))
     }
 
     /// If the FieldValue is a any, returns the associated
@@ -257,7 +257,8 @@ impl<'a> FieldValue<'a> {
     pub fn try_downcast_ref<T: Any>(&self) -> Result<&T> {
         self.downcast_ref().ok_or_else(|| {
             Error::new(format!(
-                "internal: not type \"{}\"",
+                "internal: \"{:?}\" is not of the expected type \"{}\"",
+                self,
                 std::any::type_name::<T>()
             ))
         })


### PR DESCRIPTION
Hello,

This PR implements the `Debug` trait for the `dynamic::FieldValue` type, which enhances the ability to debug issues

**Context:**

Consider the following code snippet, which contains a trivial bug where an `Option<Book>` is used instead of a `Book` for the `FieldValue`:

```rust
let book_query_field = Field::new("book", TypeRef::named(book.type_name()), |ctx| {
    FieldFuture::new(async move {
        let id = ctx.args.try_get("id")?;
        let book_id = match id.string() {
            Ok(id) => id.to_string(),
            Err(_) => id.u64()?.to_string(),
        };
        let book_id = book_id.parse::<usize>()?;
        let store = ctx.data_unchecked::<Storage>().books.lock().await;
        let book = store.get(book_id).cloned();
        Ok(Some(FieldValue::owned_any(book)))
    })
})
.argument(InputValue::new("id", TypeRef::named_nn(TypeRef::ID)));
```

This code results in an ambiguous error:

```
internal: not type Book
```

Without the `Debug` trait implemented, it’s challenging to identify the root cause of this issue at first glance. 

This PR is also Improve error messages in FieldValue methods for better debugging clarity.
