### PR TITLE
feat: Allow Introspection of __typename field only for dynamic schema

### DIFF
--- a/src/dynamic/resolve.rs
+++ b/src/dynamic/resolve.rs
@@ -55,26 +55,15 @@ fn collect_typename_field<'a>(
     ctx: &ContextSelectionSet<'a>,
     field: &'a Positioned<Field>,
 ) {
-    if matches!(
-        ctx.schema_env.registry.introspection_mode,
-        IntrospectionMode::Enabled | IntrospectionMode::IntrospectionOnly
-    ) && matches!(
-        ctx.query_env.introspection_mode,
-        IntrospectionMode::Enabled | IntrospectionMode::IntrospectionOnly,
-    ) {
-        fields.push(
-            async move {
-                Ok((
-                    field.node.response_key().node.clone(),
-                    Value::from(object.name.as_str()),
-                ))
-            }
-            .boxed(),
-        )
-    } else {
-        fields
-            .push(async move { Ok((field.node.response_key().node.clone(), Value::Null)) }.boxed())
-    }
+    fields.push(
+        async move {
+            Ok((
+                field.node.response_key().node.clone(),
+                Value::from(object.name.as_str()),
+            ))
+        }
+        .boxed(),
+    )
 }
 
 fn collect_schema_field<'a>(

--- a/src/dynamic/resolve.rs
+++ b/src/dynamic/resolve.rs
@@ -55,15 +55,26 @@ fn collect_typename_field<'a>(
     ctx: &ContextSelectionSet<'a>,
     field: &'a Positioned<Field>,
 ) {
-    fields.push(
-        async move {
-            Ok((
-                field.node.response_key().node.clone(),
-                Value::from(object.name.as_str()),
-            ))
-        }
-        .boxed(),
-    )
+    if matches!(
+        ctx.schema_env.registry.introspection_mode,
+        IntrospectionMode::Enabled | IntrospectionMode::IntrospectionOnly | IntrospectionMode::IntrospectioTypeNamenOnly 
+    ) && matches!(
+        ctx.query_env.introspection_mode,
+        IntrospectionMode::Enabled | IntrospectionMode::IntrospectionOnly | IntrospectionMode::IntrospectioTypeNamenOnly ,
+    ) {
+        fields.push(
+            async move {
+                Ok((
+                    field.node.response_key().node.clone(),
+                    Value::from(object.name.as_str()),
+                ))
+            }
+            .boxed(),
+        )
+    } else {
+        fields
+            .push(async move { Ok((field.node.response_key().node.clone(), Value::Null)) }.boxed())
+    }
 }
 
 fn collect_schema_field<'a>(

--- a/src/dynamic/resolve.rs
+++ b/src/dynamic/resolve.rs
@@ -57,10 +57,10 @@ fn collect_typename_field<'a>(
 ) {
     if matches!(
         ctx.schema_env.registry.introspection_mode,
-        IntrospectionMode::Enabled | IntrospectionMode::IntrospectionOnly | IntrospectionMode::IntrospectioTypeNameOnly 
+        IntrospectionMode::Enabled | IntrospectionMode::IntrospectionOnly | IntrospectionMode::IntrospectTypeNameOnly 
     ) && matches!(
         ctx.query_env.introspection_mode,
-        IntrospectionMode::Enabled | IntrospectionMode::IntrospectionOnly | IntrospectionMode::IntrospectioTypeNameOnly ,
+        IntrospectionMode::Enabled | IntrospectionMode::IntrospectionOnly | IntrospectionMode::IntrospectTypeNameOnly ,
     ) {
         fields.push(
             async move {

--- a/src/dynamic/resolve.rs
+++ b/src/dynamic/resolve.rs
@@ -57,10 +57,10 @@ fn collect_typename_field<'a>(
 ) {
     if matches!(
         ctx.schema_env.registry.introspection_mode,
-        IntrospectionMode::Enabled | IntrospectionMode::IntrospectionOnly | IntrospectionMode::IntrospectioTypeNamenOnly 
+        IntrospectionMode::Enabled | IntrospectionMode::IntrospectionOnly | IntrospectionMode::IntrospectioTypeNameOnly 
     ) && matches!(
         ctx.query_env.introspection_mode,
-        IntrospectionMode::Enabled | IntrospectionMode::IntrospectionOnly | IntrospectionMode::IntrospectioTypeNamenOnly ,
+        IntrospectionMode::Enabled | IntrospectionMode::IntrospectionOnly | IntrospectionMode::IntrospectioTypeNameOnly ,
     ) {
         fields.push(
             async move {

--- a/src/dynamic/schema.rs
+++ b/src/dynamic/schema.rs
@@ -119,6 +119,13 @@ impl SchemaBuilder {
         self
     }
 
+    /// Enable introspection for __typename field for queries.
+    #[must_use]
+    pub fn introspection_type_name_only(mut self) -> Self {
+        self.introspection_mode = IntrospectionMode::IntrospectioTypeNamenOnly;
+        self
+    }
+
     /// Only process introspection queries, everything else is processed as an
     /// error.
     #[must_use]

--- a/src/dynamic/schema.rs
+++ b/src/dynamic/schema.rs
@@ -122,7 +122,7 @@ impl SchemaBuilder {
     /// Enable introspection for __typename field for queries.
     #[must_use]
     pub fn introspection_type_name_only(mut self) -> Self {
-        self.introspection_mode = IntrospectionMode::IntrospectioTypeNamenOnly;
+        self.introspection_mode = IntrospectionMode::IntrospectioTypeNameOnly;
         self
     }
 

--- a/src/dynamic/schema.rs
+++ b/src/dynamic/schema.rs
@@ -122,7 +122,7 @@ impl SchemaBuilder {
     /// Enable introspection for __typename field for queries.
     #[must_use]
     pub fn introspection_type_name_only(mut self) -> Self {
-        self.introspection_mode = IntrospectionMode::IntrospectioTypeNameOnly;
+        self.introspection_mode = IntrospectionMode::IntrospectTypeNameOnly;
         self
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -99,6 +99,13 @@ impl Request {
         self
     }
 
+    /// Enable introspection for __typename field for queries.
+    #[must_use]
+    pub fn introspection_type_name_only(mut self) -> Self {
+        self.introspection_mode = IntrospectionMode::IntrospectioTypeNamenOnly;
+        self
+    }
+
     /// Only allow introspection queries for this request.
     #[must_use]
     pub fn only_introspection(mut self) -> Self {

--- a/src/request.rs
+++ b/src/request.rs
@@ -102,7 +102,7 @@ impl Request {
     /// Enable introspection for __typename field for queries.
     #[must_use]
     pub fn introspection_type_name_only(mut self) -> Self {
-        self.introspection_mode = IntrospectionMode::IntrospectioTypeNameOnly;
+        self.introspection_mode = IntrospectionMode::IntrospectTypeNameOnly;
         self
     }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -102,7 +102,7 @@ impl Request {
     /// Enable introspection for __typename field for queries.
     #[must_use]
     pub fn introspection_type_name_only(mut self) -> Self {
-        self.introspection_mode = IntrospectionMode::IntrospectioTypeNamenOnly;
+        self.introspection_mode = IntrospectionMode::IntrospectioTypeNameOnly;
         self
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -33,7 +33,7 @@ pub enum IntrospectionMode {
     /// Introspection only
     IntrospectionOnly,
     /// Introspection of __typename only
-    IntrospectioTypeNamenOnly,
+    IntrospectioTypeNameOnly,
     /// Enables introspection
     #[default]
     Enabled,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -33,7 +33,7 @@ pub enum IntrospectionMode {
     /// Introspection only
     IntrospectionOnly,
     /// Introspection of __typename only
-    IntrospectioTypeNameOnly,
+    IntrospectTypeNameOnly,
     /// Enables introspection
     #[default]
     Enabled,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -32,6 +32,8 @@ use crate::{
 pub enum IntrospectionMode {
     /// Introspection only
     IntrospectionOnly,
+    /// Introspection of __typename only
+    IntrospectioTypeNamenOnly,
     /// Enables introspection
     #[default]
     Enabled,


### PR DESCRIPTION
Issue: https://github.com/async-graphql/async-graphql/issues/1465

As described in the linked issue, `__typename` field is null when introspection is disabled for dynamic schema. This is blocking us right now.