### PR TITLE
Allow non-native concrete types in generic structs deriving SimpleObject + InputObject

### DIFF
--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -117,6 +117,8 @@ impl FromMeta for GenericParamList {
 #[derive(FromMeta)]
 pub struct ConcreteType {
     pub name: String,
+    #[darling(default)]
+    pub input_name: Option<String>,
     pub params: PathList,
     #[darling(default)]
     pub bounds: GenericParamList,

--- a/derive/src/input_object.rs
+++ b/derive/src/input_object.rs
@@ -341,7 +341,7 @@ pub fn generate(object_args: &args::InputObject) -> GeneratorResult<TokenStream>
         });
 
         for concrete in &object_args.concretes {
-            let gql_typename = &concrete.name;
+            let gql_typename = concrete.input_name.as_ref().unwrap_or(&concrete.name);
             let params = &concrete.params.0;
             let concrete_type = quote! { #ident<#(#params),*> };
 

--- a/docs/en/src/define_input_object.md
+++ b/docs/en/src/define_input_object.md
@@ -98,6 +98,8 @@ You can pass multiple generic types to `params()`, separated by a comma.
 If you also want to implement `OutputType`, then you will need to explicitly declare the input and output type names of the concrete types like so:
 
 ```rust
+# extern crate async_graphql;
+# use async_graphql::*;
 #[derive(SimpleObject, InputObject)]
 #[graphql(concrete(
     name = "SomeGenericTypeOut",

--- a/docs/en/src/define_input_object.md
+++ b/docs/en/src/define_input_object.md
@@ -95,6 +95,21 @@ pub struct YetAnotherInput {
 
 You can pass multiple generic types to `params()`, separated by a comma.
 
+If you also want to also implement `OutputType`, then you will need to explicitly declare the input and output type names of the concrete types like so:
+
+```rust
+#[derive(SimpleObject, InputObject)]
+#[graphql(concrete(
+    name = "SomeGenericTypeOut",
+    input_name = "SomeGenericTypeIn",
+    params(SomeInputAndOutputType),
+))]
+pub struct SomeGenericType<T: InputType + OutputType> {
+    field1: Option<T>,
+    field2: String
+}
+```
+
 ## Redacting sensitive data
 
 If any part of your input is considered sensitive and you wish to redact it, you can mark it with `secret` directive. For example:

--- a/docs/en/src/define_input_object.md
+++ b/docs/en/src/define_input_object.md
@@ -95,7 +95,7 @@ pub struct YetAnotherInput {
 
 You can pass multiple generic types to `params()`, separated by a comma.
 
-If you also want to also implement `OutputType`, then you will need to explicitly declare the input and output type names of the concrete types like so:
+If you also want to implement `OutputType`, then you will need to explicitly declare the input and output type names of the concrete types like so:
 
 ```rust
 #[derive(SimpleObject, InputObject)]

--- a/docs/en/src/define_input_object.md
+++ b/docs/en/src/define_input_object.md
@@ -104,7 +104,7 @@ If you also want to implement `OutputType`, then you will need to explicitly dec
 #[graphql(concrete(
     name = "SomeGenericTypeOut",
     input_name = "SomeGenericTypeIn",
-    params(SomeInputAndOutputType),
+    params(i32),
 ))]
 pub struct SomeGenericType<T: InputType + OutputType> {
     field1: Option<T>,


### PR DESCRIPTION
Currently, only native types are supported in generic structs deriving SimpleObject + InputObject. So the following works:

```rust
#[derive(SimpleObject, InputObject)]
#[graphql(concrete(name = "MyObjectString", params(String)))]
struct MyObject<T: InputType + OutputType> {
    a: T,
}
```

But this doesn't:

```rust
#[derive(Clone, Copy, PartialEq, Eq, Enum, serde::Serialize)]
enum MyEnum {
    Option1,
    Option2,
}

#[derive(SimpleObject, InputObject)]
#[graphql(concrete(name = "MyObjectMyEnum", params(MyEnum)))]
struct MyObject<T: InputType + OutputType> {
    a: T,
}
```

This is because both input and output types have the same name, so we get a runtime error like this:
```
Register `MyObjectMyEnum` as `InputObject`, but it is already registered as `Object`
```

This is the issue reported here: https://github.com/async-graphql/async-graphql/issues/1498

This PR allows users to explicitly specify the input name of concrete types, so that the input and output types can have different names. Like so:

```rust
#[derive(SimpleObject, InputObject)]
#[graphql(concrete(name = "MyObjectMyEnum", input_name = "MyObjectMyEnumInput", params(MyEnum)))]
struct MyObject<T: InputType + OutputType> {
    a: T,
}
```