### PR TITLE
integrations/axum: Add tracing support for subscription

### DIFF
--- a/integrations/axum/Cargo.toml
+++ b/integrations/axum/Cargo.toml
@@ -24,6 +24,7 @@ tokio-util = { workspace = true, default-features = false, features = [
 ] }
 tokio-stream = "0.1.15"
 tower-service = "0.3"
+tracing = { version = "0.1.40", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 axum = { version = "0.8.1", default-features = false }

--- a/integrations/axum/src/subscription.rs
+++ b/integrations/axum/src/subscription.rs
@@ -105,7 +105,7 @@ where
                 Err(err) => return Ok(err.into_response()),
             };
             let upgrade = match WebSocketUpgrade::from_request_parts(&mut parts, &()).await {
-                Ok(protocol) => protocol,
+                Ok(upgrade) => upgrade,
                 Err(err) => return Ok(err.into_response()),
             };
 


### PR DESCRIPTION
This PR adds `tracing` feature to the `async-graphql-axum` crate. With this support, function calls from `Subscription`s are properly in the correct span.