### PR TITLE
connection: Allow 'first' and 'last' parameters to exist at the same time

### DIFF
--- a/src/types/connection/mod.rs
+++ b/src/types/connection/mod.rs
@@ -352,10 +352,6 @@ where
     R: Future<Output = Result<T, E>>,
     E: Into<Error>,
 {
-    if first.is_some() && last.is_some() {
-        return Err("The \"first\" and \"last\" parameters cannot exist at the same time".into());
-    }
-
     let first = match first {
         Some(first) if first < 0 => {
             return Err("The \"first\" parameter must be a non-negative number".into());


### PR DESCRIPTION
The "first" and "last" parameters should be allowed to exist at the same time, as per [GraphQL Cursor Connection specification](https://relay.dev/graphql/connections.htm#sec-Pagination-algorithm).

Reference: https://relay.dev/graphql/connections.htm#sec-Pagination-algorithm

Closes #1601