### PR TITLE
remove needless ?Sized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ categories = ["network-programming", "asynchronous"]
 description = "A GraphQL server library implemented in Rust"
 documentation = "https://docs.rs/async-graphql/"
 edition = "2021"
+rust-version = "1.75"
 homepage = "https://github.com/async-graphql/async-graphql"
 keywords = ["futures", "async", "graphql"]
 license = "MIT OR Apache-2.0"

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -912,7 +912,7 @@ impl Registry {
 
     pub fn create_input_type<T, F>(&mut self, type_id: MetaTypeId, mut f: F) -> String
     where
-        T: InputType + ?Sized,
+        T: InputType,
         F: FnMut(&mut Registry) -> MetaType,
     {
         self.create_type(&mut f, &T::type_name(), std::any::type_name::<T>(), type_id);


### PR DESCRIPTION
Closes https://github.com/async-graphql/async-graphql/issues/1592

Also set the MSRV to 1.75.
1.74 fails with
```
> cargo +1.74 build
   Compiling async-graphql v7.0.9 (/home/jayvdb/rust/async-graphql)
error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
  --> src/base.rs:92:10
   |
92 |     ) -> impl Future<Output = ServerResult<Value>> + Send;
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information

....
error: could not compile `async-graphql` (lib) due to 91 previous errors; 2 warnings emitted
```