### PR TITLE
chore: update opentelemetry to 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ fast_chemail = { version = "0.9.6", optional = true }
 hashbrown = { version = "0.14.5", optional = true }
 iso8601 = { version = "0.6.1", optional = true }
 log = { version = "0.4.21", optional = true }
-opentelemetry = { version = "0.26.0", optional = true, default-features = false, features = [
+opentelemetry = { version = "0.27.0", optional = true, default-features = false, features = [
   "trace",
 ] }
 rust_decimal = { version = "1.35.0", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ fast_chemail = { version = "0.9.6", optional = true }
 hashbrown = { version = "0.14.5", optional = true }
 iso8601 = { version = "0.6.1", optional = true }
 log = { version = "0.4.21", optional = true }
-opentelemetry = { version = "0.25.0", optional = true, default-features = false, features = [
+opentelemetry = { version = "0.26.0", optional = true, default-features = false, features = [
   "trace",
 ] }
 rust_decimal = { version = "1.35.0", optional = true, default-features = false }


### PR DESCRIPTION
There are breaking changes in [opentelemetry 0.26](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0260) that remove the old API for converting `Key` to `KeyValue`. The opentelemetry update also fixes tokio version locking at `1.38` https://github.com/open-telemetry/opentelemetry-rust/issues/2144.