### PR TITLE
Add new feature: `nullable-result`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ dynamic-schema = []
 graphiql = ["dep:askama"]
 raw_value = ["async-graphql-value/raw_value"]
 boxed-trait = ["async-graphql-derive/boxed-trait"]
+nullable-result = []
 
 [[bench]]
 harness = false

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -133,7 +133,7 @@ pub fn generate(
                         .into());
                     }
                 };
-                let ty = ty.value_type();
+                let ty = ty.value_type(&object_args.crate_path, object_args.internal);
                 let ident = &method.sig.ident;
 
                 let assert_generics = (!generics.params.is_empty()).then(|| {
@@ -391,7 +391,7 @@ pub fn generate(
                     );
                 }
             };
-            let schema_ty = ty.value_type();
+            let schema_ty = ty.value_type(&object_args.crate_path, object_args.internal);
             let visible = visible_fn(&method_args.visible);
 
             let complexity = if let Some(complexity) = &method_args.complexity {

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -374,7 +374,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
             OutputType::Value(ty) => ty,
             OutputType::Result(ty) => ty,
         };
-        let schema_ty = oty.value_type();
+        let schema_ty = oty.value_type(&interface_args.crate_path, interface_args.internal);
 
         methods.push(quote! {
             #[allow(missing_docs)]

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -193,7 +193,7 @@ pub fn generate(
                     }
                 };
 
-                let entity_type = ty.value_type();
+                let entity_type = ty.value_type(&object_args.crate_path, object_args.internal);
                 let mut key_pat = Vec::new();
                 let mut key_getter = Vec::new();
                 let mut use_keys = Vec::new();
@@ -311,7 +311,7 @@ pub fn generate(
                             .into());
                         }
                     };
-                    let ty = ty.value_type();
+                    let ty = ty.value_type(&object_args.crate_path, object_args.internal);
                     let ident = &method.sig.ident;
 
                     schema_fields.push(quote! {
@@ -547,7 +547,7 @@ pub fn generate(
                         .into());
                     }
                 };
-                let schema_ty = ty.value_type();
+                let schema_ty = ty.value_type(&object_args.crate_path, object_args.internal);
                 let visible = visible_fn(&method_args.visible);
 
                 let complexity = if let Some(complexity) = &method_args.complexity {
@@ -699,24 +699,9 @@ pub fn generate(
                         .await;
                     }
                 } else {
-                    match &ty {
-                        OutputType::Value(_) => {
-                            quote! {
-                                let obj: #schema_ty = self.#field_ident(ctx, #(#use_params),*);
-                                return #crate_name::resolver_utils::resolve_simple_field_value(ctx, &obj).await;
-                            }
-                        }
-                        OutputType::Result(_) => {
-                            quote! {
-                                let obj: #schema_ty = self.#field_ident(ctx, #(#use_params),*)
-                                    .map_err(|err| {
-                                        let err = ::std::convert::Into::<#crate_name::Error>::into(err)
-                                            .into_server_error(ctx.item.pos);
-                                        ctx.set_error_path(err)
-                                    })?;
-                                return #crate_name::resolver_utils::resolve_simple_field_value(ctx, &obj).await;
-                            }
-                        }
+                    quote! {
+                        let obj: #schema_ty = self.#field_ident(ctx, #(#use_params),*);
+                        return #crate_name::resolver_utils::resolve_simple_field_value(ctx, &obj).await;
                     }
                 };
 

--- a/derive/src/output_type.rs
+++ b/derive/src/output_type.rs
@@ -2,6 +2,8 @@ use proc_macro2::{Ident, Span};
 use quote::quote;
 use syn::{Error, GenericArgument, PathArguments, Result, Type};
 
+use crate::utils::get_crate_path;
+
 pub enum OutputType<'a> {
     Value(&'a Type),
     Result(&'a Type),
@@ -42,10 +44,11 @@ impl<'a> OutputType<'a> {
         Ok(ty)
     }
 
-    pub fn value_type(&self) -> Type {
+    pub fn value_type(&self, crate_path: &Option<syn::Path>, internal: bool) -> Type {
+        let crate_name = get_crate_path(crate_path, internal);
         let tokens = match self {
             OutputType::Value(ty) => quote! {#ty},
-            OutputType::Result(ty) => quote! {#ty},
+            OutputType::Result(ty) => quote! {#crate_name::Result<#ty>},
         };
         let mut ty = syn::parse2::<syn::Type>(tokens).unwrap();
         Self::remove_lifecycle(&mut ty);

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -208,7 +208,10 @@ pub fn generate(
                     .into());
                 }
             };
-            let res_ty = ty.value_type();
+            let res_ty = match ty {
+                OutputType::Value(ty) => ty,
+                OutputType::Result(ty) => ty,
+            };
             let stream_ty = if let Type::ImplTrait(TypeImplTrait { bounds, .. }) = &res_ty {
                 let mut r = None;
                 for b in bounds {
@@ -219,6 +222,14 @@ pub fn generate(
                 quote! { #r }
             } else {
                 quote! { #res_ty }
+            };
+            let output_ty = match ty {
+                OutputType::Value(_) => {
+                    quote! { <#stream_ty as #crate_name::futures_util::stream::Stream>::Item }
+                }
+                OutputType::Result(_) => {
+                    quote! { #crate_name::Result<<#stream_ty as #crate_name::futures_util::stream::Stream>::Item> }
+                }
             };
 
             if let OutputType::Value(inner_ty) = &ty {
@@ -311,7 +322,7 @@ pub fn generate(
                 {
                     let mut field = #crate_name::registry::MetaField::new(
                         ::std::string::ToString::to_string(#field_name),
-                        <<#stream_ty as #crate_name::futures_util::stream::Stream>::Item as #crate_name::OutputType>::create_type_info(registry),
+                        <#output_ty as #crate_name::OutputType>::create_type_info(registry),
                     );
                     #(#schema_args)*
                     #(#field_sets)*
@@ -379,7 +390,7 @@ pub fn generate(
                                     let ri = #crate_name::extensions::ResolveInfo {
                                         path_node: ctx_selection_set.path_node.as_ref().unwrap(),
                                         parent_type: &parent_type,
-                                        return_type: &<<#stream_ty as #crate_name::futures_util::stream::Stream>::Item as #crate_name::OutputType>::qualified_type_name(),
+                                        return_type: &<#output_ty as #crate_name::OutputType>::qualified_type_name(),
                                         name: field.node.name.node.as_str(),
                                         alias: field.node.alias.as_ref().map(|alias| alias.node.as_str()),
                                         is_for_introspection: false,

--- a/tests/error_ext.rs
+++ b/tests/error_ext.rs
@@ -40,7 +40,11 @@ pub async fn test_error_extensions() {
     assert_eq!(
         serde_json::to_value(&schema.execute("{ extendErr }").await).unwrap(),
         serde_json::json!({
-            "data": null,
+            "data": (if cfg!(feature = "nullable-result"){
+                serde_json::json!({ "extendErr": null })
+            } else {
+                serde_json::Value::Null
+            }),
             "errors": [{
                 "message": "my error",
                 "locations": [{
@@ -60,7 +64,11 @@ pub async fn test_error_extensions() {
     assert_eq!(
         serde_json::to_value(&schema.execute("{ extendResult }").await).unwrap(),
         serde_json::json!({
-            "data": null,
+            "data": (if cfg!(feature = "nullable-result"){
+                serde_json::json!({ "extendResult": null })
+            } else {
+                serde_json::Value::Null
+            }),
             "errors": [{
                 "message": "my error",
                 "locations": [{

--- a/tests/result.rs
+++ b/tests/result.rs
@@ -55,12 +55,10 @@ pub async fn test_fieldresult() {
         ]
     );
 
+    let resp = schema.execute("{ optError }").await;
+    assert_eq!(resp.data, value!({ "optError": null }));
     assert_eq!(
-        schema
-            .execute("{ optError }")
-            .await
-            .into_result()
-            .unwrap_err(),
+        resp.errors,
         vec![ServerError {
             message: "TestError".to_string(),
             source: None,
@@ -70,12 +68,17 @@ pub async fn test_fieldresult() {
         }]
     );
 
+    let resp = schema.execute("{ vecError }").await;
     assert_eq!(
-        schema
-            .execute("{ vecError }")
-            .await
-            .into_result()
-            .unwrap_err(),
+        resp.data,
+        if cfg!(feature = "nullable-result") {
+            value!({ "vecError": [1, null] })
+        } else {
+            Value::Null
+        }
+    );
+    assert_eq!(
+        resp.errors,
         vec![ServerError {
             message: "TestError".to_string(),
             source: None,
@@ -187,6 +190,14 @@ pub async fn test_error_propagation() {
     let resp = schema.execute("{ parent { child { name } } }").await;
 
     assert_eq!(
+        resp.data,
+        if cfg!(feature = "nullable-result") {
+            value!({ "parent": { "child": { "name": null } } })
+        } else {
+            Value::Null
+        }
+    );
+    assert_eq!(
         resp.errors,
         vec![ServerError {
             message: "myerror".to_string(),
@@ -207,11 +218,11 @@ pub async fn test_error_propagation() {
     let resp = schema.execute("{ parent { childOpt { name } } }").await;
     assert_eq!(
         resp.data,
-        value!({
-            "parent": {
-                "childOpt": null,
-            }
-        })
+        if cfg!(feature = "nullable-result") {
+            value!({ "parent": { "childOpt": { "name": null } } })
+        } else {
+            value!({ "parent": { "childOpt": null } })
+        }
     );
     assert_eq!(
         resp.errors,
@@ -232,7 +243,14 @@ pub async fn test_error_propagation() {
     );
 
     let resp = schema.execute("{ parentOpt { child { name } } }").await;
-    assert_eq!(resp.data, value!({ "parentOpt": null }));
+    assert_eq!(
+        resp.data,
+        if cfg!(feature = "nullable-result") {
+            value!({ "parentOpt": { "child": { "name": null } } })
+        } else {
+            value!({ "parentOpt": null })
+        }
+    );
     assert_eq!(
         resp.errors,
         vec![ServerError {
@@ -254,13 +272,7 @@ pub async fn test_error_propagation() {
     let resp = schema.execute("{ parentOpt { child { nameOpt } } }").await;
     assert_eq!(
         resp.data,
-        value!({
-            "parentOpt": {
-                "child": {
-                    "nameOpt": null,
-                }
-            },
-        })
+        value!({ "parentOpt": { "child": { "nameOpt": null } } })
     );
     assert_eq!(
         resp.errors,

--- a/tests/subscription_websocket_graphql_ws.rs
+++ b/tests/subscription_websocket_graphql_ws.rs
@@ -321,7 +321,13 @@ pub async fn test_subscription_ws_transport_error() {
             "type": "next",
             "id": "1",
             "payload": {
-                "data": null,
+                "data": (
+                    if cfg!(feature = "nullable-result") {
+                        value!({ "events": { "value": null } })
+                    } else {
+                        Value::Null
+                    }
+                ),
                 "errors": [{
                     "message": "TestError",
                     "locations": [{"line": 1, "column": 25}],

--- a/tests/subscription_websocket_subscriptions_transport_ws.rs
+++ b/tests/subscription_websocket_subscriptions_transport_ws.rs
@@ -255,7 +255,13 @@ pub async fn test_subscription_ws_transport_error() {
             "type": "data",
             "id": "1",
             "payload": {
-                "data": null,
+                "data": (
+                    if cfg!(feature = "nullable-result") {
+                        value!({ "events": { "value": null } })
+                    } else {
+                        Value::Null
+                    }
+                ),
                 "errors": [{
                     "message": "TestError",
                     "locations": [{"line": 1, "column": 25}],


### PR DESCRIPTION
This PR adds a new Cargo feature, `nullable-result`.

## What does it do?

When the feature is enabled, all fields that return `Result` become nullable, and `null` is returned in place when the `Result` has `Err()`.

## Why do this?

Null bubbling is a nightmare in most cases, which makes [nullable-by-default schema one of the best practices for designing GraphQL schemas](https://graphql.org/learn/best-practices/#nullability). However, the existing behavior of `async-graphql` doesn't match with it: error bubbles until it meets `Option` to "capture" it as a null. This makes it too easy to break the app just by not wrapping it with `Option`, and wrapping all return types from resolvers that return `Result` with `Option` is a very tedious, repetitive, and easy-to-miss task to do. This wouldn't have been the case at all if `Result` got resolved into a nullable type.

If we also look at the ecosystem, Caliban, a GraphQL server framework for Scala, also infers types of fields from the return type of resolvers and emits nullable types if resolvers return a throwable type like `ZIO[R, Throwable, A]` (somewhat similar to `Result<A, Throwable>`.) [(ref)](https://ghostdogpr.github.io/caliban/docs/schema.html#schema-generation)

While I personally believe that this should be the default for all cases, I guarded it with a Cargo feature for now to keep backward compatibility. I hope we can enable this as default at some point.