### PR TITLE
Use web_time instead of std::time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ base64 = "0.22.0"
 serde_urlencoded = "0.7.1"
 http.workspace = true
 futures-timer = "3.0.3"
+web-time= "1.1.0"
 
 # Feature optional dependencies
 bson = { version = "2.9.0", optional = true, features = [

--- a/src/dataloader/mod.rs
+++ b/src/dataloader/mod.rs
@@ -67,8 +67,9 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
     },
-    time::Duration,
 };
+
+use web_time::Duration;
 
 pub use cache::{CacheFactory, CacheStorage, HashMapCache, LruCache, NoCache};
 use fnv::FnvHashMap;

--- a/src/dynamic/subscription.rs
+++ b/src/dynamic/subscription.rs
@@ -288,7 +288,7 @@ impl Subscription {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use web_time::Duration;
 
     use futures_util::StreamExt;
 

--- a/src/http/multipart_subscribe.rs
+++ b/src/http/multipart_subscribe.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use web_time::Duration;
 
 use bytes::{BufMut, Bytes, BytesMut};
 use futures_timer::Delay;

--- a/src/http/websocket.rs
+++ b/src/http/websocket.rs
@@ -6,8 +6,9 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
-    time::{Duration, Instant},
 };
+
+use web_time::{Duration, Instant};
 
 use futures_timer::Delay;
 use futures_util::{

--- a/tests/mutation.rs
+++ b/tests/mutation.rs
@@ -1,4 +1,5 @@
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
+use web_time::Duration;
 
 use async_graphql::*;
 use tokio::sync::Mutex;

--- a/tests/subscription_websocket_graphql_ws.rs
+++ b/tests/subscription_websocket_graphql_ws.rs
@@ -1,8 +1,9 @@
 use std::{
     pin::Pin,
     sync::{Arc, Mutex},
-    time::Duration,
 };
+
+use web_time::Duration;
 
 use async_graphql::{
     http::{WebSocketProtocols, WsMessage},


### PR DESCRIPTION
This replaces std::time with web_time, specifically problematic for Web Socket/Subscriptions. Integrations are not replaced, since these do not support a Wasm back-end anyway.