### PR TITLE
Refactor `CacheStorage::get` to return `Option<V>` instead of `Option<&V>`

### DIFF
--- a/src/dataloader/cache.rs
+++ b/src/dataloader/cache.rs
@@ -27,7 +27,7 @@ pub trait CacheStorage: Send + Sync + 'static {
 
     /// Returns a reference to the value of the key in the cache or None if it
     /// is not present in the cache.
-    fn get(&mut self, key: &Self::Key) -> Option<&Self::Value>;
+    fn get(&mut self, key: &Self::Key) -> Option<Self::Value>;
 
     /// Puts a key-value pair into the cache. If the key already exists in the
     /// cache, then it updates the key's value.
@@ -73,7 +73,7 @@ where
     type Value = V;
 
     #[inline]
-    fn get(&mut self, _key: &K) -> Option<&V> {
+    fn get(&mut self, _key: &K) -> Option<V> {
         None
     }
 
@@ -131,8 +131,8 @@ where
     type Value = V;
 
     #[inline]
-    fn get(&mut self, key: &Self::Key) -> Option<&Self::Value> {
-        self.0.get(key)
+    fn get(&mut self, key: &Self::Key) -> Option<Self::Value> {
+        self.0.get(key).cloned()
     }
 
     #[inline]
@@ -190,8 +190,8 @@ where
     type Value = V;
 
     #[inline]
-    fn get(&mut self, key: &Self::Key) -> Option<&Self::Value> {
-        self.0.get(key)
+    fn get(&mut self, key: &Self::Key) -> Option<Self::Value> {
+        self.0.get(key).cloned()
     }
 
     #[inline]

--- a/src/dataloader/mod.rs
+++ b/src/dataloader/mod.rs
@@ -333,7 +333,7 @@ impl<T, C: CacheFactory> DataLoader<T, C> {
                 for key in keys {
                     if let Some(value) = typed_requests.cache_storage.get(&key) {
                         // Already in cache
-                        use_cache_values.insert(key.clone(), value.clone());
+                        use_cache_values.insert(key.clone(), value);
                     } else {
                         keys_set.insert(key);
                     }


### PR DESCRIPTION
Closes #1684