### PR TITLE
Make boxed_any and borrowed_any for FieldValue work with trait objects again

### DIFF
--- a/src/dynamic/field.rs
+++ b/src/dynamic/field.rs
@@ -124,19 +124,13 @@ impl<'a> FieldValue<'a> {
     /// Create a FieldValue from unsized any value
     #[inline]
     pub fn boxed_any(obj: Box<dyn Any + Send + Sync>) -> Self {
-        Self(FieldValueInner::OwnedAny(
-            "Any".into(),
-            obj,
-        ))
+        Self(FieldValueInner::OwnedAny("Any".into(), obj))
     }
 
     /// Create a FieldValue from owned any value
     #[inline]
-    pub fn borrowed_any(obj: &'a  ( dyn Any + Send + Sync)) -> Self {
-        Self(FieldValueInner::BorrowedAny(
-            "Any".into(),
-            obj,
-        ))
+    pub fn borrowed_any(obj: &'a (dyn Any + Send + Sync)) -> Self {
+        Self(FieldValueInner::BorrowedAny("Any".into(), obj))
     }
 
     /// Create a FieldValue from list

--- a/src/dynamic/field.rs
+++ b/src/dynamic/field.rs
@@ -123,18 +123,18 @@ impl<'a> FieldValue<'a> {
 
     /// Create a FieldValue from unsized any value
     #[inline]
-    pub fn boxed_any<T: Any + Send + Sync>(obj: Box<T>) -> Self {
+    pub fn boxed_any(obj: Box<dyn Any + Send + Sync>) -> Self {
         Self(FieldValueInner::OwnedAny(
-            std::any::type_name::<T>().into(),
+            "Any".into(),
             obj,
         ))
     }
 
     /// Create a FieldValue from owned any value
     #[inline]
-    pub fn borrowed_any<T: Any + Send + Sync>(obj: &'a T) -> Self {
+    pub fn borrowed_any(obj: &'a  ( dyn Any + Send + Sync)) -> Self {
         Self(FieldValueInner::BorrowedAny(
-            std::any::type_name::<T>().into(),
+            "Any".into(),
             obj,
         ))
     }


### PR DESCRIPTION
This PR fixes #1586 by restoring the original signature for `FieldValue::borrowed_any` and `FieldValue::boxed_any` such that they can be used with `&(dyn Any + Send + Sync)` and `Box<dyn Any + Send + Sync>` again.

Note that the debug implementation for these variants now simply returns `Any` when constructed via `borrowed_any` or `boxed_any`. This shouldn't be a problem as these should be used with `.with_type` normally anyway.

This is currently blocking us from updating to the latest version of async-graphql in [Raphtory](https://github.com/Pometry/Raphtory) as we are making use of the dynamic schema. 

