### PR TITLE
Update secrecy and support new types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ opentelemetry = { version = "0.25.0", optional = true, default-features = false,
 ] }
 rust_decimal = { version = "1.35.0", optional = true, default-features = false }
 bigdecimal = { version = ">=0.3.0, <0.5.0", optional = true, default-features = false }
-secrecy = { version = "0.8.0", optional = true }
+secrecy = { version = "0.10.3", optional = true }
 smol_str = { version = "0.3.1", optional = true }
 time = { version = "0.3.36", optional = true, features = [
   "parsing",

--- a/src/base.rs
+++ b/src/base.rs
@@ -34,7 +34,7 @@ pub trait InputType: Send + Sync + Sized {
     ///
     /// `i32::RawValueType` is `i32`
     /// `Option<i32>::RawValueType` is `i32`.
-    type RawValueType;
+    type RawValueType: ?Sized;
 
     /// Type the name.
     fn type_name() -> Cow<'static, str>;

--- a/src/types/external/secrecy.rs
+++ b/src/types/external/secrecy.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
-use secrecy::{ExposeSecret, SecretBox, SecretString};
-use secrecy::zeroize::Zeroize;
+use secrecy::{zeroize::Zeroize, ExposeSecret, SecretBox, SecretString};
 
 use crate::{registry, InputType, InputValueError, InputValueResult, Value};
 

--- a/src/types/external/secrecy.rs
+++ b/src/types/external/secrecy.rs
@@ -1,10 +1,11 @@
 use std::borrow::Cow;
 
-use secrecy::{ExposeSecret, Secret, Zeroize};
+use secrecy::{ExposeSecret, SecretBox, SecretString};
+use secrecy::zeroize::Zeroize;
 
 use crate::{registry, InputType, InputValueError, InputValueResult, Value};
 
-impl<T: InputType + Zeroize> InputType for Secret<T> {
+impl<T: InputType + Zeroize> InputType for SecretBox<T> {
     type RawValueType = T::RawValueType;
 
     fn type_name() -> Cow<'static, str> {
@@ -21,7 +22,7 @@ impl<T: InputType + Zeroize> InputType for Secret<T> {
 
     fn parse(value: Option<Value>) -> InputValueResult<Self> {
         T::parse(value)
-            .map(Secret::new)
+            .map(|value| SecretBox::new(Box::new(value)))
             .map_err(InputValueError::propagate)
     }
 

--- a/src/types/external/secrecy.rs
+++ b/src/types/external/secrecy.rs
@@ -34,3 +34,33 @@ impl<T: InputType + Zeroize> InputType for SecretBox<T> {
         self.expose_secret().as_raw_value()
     }
 }
+
+impl InputType for SecretString {
+    type RawValueType = str;
+
+    fn type_name() -> Cow<'static, str> {
+        String::type_name()
+    }
+
+    fn qualified_type_name() -> String {
+        String::qualified_type_name()
+    }
+
+    fn create_type_info(registry: &mut registry::Registry) -> String {
+        String::create_type_info(registry)
+    }
+
+    fn parse(value: Option<Value>) -> InputValueResult<Self> {
+        String::parse(value)
+            .map(SecretString::from)
+            .map_err(InputValueError::propagate)
+    }
+
+    fn to_value(&self) -> Value {
+        Value::Null
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self.expose_secret())
+    }
+}


### PR DESCRIPTION
Update `secrecy` to `0.10.3`, removing deprecated `Secret` and adding `SecretBox` and `SecretString`. Note that this implementation of `SecretString` required the removal of the `Sized` bound on `InputType::RawValueType`.