### PR TITLE
chore: use std OnceLock instead LazyLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ indexmap.workspace = true
 mime = "0.3.17"
 multer = "3.0.0"
 num-traits = "0.2.18"
-once_cell = "1.19.0"
 pin-project-lite = "0.2.14"
 regex = "1.10.4"
 serde.workspace = true

--- a/src/validation/test_harness.rs
+++ b/src/validation/test_harness.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code)]
 #![allow(unreachable_code)]
 
-use once_cell::sync::Lazy;
+use std::sync::OnceLock;
 
 use crate::{
     futures_util::stream::Stream,
@@ -373,8 +373,7 @@ impl Subscription {
     }
 }
 
-static TEST_HARNESS: Lazy<Schema<Query, Mutation, Subscription>> =
-    Lazy::new(|| Schema::new(Query, Mutation, Subscription));
+static TEST_HARNESS: OnceLock<Schema<Query, Mutation, Subscription>> = OnceLock::new();
 
 pub(crate) fn validate<'a, V, F>(
     doc: &'a ExecutableDocument,
@@ -384,7 +383,7 @@ where
     V: Visitor<'a> + 'a,
     F: Fn() -> V,
 {
-    let schema = &*TEST_HARNESS;
+    let schema = &*TEST_HARNESS.get_or_init(|| Schema::new(Query, Mutation, Subscription));
     let registry = &schema.0.env.registry;
     let mut ctx = VisitorContext::new(registry, doc, None);
     let mut visitor = factory();


### PR DESCRIPTION
Since the project's MSVR is `1.75`, we can use `std::sync::OnceLock` instead of `once_cell::sync::LazyLock`, which became available with MSVR `1.70`. Since it's pulling dependency for the sake of a single place, it's better to use the native solution. In the future we can replace with `std::sync::LazyLock` when MSVR will `1.80`.