### PR TITLE
chore(deps): bump opentelemetry to 0.28.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ fast_chemail = { version = "0.9.6", optional = true }
 hashbrown = { version = "0.14.5", optional = true }
 iso8601 = { version = "0.6.1", optional = true }
 log = { version = "0.4.21", optional = true }
-opentelemetry = { version = "0.27.0", optional = true, default-features = false, features = [
+opentelemetry = { version = "0.28.0", optional = true, default-features = false, features = [
   "trace",
 ] }
 rust_decimal = { version = "1.35.0", optional = true, default-features = false }


### PR DESCRIPTION
The tests are passing, no other breaking changes were noticed.