### PR TITLE
feat: Add `custom-error-conversion` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ playground = []
 raw_value = ["async-graphql-value/raw_value"]
 uuid-validator = ["uuid"]
 boxed-trait = ["async-graphql-derive/boxed-trait"]
+custom-error-conversion = []
 
 [[bench]]
 harness = false

--- a/src/error.rs
+++ b/src/error.rs
@@ -335,7 +335,18 @@ impl From<&'static str> for Error {
     fn from(e: &'static str) -> Self {
         Self {
             message: e.to_string(),
-            source: Some(Arc::new(e)),
+            source: None,
+            extensions: None,
+        }
+    }
+}
+
+#[cfg(feature = "custom-error-conversion")]
+impl From<String> for Error {
+    fn from(e: String) -> Self {
+        Self {
+            message: e,
+            source: None,
             extensions: None,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -319,8 +319,20 @@ impl Error {
     }
 }
 
+#[cfg(not(feature = "custom-error-conversion"))]
 impl<T: Display + Send + Sync + 'static> From<T> for Error {
     fn from(e: T) -> Self {
+        Self {
+            message: e.to_string(),
+            source: Some(Arc::new(e)),
+            extensions: None,
+        }
+    }
+}
+
+#[cfg(feature = "custom-error-conversion")]
+impl From<&'static str> for Error {
+    fn from(e: &'static str) -> Self {
         Self {
             message: e.to_string(),
             source: Some(Arc::new(e)),

--- a/src/types/connection/mod.rs
+++ b/src/types/connection/mod.rs
@@ -258,7 +258,7 @@ where
 /// # Examples
 ///
 /// ```rust
-///
+/// 
 /// use async_graphql::*;
 /// use async_graphql::types::connection::*;
 ///

--- a/src/types/connection/mod.rs
+++ b/src/types/connection/mod.rs
@@ -258,7 +258,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// 
+///
 /// use async_graphql::*;
 /// use async_graphql::types::connection::*;
 ///
@@ -354,7 +354,9 @@ where
 {
     let first = match first {
         Some(first) if first < 0 => {
-            return Err("The \"first\" parameter must be a non-negative number".into());
+            return Err(Error::new(
+                "The \"first\" parameter must be a non-negative number",
+            ));
         }
         Some(first) => Some(first as usize),
         None => None,
@@ -362,19 +364,21 @@ where
 
     let last = match last {
         Some(last) if last < 0 => {
-            return Err("The \"last\" parameter must be a non-negative number".into());
+            return Err(Error::new(
+                "The \"last\" parameter must be a non-negative number",
+            ));
         }
         Some(last) => Some(last as usize),
         None => None,
     };
 
     let before = match before {
-        Some(before) => Some(Cursor::decode_cursor(&before)?),
+        Some(before) => Some(Cursor::decode_cursor(&before).map_err(Error::new_with_source)?),
         None => None,
     };
 
     let after = match after {
-        Some(after) => Some(Cursor::decode_cursor(&after)?),
+        Some(after) => Some(Cursor::decode_cursor(&after).map_err(Error::new_with_source)?),
         None => None,
     };
 

--- a/tests/error_ext.rs
+++ b/tests/error_ext.rs
@@ -173,6 +173,13 @@ pub async fn test_failure2() {
         Error1,
     }
 
+    #[cfg(feature = "custom-error-conversion")]
+    impl From<MyError> for Error {
+        fn from(e: MyError) -> Self {
+            Self::new_with_source(e)
+        }
+    }
+
     struct Query;
 
     #[Object]


### PR DESCRIPTION
# Context
async-graphql doesn't support crate users implementing `From<T> for async_graphql::Error` for their own error type `T` because there's an existing impl for types that implement Display. This means that users aren't able to implement custom logic when converting their type such as setting error extensions.

The way to set error extensions is with the `ErrorExtensions`. But that requires calling `.extend()` in all the field resolvers, and prevents use of the `?` operator, since that won't call `.extend()`.

# Solution
Add `custom-error-conversion` feature which prevents `From<T: Display + ...>` from being implemented for `async_graphql::Error`. This allows users to implement their own `From<T> for Error`, which can construct Error as they need.

This has the added benefit of creating a more seamless transition path for users coming from juniper, as juniper allows custom error conversion with the `IntoFieldError` trait.
