### PR TITLE
UUID validator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ graphiql = ["handlebars"]
 altair = ["handlebars", "schemars"]
 playground = []
 raw_value = ["async-graphql-value/raw_value"]
+uuid-validator = ["uuid"]
 
 [[bench]]
 harness = false

--- a/derive/src/validators.rs
+++ b/derive/src/validators.rs
@@ -58,6 +58,8 @@ pub struct Validators {
     ip: bool,
     #[darling(default)]
     regex: Option<String>,
+    #[darling(default)]
+    uuid: Option<usize>,
     #[darling(default, multiple)]
     custom: Vec<Expr>,
     #[darling(default)]
@@ -156,6 +158,12 @@ impl Validators {
         if let Some(re) = &self.regex {
             elem_validators.push(quote! {
                 #crate_name::validators::regex(__raw_value, #re)
+            });
+        }
+
+        if let Some(version) = &self.uuid {
+            elem_validators.push(quote! {
+                #crate_name::validators::uuid(__raw_value, #version)
             });
         }
 

--- a/docs/en/src/input_value_validators.md
+++ b/docs/en/src/input_value_validators.md
@@ -15,6 +15,7 @@
 - **url** is valid url.
 - **ip** is valid ip address.
 - **regex=RE** is match for the regex.
+- **uuid=V** the string or ID is a valid UUID with version `V`.
 
 ```rust
 # extern crate async_graphql;

--- a/src/types/id.rs
+++ b/src/types/id.rs
@@ -18,6 +18,12 @@ use crate::{InputValueError, InputValueResult, Scalar, ScalarType, Value};
 #[serde(transparent)]
 pub struct ID(pub String);
 
+impl AsRef<str> for ID {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
 impl Deref for ID {
     type Target = String;
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -14,6 +14,8 @@ mod minimum;
 mod multiple_of;
 mod regex;
 mod url;
+#[cfg(feature = "uuid-validator")]
+mod uuid;
 
 pub use chars_max_length::chars_max_length;
 pub use chars_min_length::chars_min_length;
@@ -29,6 +31,8 @@ pub use min_length::min_length;
 pub use min_password_strength::min_password_strength;
 pub use minimum::minimum;
 pub use multiple_of::multiple_of;
+#[cfg(feature = "uuid-validator")]
+pub use uuid::uuid;
 
 pub use self::{regex::regex, url::url};
 use crate::{InputType, InputValueError};

--- a/src/validators/uuid.rs
+++ b/src/validators/uuid.rs
@@ -1,0 +1,42 @@
+use uuid::Uuid;
+
+use crate::{InputType, InputValueError};
+
+pub fn uuid<T: AsRef<str> + InputType>(
+    value: &T,
+    version: usize,
+) -> Result<(), InputValueError<T>> {
+    match Uuid::try_parse(value.as_ref()) {
+        Ok(uuid) => {
+            if uuid.get_version_num() == version {
+                return Ok(());
+            }
+            Err(InputValueError::custom("UUID version mismatch"))
+        }
+        Err(_) => Err(InputValueError::custom("Invalid UUID")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_uuid() {
+        assert!(uuid(&"94c59486-c302-4f43-abd7-a9c980ddab36".to_string(), 4).is_ok());
+        assert!(
+            uuid(&"94c59486-c302-4f43-abd7-a9c980ddab3".to_string(), 4).is_err_and(|e| {
+                let message = format!("{:?}", e);
+                println!("{}", message);
+                message.contains("Invalid UUID")
+            })
+        );
+        assert!(
+            uuid(&"94c59486-c302-5f43-abd7-a9c980ddab36".to_string(), 4).is_err_and(|e| {
+                let message = format!("{:?}", e);
+                println!("{}", message);
+                message.contains("UUID version mismatch")
+            })
+        );
+    }
+}


### PR DESCRIPTION
Add a validator that accepts ID or String Input Values that are UUIDs and validates them for correctness and checks the version number is correct.

Example:

```
#[Object]
impl MutationRoot {
    async fn add_user_to_team(
        &self,
        ctx: &Context<'_>,
        #[graphql(validator(uuid = 4))] team_id: ID,
        #[graphql(validator(uuid = 4))] user_id: ID,
    ) -> ID {
        let pool = ctx.data::<Pool<Postgres>>().unwrap();
        team_repository::add_user_to_team(
            &pool,
            Uuid::parse_str(&team_id).unwrap(),
            Uuid::parse_str(&user_id).unwrap(),
        )
        .await
        .unwrap();
        team_id
    }
```