### PR TITLE
Deprecate `data_unchecked` and `data_opt` methods

### DIFF
--- a/benches/static_schema.rs
+++ b/benches/static_schema.rs
@@ -187,7 +187,7 @@ impl<'a> Human<'a> {
 
     /// The friends of the human, or an empty list if they have none.
     async fn friends<'ctx>(&self, ctx: &Context<'ctx>) -> Vec<Character<'ctx>> {
-        let star_wars = ctx.data_unchecked::<StarWars>();
+        let star_wars = ctx.data::<StarWars>().unwrap();
         star_wars
             .friends(self.0)
             .into_iter()
@@ -229,7 +229,7 @@ impl<'a> Droid<'a> {
 
     /// The friends of the droid, or an empty list if they have none.
     async fn friends<'ctx>(&self, ctx: &Context<'ctx>) -> Vec<Character<'ctx>> {
-        let star_wars = ctx.data_unchecked::<StarWars>();
+        let star_wars = ctx.data::<StarWars>().unwrap();
         star_wars
             .friends(self.0)
             .into_iter()
@@ -266,7 +266,7 @@ impl QueryRoot {
         )]
         episode: Option<Episode>,
     ) -> Character<'a> {
-        let star_wars = ctx.data_unchecked::<StarWars>();
+        let star_wars = ctx.data::<StarWars>().unwrap();
         match episode {
             Some(episode) => {
                 if episode == Episode::Empire {
@@ -284,7 +284,7 @@ impl QueryRoot {
         ctx: &Context<'a>,
         #[graphql(desc = "id of the human")] id: String,
     ) -> Option<Human<'a>> {
-        ctx.data_unchecked::<StarWars>().human(&id).map(Human)
+        ctx.data::<StarWars>().unwrap().human(&id).map(Human)
     }
 
     async fn humans<'a>(
@@ -295,7 +295,7 @@ impl QueryRoot {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<usize, Human<'a>>> {
-        let humans = ctx.data_unchecked::<StarWars>().humans().to_vec();
+        let humans = ctx.data::<StarWars>().unwrap().humans().to_vec();
         query_characters(after, before, first, last, &humans, Human).await
     }
 
@@ -304,7 +304,7 @@ impl QueryRoot {
         ctx: &Context<'a>,
         #[graphql(desc = "id of the droid")] id: String,
     ) -> Option<Droid<'a>> {
-        ctx.data_unchecked::<StarWars>().droid(&id).map(Droid)
+        ctx.data::<StarWars>().unwrap().droid(&id).map(Droid)
     }
 
     async fn droids<'a>(
@@ -315,7 +315,7 @@ impl QueryRoot {
         first: Option<i32>,
         last: Option<i32>,
     ) -> Result<Connection<usize, Droid<'a>>> {
-        let droids = ctx.data_unchecked::<StarWars>().droids().to_vec();
+        let droids = ctx.data::<StarWars>().unwrap().droids().to_vec();
         query_characters(after, before, first, last, &droids, Droid).await
     }
 }

--- a/docs/en/src/dataloader.md
+++ b/docs/en/src/dataloader.md
@@ -26,7 +26,7 @@ struct User {
 #[Object]
 impl User {
     async fn name(&self, ctx: &Context<'_>) -> Result<String> {
-        let pool = ctx.data_unchecked::<Pool<Postgres>>();
+        let pool = ctx.data::<Pool<Postgres>>().unwrap();
         let (name,): (String,) = sqlx::query_as("SELECT name FROM user WHERE id = $1")
             .bind(self.id)
             .fetch_one(pool)
@@ -103,7 +103,7 @@ struct User {
 #[ComplexObject]
 impl User {
     async fn name(&self, ctx: &Context<'_>) -> Result<String> {
-        let loader = ctx.data_unchecked::<DataLoader<UserNameLoader>>();
+        let loader = ctx.data::<DataLoader<UserNameLoader>>().unwrap();
         let name: Option<String> = loader.load_one(self.id).await?;
         name.ok_or_else(|| "Not found".into())
     }

--- a/docs/en/src/field_guard.md
+++ b/docs/en/src/field_guard.md
@@ -23,7 +23,7 @@ impl RoleGuard {
 
 impl Guard for RoleGuard {
     async fn check(&self, ctx: &Context<'_>) -> Result<()> {
-        if ctx.data_opt::<Role>() == Some(&self.role) {
+        if ctx.data::<Role>().ok() == Some(&self.role) {
             Ok(())
         } else {
             Err("Forbidden".into())

--- a/docs/en/src/visibility.md
+++ b/docs/en/src/visibility.md
@@ -39,7 +39,7 @@ enum MyEnum {
 struct IsAdmin(bool);
 
 fn is_admin(ctx: &Context<'_>) -> bool {
-    ctx.data_unchecked::<IsAdmin>().0
+    ctx.data::<IsAdmin>().unwrap().0
 }
 
 ```

--- a/docs/zh-CN/src/dataloader.md
+++ b/docs/zh-CN/src/dataloader.md
@@ -20,7 +20,7 @@ struct User {
 #[Object]
 impl User {
     async fn name(&self, ctx: &Context<'_>) -> Result<String> {
-        let pool = ctx.data_unchecked::<Pool<Postgres>>();
+        let pool = ctx.data::<Pool<Postgres>>().unwrap();
         let (name,): (String,) = sqlx::query_as("SELECT name FROM user WHERE id = $1")
             .bind(self.id)
             .fetch_one(pool)
@@ -94,7 +94,7 @@ struct User {
 #[Object]
 impl User {
     async fn name(&self, ctx: &Context<'_>) -> Result<String> {
-        let loader = ctx.data_unchecked::<DataLoader<UserNameLoader>>();
+        let loader = ctx.data::<DataLoader<UserNameLoader>>().unwrap();
         let name: Option<String> = loader.load_one(self.id).await?;
         name.ok_or_else(|| "Not found".into())
     }

--- a/docs/zh-CN/src/field_guard.md
+++ b/docs/zh-CN/src/field_guard.md
@@ -23,7 +23,7 @@ impl RoleGuard {
 
 impl Guard for RoleGuard {
     async fn check(&self, ctx: &Context<'_>) -> Result<()> {
-        if ctx.data_opt::<Role>() == Some(&self.role) {
+        if ctx.data::<Role>().ok() == Some(&self.role) {
             Ok(())
         } else {
             Err("Forbidden".into())

--- a/docs/zh-CN/src/visibility.md
+++ b/docs/zh-CN/src/visibility.md
@@ -37,7 +37,7 @@ enum MyEnum {
 struct IsAdmin(bool);
 
 fn is_admin(ctx: &Context<'_>) -> bool {
-    ctx.data_unchecked::<IsAdmin>().0
+    ctx.data::<IsAdmin>().unwrap().0
 }
 
 ```

--- a/integrations/actix-web/tests/test_utils.rs
+++ b/integrations/actix-web/tests/test_utils.rs
@@ -30,7 +30,7 @@ pub(crate) struct HelloQueryRoot;
 impl HelloQueryRoot {
     /// Returns hello
     async fn hello<'a>(&self, ctx: &'a Context<'_>) -> String {
-        let name = ctx.data_opt::<Hello>().map(|hello| hello.0.as_str());
+        let name = ctx.data::<Hello>().ok().map(|hello| hello.0.as_str());
         format!("Hello, {}!", name.unwrap_or("world"))
     }
 }
@@ -42,7 +42,7 @@ pub(crate) struct CountQueryRoot;
 #[Object]
 impl CountQueryRoot {
     async fn count<'a>(&self, ctx: &'a Context<'_>) -> i32 {
-        *ctx.data_unchecked::<Count>().lock().await
+        *ctx.data::<Count>().unwrap().lock().await
     }
 }
 
@@ -51,13 +51,13 @@ pub(crate) struct CountMutation;
 #[Object]
 impl CountMutation {
     async fn add_count<'a>(&self, ctx: &'a Context<'_>, count: i32) -> i32 {
-        let mut guard_count = ctx.data_unchecked::<Count>().lock().await;
+        let mut guard_count = ctx.data::<Count>().unwrap().lock().await;
         *guard_count += count;
         *guard_count
     }
 
     async fn subtract_count<'a>(&self, ctx: &'a Context<'_>, count: i32) -> i32 {
-        let mut guard_count = ctx.data_unchecked::<Count>().lock().await;
+        let mut guard_count = ctx.data::<Count>().unwrap().lock().await;
         *guard_count -= count;
         *guard_count
     }

--- a/integrations/tide/tests/graphql.rs
+++ b/integrations/tide/tests/graphql.rs
@@ -74,7 +74,7 @@ async fn hello() -> Result<()> {
         impl QueryRoot {
             /// Returns hello
             async fn hello<'a>(&self, ctx: &'a Context<'_>) -> String {
-                let name = ctx.data_opt::<Hello>().map(|hello| hello.0.as_str());
+                let name = ctx.data::<Hello>().ok().map(|hello| hello.0.as_str());
                 format!("Hello, {}!", name.unwrap_or("world"))
             }
         }

--- a/src/dataloader/mod.rs
+++ b/src/dataloader/mod.rs
@@ -27,7 +27,7 @@
 //! #[Object]
 //! impl Query {
 //!     async fn value(&self, ctx: &Context<'_>, n: i32) -> Option<String> {
-//!         ctx.data_unchecked::<DataLoader<MyLoader>>().load_one(n).await.unwrap()
+//!         ctx.data::<DataLoader<MyLoader>>().unwrap().load_one(n).await.unwrap()
 //!     }
 //! }
 //!

--- a/src/dynamic/object.rs
+++ b/src/dynamic/object.rs
@@ -252,7 +252,7 @@ mod tests {
             |ctx| {
                 FieldFuture::new(async move {
                     Ok(Some(FieldValue::borrowed_any(
-                        ctx.data_unchecked::<MyObjData>(),
+                        ctx.data::<MyObjData>().unwrap(),
                     )))
                 })
             },

--- a/src/dynamic/subscription.rs
+++ b/src/dynamic/subscription.rs
@@ -370,7 +370,7 @@ mod tests {
                     Ok(async_stream::try_stream! {
                         for i in 0..10 {
                             tokio::time::sleep(Duration::from_millis(100)).await;
-                            yield FieldValue::value(ctx.data_unchecked::<State>().value + i);
+                            yield FieldValue::value(ctx.data::<State>().unwrap().value + i);
                         }
                     })
                 })

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -53,11 +53,11 @@ impl<'a> DataContext<'a> for ExtensionContext<'a> {
     }
 
     fn data_unchecked<D: Any + Send + Sync>(&self) -> &'a D {
-        ExtensionContext::data_unchecked::<D>(self)
+        ExtensionContext::data::<D>(self).unwrap()
     }
 
     fn data_opt<D: Any + Send + Sync>(&self) -> Option<&'a D> {
-        ExtensionContext::data_opt::<D>(self)
+        ExtensionContext::data::<D>(self).ok()
     }
 }
 
@@ -81,12 +81,17 @@ impl<'a> ExtensionContext<'a> {
     ///
     /// Returns a `Error` if the specified type data does not exist.
     pub fn data<D: Any + Send + Sync>(&self) -> Result<&'a D> {
-        self.data_opt::<D>().ok_or_else(|| {
-            Error::new(format!(
-                "Data `{}` does not exist.",
-                std::any::type_name::<D>()
-            ))
-        })
+        self.query_data
+            .and_then(|query_data| query_data.get(&TypeId::of::<D>()))
+            .or_else(|| self.session_data.get(&TypeId::of::<D>()))
+            .or_else(|| self.schema_env.data.get(&TypeId::of::<D>()))
+            .and_then(|d| d.downcast_ref::<D>())
+            .ok_or_else(|| {
+                Error::new(format!(
+                    "Data `{}` does not exist.",
+                    std::any::type_name::<D>()
+                ))
+            })
     }
 
     /// Gets the global data defined in the `Context` or `Schema`.
@@ -94,19 +99,16 @@ impl<'a> ExtensionContext<'a> {
     /// # Panics
     ///
     /// It will panic if the specified data type does not exist.
+    #[deprecated(since = "7.0.12", note = "Use `data::<D>().unwrap()` instead.")]
     pub fn data_unchecked<D: Any + Send + Sync>(&self) -> &'a D {
-        self.data_opt::<D>()
-            .unwrap_or_else(|| panic!("Data `{}` does not exist.", std::any::type_name::<D>()))
+        self.data::<D>().unwrap()
     }
 
     /// Gets the global data defined in the `Context` or `Schema` or `None` if
     /// the specified type data does not exist.
+    #[deprecated(since = "7.0.12", note = "Use `data::<D>().ok()` instead.")]
     pub fn data_opt<D: Any + Send + Sync>(&self) -> Option<&'a D> {
-        self.query_data
-            .and_then(|query_data| query_data.get(&TypeId::of::<D>()))
-            .or_else(|| self.session_data.get(&TypeId::of::<D>()))
-            .or_else(|| self.schema_env.data.get(&TypeId::of::<D>()))
-            .and_then(|d| d.downcast_ref::<D>())
+        self.data::<D>().ok()
     }
 }
 

--- a/tests/complex_object.rs
+++ b/tests/complex_object.rs
@@ -141,7 +141,7 @@ pub async fn test_complex_object_with_generic_context_data() {
         }
 
         async fn obj(&self, ctx: &Context<'_>) -> MyObject<D> {
-            MyObject::new(ctx.data_unchecked::<D>().answer())
+            MyObject::new(ctx.data::<D>().unwrap().answer())
         }
     }
 

--- a/tests/extension.rs
+++ b/tests/extension.rs
@@ -25,7 +25,7 @@ pub async fn test_extension_ctx() {
     #[Object]
     impl Query {
         async fn value(&self, ctx: &Context<'_>) -> i32 {
-            *ctx.data_unchecked::<MyData>().0.lock().await
+            *ctx.data::<MyData>().unwrap().0.lock().await
         }
     }
 
@@ -34,7 +34,7 @@ pub async fn test_extension_ctx() {
     #[Subscription]
     impl Subscription {
         async fn value(&self, ctx: &Context<'_>) -> impl Stream<Item = i32> {
-            let data = *ctx.data_unchecked::<MyData>().0.lock().await;
+            let data = *ctx.data::<MyData>().unwrap().0.lock().await;
             futures_util::stream::once(async move { data })
         }
     }
@@ -451,7 +451,7 @@ pub async fn subscription_execute_with_data() {
     #[Object]
     impl Inner {
         async fn value(&self, ctx: &Context<'_>) -> i32 {
-            if let Some(logs) = ctx.data_opt::<Logs>() {
+            if let Some(logs) = ctx.data::<Logs>().ok() {
                 logs.lock().await.push(LogElement::InnerAccess(self.0));
             }
             self.0
@@ -464,7 +464,7 @@ pub async fn subscription_execute_with_data() {
     #[Object]
     impl Outer {
         async fn inner(&self, ctx: &Context<'_>) -> Inner {
-            if let Some(logs) = ctx.data_opt::<Logs>() {
+            if let Some(logs) = ctx.data::<Logs>().ok() {
                 logs.lock().await.push(LogElement::OuterAccess(self.0 .0));
             }
             self.0

--- a/tests/federation.rs
+++ b/tests/federation.rs
@@ -191,7 +191,7 @@ pub async fn test_find_entity_with_context() {
     impl Query {
         #[graphql(entity)]
         async fn find_user_by_id(&self, ctx: &Context<'_>, id: ID) -> FieldResult<MyObj> {
-            let loader = ctx.data_unchecked::<DataLoader<MyLoader>>();
+            let loader = ctx.data::<DataLoader<MyLoader>>().unwrap();
             loader
                 .load_one(id)
                 .await

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -19,7 +19,7 @@ impl RoleGuard {
 
 impl Guard for RoleGuard {
     async fn check(&self, ctx: &Context<'_>) -> Result<()> {
-        if ctx.data_opt::<Role>() == Some(&self.role) {
+        if ctx.data::<Role>().ok() == Some(&self.role) {
             Ok(())
         } else {
             Err("Forbidden".into())
@@ -41,7 +41,7 @@ impl<'a> UserGuard<'a> {
 
 impl<'a> Guard for UserGuard<'a> {
     async fn check(&self, ctx: &Context<'_>) -> Result<()> {
-        if ctx.data_opt::<Username>().map(|name| name.0.as_str()) == Some(self.username) {
+        if ctx.data::<Username>().ok().map(|name| name.0.as_str()) == Some(self.username) {
             Ok(())
         } else {
             Err("Forbidden".into())
@@ -584,7 +584,7 @@ pub async fn test_guard_on_complex_object_field() {
 #[tokio::test]
 pub async fn test_guard_with_fn() {
     fn is_admin(ctx: &Context<'_>) -> Result<()> {
-        if ctx.data_opt::<Role>() == Some(&Role::Admin) {
+        if ctx.data::<Role>().ok() == Some(&Role::Admin) {
             Ok(())
         } else {
             Err("Forbidden".into())

--- a/tests/introspection_visible.rs
+++ b/tests/introspection_visible.rs
@@ -210,7 +210,7 @@ pub async fn test_visible_fn() {
         pub struct IsAdmin(pub bool);
 
         pub fn is_admin(ctx: &Context<'_>) -> bool {
-            ctx.data_unchecked::<IsAdmin>().0
+            ctx.data::<IsAdmin>().unwrap().0
         }
     }
 

--- a/tests/mutation.rs
+++ b/tests/mutation.rs
@@ -22,13 +22,13 @@ pub async fn test_root_mutation_execution_order() {
     impl Mutation {
         async fn append1(&self, ctx: &Context<'_>) -> bool {
             tokio::time::sleep(Duration::from_secs(1)).await;
-            ctx.data_unchecked::<List>().lock().await.push(1);
+            ctx.data::<List>().unwrap().lock().await.push(1);
             true
         }
 
         async fn append2(&self, ctx: &Context<'_>) -> bool {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            ctx.data_unchecked::<List>().lock().await.push(2);
+            ctx.data::<List>().unwrap().lock().await.push(2);
             true
         }
     }
@@ -94,13 +94,13 @@ pub async fn test_serial_object() {
     impl MyObj {
         async fn append1(&self, ctx: &Context<'_>) -> bool {
             tokio::time::sleep(Duration::from_secs(1)).await;
-            ctx.data_unchecked::<List>().lock().await.push(1);
+            ctx.data::<List>().unwrap().lock().await.push(1);
             true
         }
 
         async fn append2(&self, ctx: &Context<'_>) -> bool {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            ctx.data_unchecked::<List>().lock().await.push(2);
+            ctx.data::<List>().unwrap().lock().await.push(2);
             true
         }
     }
@@ -145,13 +145,13 @@ pub async fn test_serial_simple_object() {
     impl MyObj {
         async fn append1(&self, ctx: &Context<'_>) -> bool {
             tokio::time::sleep(Duration::from_secs(1)).await;
-            ctx.data_unchecked::<List>().lock().await.push(1);
+            ctx.data::<List>().unwrap().lock().await.push(1);
             true
         }
 
         async fn append2(&self, ctx: &Context<'_>) -> bool {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            ctx.data_unchecked::<List>().lock().await.push(2);
+            ctx.data::<List>().unwrap().lock().await.push(2);
             true
         }
     }
@@ -196,13 +196,13 @@ pub async fn test_serial_merged_object() {
     impl MyObj1 {
         async fn append1(&self, ctx: &Context<'_>) -> bool {
             tokio::time::sleep(Duration::from_secs(1)).await;
-            ctx.data_unchecked::<List>().lock().await.push(1);
+            ctx.data::<List>().unwrap().lock().await.push(1);
             true
         }
 
         async fn append2(&self, ctx: &Context<'_>) -> bool {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            ctx.data_unchecked::<List>().lock().await.push(2);
+            ctx.data::<List>().unwrap().lock().await.push(2);
             true
         }
     }
@@ -213,13 +213,13 @@ pub async fn test_serial_merged_object() {
     impl MyObj2 {
         async fn append3(&self, ctx: &Context<'_>) -> bool {
             tokio::time::sleep(Duration::from_millis(200)).await;
-            ctx.data_unchecked::<List>().lock().await.push(3);
+            ctx.data::<List>().unwrap().lock().await.push(3);
             true
         }
 
         async fn append4(&self, ctx: &Context<'_>) -> bool {
             tokio::time::sleep(Duration::from_millis(700)).await;
-            ctx.data_unchecked::<List>().lock().await.push(4);
+            ctx.data::<List>().unwrap().lock().await.push(4);
             true
         }
     }

--- a/tests/object.rs
+++ b/tests/object.rs
@@ -260,7 +260,7 @@ async fn test_optional_output_with_try() {
     #[Object]
     impl Query {
         async fn obj(&self, ctx: &Context<'_>) -> Option<u32> {
-            let x = ctx.data_unchecked::<B>();
+            let x = ctx.data::<B>().unwrap();
 
             if x.some? {
                 Some(300)

--- a/tests/subscription.rs
+++ b/tests/subscription.rs
@@ -73,7 +73,7 @@ pub async fn test_subscription_with_ctx_data() {
     #[Object]
     impl MyObject {
         async fn value(&self, ctx: &Context<'_>) -> i32 {
-            *ctx.data_unchecked::<i32>()
+            *ctx.data::<i32>().unwrap()
         }
     }
 
@@ -82,7 +82,7 @@ pub async fn test_subscription_with_ctx_data() {
     #[Subscription]
     impl Subscription {
         async fn values(&self, ctx: &Context<'_>) -> impl Stream<Item = i32> {
-            let value = *ctx.data_unchecked::<i32>();
+            let value = *ctx.data::<i32>().unwrap();
             futures_util::stream::once(async move { value })
         }
 
@@ -124,7 +124,7 @@ pub async fn test_subscription_with_token() {
     #[Subscription]
     impl Subscription {
         async fn values(&self, ctx: &Context<'_>) -> Result<impl Stream<Item = i32>> {
-            if ctx.data_unchecked::<Token>().0 != "123456" {
+            if ctx.data::<Token>().unwrap().0 != "123456" {
                 return Err("forbidden".into());
             }
             Ok(futures_util::stream::once(async move { 100 }))

--- a/tests/subscription_websocket_graphql_ws.rs
+++ b/tests/subscription_websocket_graphql_ws.rs
@@ -108,7 +108,7 @@ pub async fn test_subscription_ws_transport_with_token() {
     #[Subscription]
     impl Subscription {
         async fn values(&self, ctx: &Context<'_>) -> Result<impl Stream<Item = i32>> {
-            if ctx.data_unchecked::<Token>().0 != "123456" {
+            if ctx.data::<Token>().unwrap().0 != "123456" {
                 return Err("forbidden".into());
             }
             Ok(futures_util::stream::iter(0..10))
@@ -567,7 +567,7 @@ pub async fn test_stream_drop() {
                         yield 10;
                     }
                 }),
-                dropped: ctx.data_unchecked::<Dropped>().clone(),
+                dropped: ctx.data::<Dropped>().unwrap().clone(),
             }
         }
     }

--- a/tests/subscription_websocket_subscriptions_transport_ws.rs
+++ b/tests/subscription_websocket_subscriptions_transport_ws.rs
@@ -99,7 +99,7 @@ pub async fn test_subscription_ws_transport_with_token() {
     #[Subscription]
     impl Subscription {
         async fn values(&self, ctx: &Context<'_>) -> Result<impl Stream<Item = i32>> {
-            if ctx.data_unchecked::<Token>().0 != "123456" {
+            if ctx.data::<Token>().unwrap().0 != "123456" {
                 return Err("forbidden".into());
             }
             Ok(futures_util::stream::iter(0..10))


### PR DESCRIPTION
There are currently three ways of retrieving data:

- `data()` -> returns `Result<D>`
- `data_unchecked()` -> panicking version of `data()`
- `data_opt()` -> like `data()`, but returns `Option<D>`

But the API feels awkward and unidiomatic for a few reasons:

1. `data_unchecked()` is a hugely misleading name. `*_unchecked` is a name usually reserved for unsafe functions that can potentially invoke undefined behavior (e.g. [`get_unchecked`](https://doc.rust-lang.org/std/primitive.slice.html#method.get_unchecked)). Here, it's simply a panicking version of `data()`.
2. `data_unchecked()` and `data_opt()` is redundant. They can already be achieved by using `data().unwrap()` and `data().ok()`, respectively for the exact same effect. `data().ok()` is only a character longer and `data().unwrap()` is actually shorter, so brevity is not harmed here.

I propose to mark `data_unchecked()` and `data_opt()` as deprecated on the next version bump, with a message nudging the user to more idiomatic patterns.

Examples:

```rust
ctx.data::<D>() // No warnings
ctx.data_unchecked::<D>() // Use `data::<D>().unwrap()` instead.
ctx.data_opt::<D>() // Use `data::<D>().ok()` instead.
```