### PR TITLE
Add new altair option

### DIFF
--- a/integrations/rocket/Cargo.toml
+++ b/integrations/rocket/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Daniel Wiesenberg <daniel@simplificAR.io>"]
+authors = ["Daniel Wiesenberg <daniel@wsnbrg.de>"]
 categories = ["network-programming", "asynchronous"]
 description = "async-graphql for Rocket.rs"
 documentation = "https://docs.rs/async-graphql/"

--- a/src/http/altair_source.rs
+++ b/src/http/altair_source.rs
@@ -254,7 +254,7 @@ pub enum AltairAuthorizationProviderInput {
     },
     /// OAuth2 access token authorization
     #[serde(rename = "oauth2")]
-    OAuth2{
+    OAuth2 {
         /// Access token response
         access_token_response: String,
     },

--- a/src/http/altair_source.rs
+++ b/src/http/altair_source.rs
@@ -119,6 +119,9 @@ pub struct AltairWindowOptions {
     /// Initial post-request script to be added
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub initial_post_request_script: Option<String>,
+    /// Initial authorization type and data
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initial_authorization: Option<AltairAuthorizationProviderInput>,
     /// Initial headers object to be added
     /// ```js
     /// {
@@ -221,6 +224,40 @@ pub struct AltairInitialEnvironmentState {
     /// Environment variables
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub variables: HashMap<String, String>,
+}
+
+/// Altair authorization provider input
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "data")]
+pub enum AltairAuthorizationProviderInput {
+    /// Api key authorization
+    #[serde(rename = "api-key")]
+    ApiKey {
+        /// Header name
+        header_name: String,
+        /// Header value
+        header_value: String,
+    },
+    /// Basic authorization
+    #[serde(rename = "basic")]
+    Basic {
+        /// Password
+        password: String,
+        /// Username
+        username: String,
+    },
+    /// Bearer token authorization
+    #[serde(rename = "bearer")]
+    Bearer {
+        /// Token
+        token: String,
+    },
+    /// OAuth2 access token authorization
+    #[serde(rename = "oauth2")]
+    OAuth2{
+        /// Access token response
+        access_token_response: String,
+    },
 }
 
 /// Altair application settings state


### PR DESCRIPTION
Adds `initial_authorization` to `AltairWindowsOptions`.
This enables us to set an initial authorization in the `Auth` tab, see:
![image](https://github.com/user-attachments/assets/dd5c4113-985c-4882-82be-1c1b93343b10)

I've also changed my email address in the Rocket example, because that one is not available anymore.