### PR TITLE
Mark fields returning Result as semanticNonNull

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ dynamic-schema = []
 graphiql = ["dep:askama"]
 raw_value = ["async-graphql-value/raw_value"]
 boxed-trait = ["async-graphql-derive/boxed-trait"]
+nullable-result = []
 
 [[bench]]
 harness = false

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -237,6 +237,8 @@ pub struct SimpleObjectField {
     pub complexity: Option<Expr>,
     #[darling(default, multiple)]
     pub requires_scopes: Vec<String>,
+    #[darling(default)]
+    pub semantic_non_null: Option<bool>,
 }
 
 #[derive(FromDeriveInput)]
@@ -292,6 +294,8 @@ pub struct SimpleObject {
     pub requires_scopes: Vec<String>,
     #[darling(rename = "crate")]
     pub crate_path: Option<Path>,
+    #[darling(default)]
+    pub semantic_non_null: bool,
 }
 
 #[derive(FromMeta, Default)]
@@ -345,6 +349,8 @@ pub struct Object {
     pub requires_scopes: Vec<String>,
     #[darling(rename = "crate")]
     pub crate_path: Option<Path>,
+    #[darling(default)]
+    pub semantic_non_null: bool,
 }
 
 #[derive(FromMeta, Default)]
@@ -373,6 +379,7 @@ pub struct ObjectField {
     pub directives: Vec<Expr>,
     #[darling(default, multiple)]
     pub requires_scopes: Vec<String>,
+    pub semantic_non_null: Option<bool>,
 }
 
 #[derive(FromMeta, Default, Clone)]
@@ -681,6 +688,8 @@ pub struct InterfaceField {
     pub directives: Vec<Expr>,
     #[darling(default, multiple)]
     pub requires_scopes: Vec<String>,
+    #[darling(default)]
+    pub semantic_non_null: Option<bool>,
 }
 
 #[derive(FromVariant)]
@@ -719,6 +728,8 @@ pub struct Interface {
     pub tags: Vec<String>,
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
+    #[darling(default)]
+    pub semantic_non_null: bool,
     // for OneofObject
     #[darling(default)]
     pub input_name: Option<String>,
@@ -765,6 +776,7 @@ pub struct Subscription {
     pub directives: Vec<Expr>,
     #[darling(rename = "crate")]
     pub crate_path: Option<Path>,
+    pub semantic_non_null: bool,
 }
 
 #[derive(FromMeta, Default)]
@@ -793,6 +805,7 @@ pub struct SubscriptionField {
     pub complexity: Option<Expr>,
     #[darling(default, multiple, rename = "directive")]
     pub directives: Vec<Expr>,
+    pub semantic_non_null: Option<bool>,
 }
 
 #[derive(FromField)]
@@ -997,6 +1010,7 @@ pub struct ComplexObject {
     pub guard: Option<Expr>,
     #[darling(rename = "crate")]
     pub crate_path: Option<Path>,
+    pub semantic_non_null: bool,
 }
 
 #[derive(FromMeta, Default)]
@@ -1024,6 +1038,7 @@ pub struct ComplexObjectField {
     pub directives: Vec<Expr>,
     #[darling(default, multiple)]
     pub requires_scopes: Vec<String>,
+    pub semantic_non_null: Option<bool>,
 }
 
 #[derive(FromMeta, Default)]

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -250,6 +250,9 @@ pub fn generate(
             let has_complexity = method_args.complexity.is_some();
             let has_directives = !method_args.directives.is_empty();
             let has_requires_scopes = !method_args.requires_scopes.is_empty();
+            let has_semantic_non_null = method_args
+                .semantic_non_null
+                .unwrap_or(object_args.semantic_non_null);
 
             let args = extract_input_args::<args::Argument>(&crate_name, method)?;
             let mut schema_args = Vec::new();
@@ -481,6 +484,10 @@ pub fn generate(
             if has_requires_scopes {
                 field_sets
                     .push(quote!(field.requires_scopes = ::std::vec![ #(#requires_scopes),* ];));
+            }
+            if has_semantic_non_null {
+                field_sets
+                    .push(quote!(field.semantic_nullability = <#schema_ty as #crate_name::OutputType>::semantic_nullability();));
             }
 
             schema_fields.push(quote! {

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -133,7 +133,7 @@ pub fn generate(
                         .into());
                     }
                 };
-                let ty = ty.value_type();
+                let ty = ty.value_type(&object_args.crate_path, object_args.internal);
                 let ident = &method.sig.ident;
 
                 let assert_generics = (!generics.params.is_empty()).then(|| {
@@ -391,7 +391,7 @@ pub fn generate(
                     );
                 }
             };
-            let schema_ty = ty.value_type();
+            let schema_ty = ty.value_type(&object_args.crate_path, object_args.internal);
             let visible = visible_fn(&method_args.visible);
 
             let complexity = if let Some(complexity) = &method_args.complexity {

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -215,6 +215,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
         override_from,
         directives,
         requires_scopes,
+        semantic_non_null,
     } in &interface_args.fields
     {
         let (name, method_name) = if let Some(method) = method {
@@ -368,6 +369,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
             .map(|s| quote! {::std::option::Option::Some(::std::string::ToString::to_string(#s))})
             .unwrap_or_else(|| quote! {::std::option::Option::None});
         let deprecation = gen_deprecation(deprecation, &crate_name);
+        let has_semantic_non_null = semantic_non_null.unwrap_or(interface_args.semantic_non_null);
 
         let oty = OutputType::parse(ty)?;
         let ty = match oty {
@@ -448,6 +450,9 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
         }
         if has_requires_scopes {
             field_sets.push(quote!(field.requires_scopes = ::std::vec![ #(#requires_scopes),* ];));
+        }
+        if has_semantic_non_null {
+            field_sets.push(quote!(field.semantic_nullability = <#schema_ty as #crate_name::OutputType>::semantic_nullability();));
         }
 
         schema_fields.push(quote! {

--- a/derive/src/interface.rs
+++ b/derive/src/interface.rs
@@ -374,7 +374,7 @@ pub fn generate(interface_args: &args::Interface) -> GeneratorResult<TokenStream
             OutputType::Value(ty) => ty,
             OutputType::Result(ty) => ty,
         };
-        let schema_ty = oty.value_type();
+        let schema_ty = oty.value_type(&interface_args.crate_path, interface_args.internal);
 
         methods.push(quote! {
             #[allow(missing_docs)]

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -193,7 +193,7 @@ pub fn generate(
                     }
                 };
 
-                let entity_type = ty.value_type();
+                let entity_type = ty.value_type(&object_args.crate_path, object_args.internal);
                 let mut key_pat = Vec::new();
                 let mut key_getter = Vec::new();
                 let mut use_keys = Vec::new();
@@ -311,7 +311,7 @@ pub fn generate(
                             .into());
                         }
                     };
-                    let ty = ty.value_type();
+                    let ty = ty.value_type(&object_args.crate_path, object_args.internal);
                     let ident = &method.sig.ident;
 
                     schema_fields.push(quote! {
@@ -547,7 +547,7 @@ pub fn generate(
                         .into());
                     }
                 };
-                let schema_ty = ty.value_type();
+                let schema_ty = ty.value_type(&object_args.crate_path, object_args.internal);
                 let visible = visible_fn(&method_args.visible);
 
                 let complexity = if let Some(complexity) = &method_args.complexity {
@@ -699,24 +699,9 @@ pub fn generate(
                         .await;
                     }
                 } else {
-                    match &ty {
-                        OutputType::Value(_) => {
-                            quote! {
-                                let obj: #schema_ty = self.#field_ident(ctx, #(#use_params),*);
-                                return #crate_name::resolver_utils::resolve_simple_field_value(ctx, &obj).await;
-                            }
-                        }
-                        OutputType::Result(_) => {
-                            quote! {
-                                let obj: #schema_ty = self.#field_ident(ctx, #(#use_params),*)
-                                    .map_err(|err| {
-                                        let err = ::std::convert::Into::<#crate_name::Error>::into(err)
-                                            .into_server_error(ctx.item.pos);
-                                        ctx.set_error_path(err)
-                                    })?;
-                                return #crate_name::resolver_utils::resolve_simple_field_value(ctx, &obj).await;
-                            }
-                        }
+                    quote! {
+                        let obj: #schema_ty = self.#field_ident(ctx, #(#use_params),*);
+                        return #crate_name::resolver_utils::resolve_simple_field_value(ctx, &obj).await;
                     }
                 };
 

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -428,6 +428,9 @@ pub fn generate(
                 let has_complexity = method_args.complexity.is_some();
                 let has_directives = !method_args.directives.is_empty();
                 let has_requires_scopes = !method_args.requires_scopes.is_empty();
+                let has_semantic_non_null = method_args
+                    .semantic_non_null
+                    .unwrap_or(object_args.semantic_non_null);
 
                 let args = extract_input_args::<args::Argument>(&crate_name, method)?;
                 let mut schema_args = Vec::new();
@@ -639,6 +642,11 @@ pub fn generate(
                     field_sets.push(
                         quote!(field.requires_scopes = ::std::vec![ #(#requires_scopes),* ];),
                     );
+                }
+                if has_semantic_non_null {
+                    field_sets.push(
+                        quote!(field.semantic_nullability = <#schema_ty as #crate_name::OutputType>::semantic_nullability();),
+                    )
                 }
 
                 schema_fields.push(quote! {

--- a/derive/src/output_type.rs
+++ b/derive/src/output_type.rs
@@ -2,6 +2,8 @@ use proc_macro2::{Ident, Span};
 use quote::quote;
 use syn::{Error, GenericArgument, PathArguments, Result, Type};
 
+use crate::utils::get_crate_path;
+
 pub enum OutputType<'a> {
     Value(&'a Type),
     Result(&'a Type),
@@ -42,10 +44,11 @@ impl<'a> OutputType<'a> {
         Ok(ty)
     }
 
-    pub fn value_type(&self) -> Type {
+    pub fn value_type(&self, crate_path: &Option<syn::Path>, internal: bool) -> Type {
+        let crate_name = get_crate_path(crate_path, internal);
         let tokens = match self {
             OutputType::Value(ty) => quote! {#ty},
-            OutputType::Result(ty) => quote! {#ty},
+            OutputType::Result(ty) => quote! {#crate_name::Result<#ty>},
         };
         let mut ty = syn::parse2::<syn::Type>(tokens).unwrap();
         Self::remove_lifecycle(&mut ty);

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -237,6 +237,9 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
         let has_complexity = field.complexity.is_some();
         let has_directives = !field.directives.is_empty();
         let has_requires_scopes = !field.requires_scopes.is_empty();
+        let has_semantic_non_null = field
+            .semantic_non_null
+            .unwrap_or(object_args.semantic_non_null);
 
         let visible = visible_fn(&field.visible);
         let directives = gen_directive_calls(
@@ -301,6 +304,10 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
             if has_requires_scopes {
                 field_sets
                     .push(quote!(field.requires_scopes = ::std::vec![ #(#requires_scopes),* ];));
+            }
+            if has_semantic_non_null {
+                field_sets
+                    .push(quote!(field.semantic_nullability = <#ty as #crate_name::OutputType>::semantic_nullability();));
             }
 
             schema_fields.push(quote! {

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -208,7 +208,10 @@ pub fn generate(
                     .into());
                 }
             };
-            let res_ty = ty.value_type();
+            let res_ty = match ty {
+                OutputType::Value(ty) => ty,
+                OutputType::Result(ty) => ty,
+            };
             let stream_ty = if let Type::ImplTrait(TypeImplTrait { bounds, .. }) = &res_ty {
                 let mut r = None;
                 for b in bounds {
@@ -219,6 +222,14 @@ pub fn generate(
                 quote! { #r }
             } else {
                 quote! { #res_ty }
+            };
+            let output_ty = match ty {
+                OutputType::Value(_) => {
+                    quote! { <#stream_ty as #crate_name::futures_util::stream::Stream>::Item }
+                }
+                OutputType::Result(_) => {
+                    quote! { #crate_name::Result<<#stream_ty as #crate_name::futures_util::stream::Stream>::Item> }
+                }
             };
 
             if let OutputType::Value(inner_ty) = &ty {
@@ -311,7 +322,7 @@ pub fn generate(
                 {
                     let mut field = #crate_name::registry::MetaField::new(
                         ::std::string::ToString::to_string(#field_name),
-                        <<#stream_ty as #crate_name::futures_util::stream::Stream>::Item as #crate_name::OutputType>::create_type_info(registry),
+                        <#output_ty as #crate_name::OutputType>::create_type_info(registry),
                     );
                     #(#schema_args)*
                     #(#field_sets)*
@@ -379,7 +390,7 @@ pub fn generate(
                                     let ri = #crate_name::extensions::ResolveInfo {
                                         path_node: ctx_selection_set.path_node.as_ref().unwrap(),
                                         parent_type: &parent_type,
-                                        return_type: &<<#stream_ty as #crate_name::futures_util::stream::Stream>::Item as #crate_name::OutputType>::qualified_type_name(),
+                                        return_type: &<#output_ty as #crate_name::OutputType>::qualified_type_name(),
                                         name: field.node.name.node.as_str(),
                                         alias: field.node.alias.as_ref().map(|alias| alias.node.as_str()),
                                         is_for_introspection: false,

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -298,6 +298,9 @@ pub fn generate(
                 &field.directives,
                 TypeDirectiveLocation::FieldDefinition,
             );
+            let has_semantic_non_null = field
+                .semantic_non_null
+                .unwrap_or(subscription_args.semantic_non_null);
 
             let mut field_sets = Vec::new();
             if has_field_desc {
@@ -315,6 +318,9 @@ pub fn generate(
             if has_directives {
                 field_sets
                     .push(quote!(field.directive_invocations = ::std::vec![ #(#directives),* ];));
+            }
+            if has_semantic_non_null {
+                field_sets.push(quote!(field.semantic_nullability = <#output_ty as #crate_name::OutputType>::semantic_nullability();));
             }
 
             schema_fields.push(quote! {

--- a/src/base.rs
+++ b/src/base.rs
@@ -11,7 +11,7 @@ use crate::{
     ContainerType, Context, ContextSelectionSet, Error, InputValueError, InputValueResult,
     Positioned, Result, ServerResult, Value,
     parser::types::Field,
-    registry::{self, Registry},
+    registry::{self, Registry, SemanticNullability},
 };
 
 #[doc(hidden)]
@@ -83,6 +83,11 @@ pub trait OutputType: Send + Sync {
         Self::type_name()
     }
 
+    /// Semantic nullability
+    fn semantic_nullability() -> SemanticNullability {
+        SemanticNullability::None
+    }
+
     /// Create type information in the registry and return qualified typename.
     fn create_type_info(registry: &mut registry::Registry) -> String;
 
@@ -109,6 +114,10 @@ impl<T: OutputType + ?Sized> OutputType for &T {
         T::type_name()
     }
 
+    fn semantic_nullability() -> SemanticNullability {
+        T::semantic_nullability()
+    }
+
     fn create_type_info(registry: &mut Registry) -> String {
         T::create_type_info(registry)
     }
@@ -132,6 +141,16 @@ impl<T: OutputType + Sync, E: Into<Error> + Send + Sync + Clone> OutputType for 
     #[cfg(feature = "nullable-result")]
     fn qualified_type_name() -> String {
         T::type_name().to_string()
+    }
+
+    #[cfg(feature = "nullable-result")]
+    fn semantic_nullability() -> SemanticNullability {
+        match T::semantic_nullability() {
+            SemanticNullability::None => SemanticNullability::OutNonNull,
+            SemanticNullability::OutNonNull => SemanticNullability::OutNonNull,
+            SemanticNullability::InNonNull => SemanticNullability::BothNonNull,
+            SemanticNullability::BothNonNull => SemanticNullability::BothNonNull,
+        }
     }
 
     fn create_type_info(registry: &mut Registry) -> String {
@@ -192,6 +211,10 @@ impl<T: OutputType + ?Sized> OutputType for Box<T> {
         T::type_name()
     }
 
+    fn semantic_nullability() -> SemanticNullability {
+        T::semantic_nullability()
+    }
+
     fn create_type_info(registry: &mut Registry) -> String {
         T::create_type_info(registry)
     }
@@ -248,6 +271,10 @@ impl<T: OutputType + ?Sized> OutputType for Arc<T> {
         T::type_name()
     }
 
+    fn semantic_nullability() -> SemanticNullability {
+        T::semantic_nullability()
+    }
+
     fn create_type_info(registry: &mut Registry) -> String {
         T::create_type_info(registry)
     }
@@ -292,6 +319,10 @@ impl<T: InputType> InputType for Arc<T> {
 impl<T: OutputType + ?Sized> OutputType for Weak<T> {
     fn type_name() -> Cow<'static, str> {
         <Option<Arc<T>> as OutputType>::type_name()
+    }
+
+    fn semantic_nullability() -> SemanticNullability {
+        T::semantic_nullability()
     }
 
     fn create_type_info(registry: &mut Registry) -> String {

--- a/src/dynamic/field.rs
+++ b/src/dynamic/field.rs
@@ -12,7 +12,7 @@ use super::Directive;
 use crate::{
     Context, Error, Result, Value,
     dynamic::{InputValue, ObjectAccessor, TypeRef},
-    registry::Deprecation,
+    registry::{Deprecation, SemanticNullability},
 };
 
 /// A value returned from the resolver function
@@ -334,6 +334,7 @@ pub struct Field {
     pub(crate) override_from: Option<String>,
     pub(crate) directives: Vec<Directive>,
     pub(crate) requires_scopes: Vec<String>,
+    pub(crate) semantic_nullability: SemanticNullability,
 }
 
 impl Debug for Field {
@@ -374,6 +375,7 @@ impl Field {
             override_from: None,
             directives: Vec::new(),
             requires_scopes: Vec::new(),
+            semantic_nullability: SemanticNullability::None,
         }
     }
 
@@ -386,6 +388,7 @@ impl Field {
     impl_set_inaccessible!();
     impl_set_tags!();
     impl_set_override_from!();
+    impl_set_semantic_nullability!();
     impl_directive!();
 
     /// Add an argument to the field

--- a/src/dynamic/interface.rs
+++ b/src/dynamic/interface.rs
@@ -3,7 +3,7 @@ use indexmap::{IndexMap, IndexSet};
 use super::{Directive, directive::to_meta_directive_invocation};
 use crate::{
     dynamic::{InputValue, SchemaError, TypeRef},
-    registry::{Deprecation, MetaField, MetaType, Registry},
+    registry::{Deprecation, MetaField, MetaType, Registry, SemanticNullability},
 };
 
 /// A GraphQL interface field type
@@ -98,6 +98,7 @@ pub struct InterfaceField {
     pub(crate) override_from: Option<String>,
     pub(crate) directives: Vec<Directive>,
     pub(crate) requires_scopes: Vec<String>,
+    pub(crate) semantic_nullability: SemanticNullability,
 }
 
 impl InterfaceField {
@@ -118,6 +119,7 @@ impl InterfaceField {
             override_from: None,
             directives: Vec::new(),
             requires_scopes: Vec::new(),
+            semantic_nullability: SemanticNullability::None,
         }
     }
 
@@ -130,6 +132,7 @@ impl InterfaceField {
     impl_set_inaccessible!();
     impl_set_tags!();
     impl_set_override_from!();
+    impl_set_semantic_nullability!();
     impl_directive!();
 
     /// Add an argument to the field
@@ -253,6 +256,7 @@ impl Interface {
                     compute_complexity: None,
                     directive_invocations: to_meta_directive_invocation(field.directives.clone()),
                     requires_scopes: field.requires_scopes.clone(),
+                    semantic_nullability: field.semantic_nullability,
                 },
             );
         }

--- a/src/dynamic/macros.rs
+++ b/src/dynamic/macros.rs
@@ -162,6 +162,19 @@ macro_rules! impl_set_override_from {
     };
 }
 
+macro_rules! impl_set_semantic_nullability {
+    () => {
+        /// Semantic nullability
+        #[inline]
+        pub fn semantic_nullability(self, semantic_nullability: SemanticNullability) -> Self {
+            Self {
+                semantic_nullability,
+                ..self
+            }
+        }
+    };
+}
+
 macro_rules! impl_directive {
     () => {
         /// Attach directive to the entity

--- a/src/dynamic/object.rs
+++ b/src/dynamic/object.rs
@@ -192,6 +192,7 @@ impl Object {
                     compute_complexity: None,
                     directive_invocations: to_meta_directive_invocation(field.directives.clone()),
                     requires_scopes: field.requires_scopes.clone(),
+                    semantic_nullability: field.semantic_nullability,
                 },
             );
         }

--- a/src/dynamic/subscription.rs
+++ b/src/dynamic/subscription.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     extensions::ResolveInfo,
     parser::types::Selection,
-    registry::{Deprecation, MetaField, MetaType, Registry},
+    registry::{Deprecation, MetaField, MetaType, Registry, SemanticNullability},
     subscription::BoxFieldStream,
 };
 
@@ -52,6 +52,7 @@ pub struct SubscriptionField {
     pub(crate) ty: TypeRef,
     pub(crate) resolver_fn: BoxResolverFn,
     pub(crate) deprecation: Deprecation,
+    pub(crate) semantic_nullability: SemanticNullability,
 }
 
 impl SubscriptionField {
@@ -69,11 +70,13 @@ impl SubscriptionField {
             ty: ty.into(),
             resolver_fn: Arc::new(resolver_fn),
             deprecation: Deprecation::NoDeprecated,
+            semantic_nullability: SemanticNullability::None,
         }
     }
 
     impl_set_description!();
     impl_set_deprecation!();
+    impl_set_semantic_nullability!();
 
     /// Add an argument to the subscription field
     #[inline]
@@ -164,6 +167,7 @@ impl Subscription {
                     compute_complexity: None,
                     directive_invocations: vec![],
                     requires_scopes: vec![],
+                    semantic_nullability: field.semantic_nullability,
                 },
             );
         }

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, fmt::Write};
 
+use super::SemanticNullability;
 use crate::registry::{Deprecation, MetaField, MetaInputValue, MetaType, Registry};
 
 const SYSTEM_SCALARS: &[&str] = &["Int", "Float", "String", "Boolean", "ID"];
@@ -186,6 +187,18 @@ impl Registry {
                 return;
             }
 
+            // Filter out semanticNonNull directive from SDL if it is not used
+            if directive.name == "semanticNonNull"
+                && !self.types.values().any(|ty| match ty {
+                    MetaType::Object { fields, .. } => fields.values().any(|field| {
+                        field.semantic_nullability != crate::registry::SemanticNullability::None
+                    }),
+                    _ => false,
+                })
+            {
+                return;
+            }
+
             writeln!(sdl, "{}", directive.sdl(&options)).ok();
         });
 
@@ -313,6 +326,19 @@ impl Registry {
             }
 
             write_deprecated(sdl, &field.deprecation);
+
+            match field.semantic_nullability {
+                SemanticNullability::OutNonNull => {
+                    write!(sdl, " @semanticNonNull").ok();
+                }
+                SemanticNullability::InNonNull => {
+                    write!(sdl, " @semanticNonNull(levels: [1])").ok();
+                }
+                SemanticNullability::BothNonNull => {
+                    write!(sdl, " @semanticNonNull(levels: [0, 1])").ok();
+                }
+                SemanticNullability::None => {}
+            }
 
             for directive in &field.directive_invocations {
                 write!(sdl, " {}", directive.sdl()).ok();

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -209,6 +209,15 @@ impl Deprecation {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SemanticNullability {
+    #[default]
+    None,
+    OutNonNull,
+    InNonNull,
+    BothNonNull,
+}
+
 /// Field metadata
 #[derive(Clone)]
 pub struct MetaField {
@@ -259,6 +268,8 @@ pub struct MetaField {
     /// the authenticated supergraph users with the appropriate JWT scopes
     /// when using Apollo Federation.
     pub requires_scopes: Vec<String>,
+    /// Semantic nullability
+    pub semantic_nullability: SemanticNullability,
 }
 
 impl MetaField {
@@ -281,6 +292,7 @@ impl MetaField {
             compute_complexity: None,
             directive_invocations: Vec::new(),
             requires_scopes: Vec::new(),
+            semantic_nullability: SemanticNullability::None,
         }
     }
 }
@@ -1332,6 +1344,42 @@ impl Registry {
             composable: None,
         });
 
+        self.add_directive(MetaDirective {
+            name: "semanticNonNull".into(),
+            description: Some(
+                r#"Indicates that a position is semantically non null: it is only null if there is a matching error in the `errors` array.
+In all other cases, the position is non-null.
+
+Tools doing code generation may use this information to generate the position as non-null if field errors are handled out of band:
+
+`levels` are zero indexed.
+Passing a negative level or a level greater than the list dimension is an error."#.to_string()
+            ),
+            locations: vec![__DirectiveLocation::FIELD_DEFINITION],
+            args: {
+                let mut args = IndexMap::new();
+                args.insert(
+                    "levels".into(),
+                    MetaInputValue {
+                        name: "levels".into(),
+                        description: None,
+                        ty: "[Int!]!".into(),
+                        deprecation: Deprecation::NoDeprecated,
+                        default_value: Some(r#"[0]"#.into()),
+                        visible: None,
+                        inaccessible: false,
+                        tags: Default::default(),
+                        is_secret: false,
+                        directive_invocations: vec![],
+                    },
+                );
+                args
+            },
+            is_repeatable: false,
+            visible: None,
+            composable: None,
+        });
+
         // create system scalars
         <bool as InputType>::create_type_info(self);
         <i32 as InputType>::create_type_info(self);
@@ -1545,6 +1593,7 @@ impl Registry {
                     compute_complexity: None,
                     directive_invocations: vec![],
                     requires_scopes: vec![],
+                    semantic_nullability: SemanticNullability::None,
                 },
             );
         }
@@ -1603,6 +1652,7 @@ impl Registry {
                         compute_complexity: None,
                         directive_invocations: vec![],
                         requires_scopes: vec![],
+                        semantic_nullability: SemanticNullability::None,
                     },
                 );
             }
@@ -1633,6 +1683,7 @@ impl Registry {
                     override_from: None,
                     directive_invocations: vec![],
                     requires_scopes: vec![],
+                    semantic_nullability: SemanticNullability::None,
                 },
             );
 
@@ -1674,6 +1725,7 @@ impl Registry {
                     compute_complexity: None,
                     directive_invocations: vec![],
                     requires_scopes: vec![],
+                    semantic_nullability: SemanticNullability::None,
                 },
             );
         }
@@ -1709,6 +1761,7 @@ impl Registry {
                             compute_complexity: None,
                             directive_invocations: vec![],
                             requires_scopes: vec![],
+                            semantic_nullability: SemanticNullability::None,
                         },
                     );
                     fields

--- a/src/types/external/cow.rs
+++ b/src/types/external/cow.rs
@@ -14,6 +14,10 @@ where
         T::type_name()
     }
 
+    fn semantic_nullability() -> registry::SemanticNullability {
+        T::semantic_nullability()
+    }
+
     fn create_type_info(registry: &mut registry::Registry) -> String {
         <T as OutputType>::create_type_info(registry)
     }

--- a/src/types/external/list/array.rs
+++ b/src/types/external/list/array.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     ContextSelectionSet, InputType, InputValueError, InputValueResult, OutputType, Positioned,
     ServerResult, Value, parser::types::Field, registry, resolver_utils::resolve_list,
@@ -60,6 +61,10 @@ impl<T: OutputType, const N: usize> OutputType for [T; N] {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/btree_set.rs
+++ b/src/types/external/list/btree_set.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::BTreeSet};
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     ContextSelectionSet, InputType, InputValueError, InputValueResult, OutputType, Positioned,
     ServerResult, Value, parser::types::Field, registry, resolver_utils::resolve_list,
@@ -53,6 +54,10 @@ impl<T: OutputType + Ord> OutputType for BTreeSet<T> {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/hash_set.rs
+++ b/src/types/external/list/hash_set.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::HashSet, hash::Hash};
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     ContextSelectionSet, InputType, InputValueError, InputValueResult, OutputType, Positioned,
     Result, ServerResult, Value, parser::types::Field, registry, resolver_utils::resolve_list,
@@ -53,6 +54,10 @@ impl<T: OutputType + Hash + Eq> OutputType for HashSet<T> {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/linked_list.rs
+++ b/src/types/external/list/linked_list.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::LinkedList};
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     ContextSelectionSet, InputType, InputValueError, InputValueResult, OutputType, Positioned,
     ServerResult, Value, parser::types::Field, registry, resolver_utils::resolve_list,
@@ -54,6 +55,10 @@ impl<T: OutputType> OutputType for LinkedList<T> {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/mod.rs
+++ b/src/types/external/list/mod.rs
@@ -1,3 +1,5 @@
+use crate::registry::SemanticNullability;
+
 mod array;
 mod btree_set;
 mod hash_set;
@@ -5,3 +7,18 @@ mod linked_list;
 mod slice;
 mod vec;
 mod vec_deque;
+
+fn wrap_semantic_nullability_in_list(
+    semantic_nullability: SemanticNullability,
+) -> SemanticNullability {
+    if cfg!(feature = "nullable-result") {
+        match semantic_nullability {
+            SemanticNullability::None => SemanticNullability::None,
+            SemanticNullability::OutNonNull => SemanticNullability::InNonNull,
+            SemanticNullability::InNonNull => SemanticNullability::InNonNull,
+            SemanticNullability::BothNonNull => SemanticNullability::BothNonNull,
+        }
+    } else {
+        semantic_nullability
+    }
+}

--- a/src/types/external/list/slice.rs
+++ b/src/types/external/list/slice.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     ContextSelectionSet, InputType, InputValueError, InputValueResult, OutputType, Positioned,
     ServerResult, Value, parser::types::Field, registry, resolver_utils::resolve_list,
@@ -13,6 +14,10 @@ impl<'a, T: OutputType + 'a> OutputType for &'a [T] {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {
@@ -39,6 +44,10 @@ macro_rules! impl_output_slice_for_smart_ptr {
 
             fn qualified_type_name() -> String {
                 format!("[{}]!", T::qualified_type_name())
+            }
+
+            fn semantic_nullability() -> registry::SemanticNullability {
+                wrap_semantic_nullability_in_list(T::semantic_nullability())
             }
 
             fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/vec.rs
+++ b/src/types/external/list/vec.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     ContextSelectionSet, InputType, InputValueError, InputValueResult, OutputType, Positioned,
     Result, ServerResult, Value, parser::types::Field, registry, resolver_utils::resolve_list,
@@ -51,6 +52,10 @@ impl<T: OutputType> OutputType for Vec<T> {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/src/types/external/list/vec_deque.rs
+++ b/src/types/external/list/vec_deque.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::VecDeque};
 
+use super::wrap_semantic_nullability_in_list;
 use crate::{
     ContextSelectionSet, InputType, InputValueError, InputValueResult, OutputType, Positioned,
     ServerResult, Value, parser::types::Field, registry, resolver_utils::resolve_list,
@@ -54,6 +55,10 @@ impl<T: OutputType> OutputType for VecDeque<T> {
 
     fn qualified_type_name() -> String {
         format!("[{}]!", T::qualified_type_name())
+    }
+
+    fn semantic_nullability() -> registry::SemanticNullability {
+        wrap_semantic_nullability_in_list(T::semantic_nullability())
     }
 
     fn create_type_info(registry: &mut registry::Registry) -> String {

--- a/tests/error_ext.rs
+++ b/tests/error_ext.rs
@@ -40,7 +40,11 @@ pub async fn test_error_extensions() {
     assert_eq!(
         serde_json::to_value(&schema.execute("{ extendErr }").await).unwrap(),
         serde_json::json!({
-            "data": null,
+            "data": (if cfg!(feature = "nullable-result"){
+                serde_json::json!({ "extendErr": null })
+            } else {
+                serde_json::Value::Null
+            }),
             "errors": [{
                 "message": "my error",
                 "locations": [{
@@ -60,7 +64,11 @@ pub async fn test_error_extensions() {
     assert_eq!(
         serde_json::to_value(&schema.execute("{ extendResult }").await).unwrap(),
         serde_json::json!({
-            "data": null,
+            "data": (if cfg!(feature = "nullable-result"){
+                serde_json::json!({ "extendResult": null })
+            } else {
+                serde_json::Value::Null
+            }),
             "errors": [{
                 "message": "my error",
                 "locations": [{

--- a/tests/introspection.rs
+++ b/tests/introspection.rs
@@ -1540,7 +1540,7 @@ pub async fn test_introspection_directives() {
           }
         }
       }
-      
+
       fragment InputValue on __InputValue {
         name
         type {
@@ -1548,7 +1548,7 @@ pub async fn test_introspection_directives() {
         }
         defaultValue
       }
-      
+
       fragment TypeRef on __Type {
         kind
         name
@@ -1609,6 +1609,26 @@ pub async fn test_introspection_directives() {
             "INPUT_OBJECT"
           ],
           "args": []
+        },
+        {
+          "name": "semanticNonNull",
+          "locations": [
+            "FIELD_DEFINITION"
+          ],
+          "args": [
+            {
+              "name": "levels",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null
+                }
+              },
+              "defaultValue": "[0]"
+            }
+          ]
         },
         {
           "name": "skip",

--- a/tests/result.rs
+++ b/tests/result.rs
@@ -55,12 +55,10 @@ pub async fn test_fieldresult() {
         ]
     );
 
+    let resp = schema.execute("{ optError }").await;
+    assert_eq!(resp.data, value!({ "optError": null }));
     assert_eq!(
-        schema
-            .execute("{ optError }")
-            .await
-            .into_result()
-            .unwrap_err(),
+        resp.errors,
         vec![ServerError {
             message: "TestError".to_string(),
             source: None,
@@ -70,12 +68,17 @@ pub async fn test_fieldresult() {
         }]
     );
 
+    let resp = schema.execute("{ vecError }").await;
     assert_eq!(
-        schema
-            .execute("{ vecError }")
-            .await
-            .into_result()
-            .unwrap_err(),
+        resp.data,
+        if cfg!(feature = "nullable-result") {
+            value!({ "vecError": [1, null] })
+        } else {
+            Value::Null
+        }
+    );
+    assert_eq!(
+        resp.errors,
         vec![ServerError {
             message: "TestError".to_string(),
             source: None,
@@ -187,6 +190,14 @@ pub async fn test_error_propagation() {
     let resp = schema.execute("{ parent { child { name } } }").await;
 
     assert_eq!(
+        resp.data,
+        if cfg!(feature = "nullable-result") {
+            value!({ "parent": { "child": { "name": null } } })
+        } else {
+            Value::Null
+        }
+    );
+    assert_eq!(
         resp.errors,
         vec![ServerError {
             message: "myerror".to_string(),
@@ -207,11 +218,11 @@ pub async fn test_error_propagation() {
     let resp = schema.execute("{ parent { childOpt { name } } }").await;
     assert_eq!(
         resp.data,
-        value!({
-            "parent": {
-                "childOpt": null,
-            }
-        })
+        if cfg!(feature = "nullable-result") {
+            value!({ "parent": { "childOpt": { "name": null } } })
+        } else {
+            value!({ "parent": { "childOpt": null } })
+        }
     );
     assert_eq!(
         resp.errors,
@@ -232,7 +243,14 @@ pub async fn test_error_propagation() {
     );
 
     let resp = schema.execute("{ parentOpt { child { name } } }").await;
-    assert_eq!(resp.data, value!({ "parentOpt": null }));
+    assert_eq!(
+        resp.data,
+        if cfg!(feature = "nullable-result") {
+            value!({ "parentOpt": { "child": { "name": null } } })
+        } else {
+            value!({ "parentOpt": null })
+        }
+    );
     assert_eq!(
         resp.errors,
         vec![ServerError {
@@ -254,13 +272,7 @@ pub async fn test_error_propagation() {
     let resp = schema.execute("{ parentOpt { child { nameOpt } } }").await;
     assert_eq!(
         resp.data,
-        value!({
-            "parentOpt": {
-                "child": {
-                    "nameOpt": null,
-                }
-            },
-        })
+        value!({ "parentOpt": { "child": { "nameOpt": null } } })
     );
     assert_eq!(
         resp.errors,

--- a/tests/subscription_websocket_graphql_ws.rs
+++ b/tests/subscription_websocket_graphql_ws.rs
@@ -321,7 +321,13 @@ pub async fn test_subscription_ws_transport_error() {
             "type": "next",
             "id": "1",
             "payload": {
-                "data": null,
+                "data": (
+                    if cfg!(feature = "nullable-result") {
+                        value!({ "events": { "value": null } })
+                    } else {
+                        Value::Null
+                    }
+                ),
                 "errors": [{
                     "message": "TestError",
                     "locations": [{"line": 1, "column": 25}],

--- a/tests/subscription_websocket_subscriptions_transport_ws.rs
+++ b/tests/subscription_websocket_subscriptions_transport_ws.rs
@@ -255,7 +255,13 @@ pub async fn test_subscription_ws_transport_error() {
             "type": "data",
             "id": "1",
             "payload": {
-                "data": null,
+                "data": (
+                    if cfg!(feature = "nullable-result") {
+                        value!({ "events": { "value": null } })
+                    } else {
+                        Value::Null
+                    }
+                ),
                 "errors": [{
                     "message": "TestError",
                     "locations": [{"line": 1, "column": 25}],


### PR DESCRIPTION
Stacked on #1637
Closes #1605

This PR adds support for semantic nullability as an opt-in feature, with [GAP-49](https://gaps.graphql.org/GAP-49/draft/) as the reference.

A field gets marked as `@semanticNonNull` when:

- The `nullable-result` feature is enabled
- A field or container type is marked as `#[graphql(semantic_non_null)]`
- A field returns type that contains `Result`

By introducing the feature as an opt-in, it is now a non-breaking, purely additive change. While I'd want to propose a whole rework to the core type system around nullability, that would be a huge breaking one so I went sideways for now. When the semantic nullability proposal gets merged, it'd be better to make this change more fundamentally, instead of doing workarounds like this.