### PR TITLE
Preserve underscore when renaming field

### DIFF
--- a/tests/federation.rs
+++ b/tests/federation.rs
@@ -268,7 +268,7 @@ pub async fn test_entity_union() {
     #[Object]
     impl Query {
         #[graphql(entity)]
-        async fn find_obj(&self, _id: i32) -> MyObj {
+        async fn find_obj(&self, #[graphql(name = "id")] _id: i32) -> MyObj {
             todo!()
         }
     }
@@ -308,11 +308,14 @@ pub async fn test_entity_shareable() {
     #[Object(extends)]
     impl Query {
         #[graphql(entity)]
-        async fn find_obj_field_shareable(&self, _id: i32) -> MyObjFieldShareable {
+        async fn find_obj_field_shareable(
+            &self,
+            #[graphql(name = "id")] _id: i32,
+        ) -> MyObjFieldShareable {
             todo!()
         }
         #[graphql(entity)]
-        async fn find_obj_shareable(&self, _id: i32) -> MyObjShareable {
+        async fn find_obj_shareable(&self, #[graphql(name = "id")] _id: i32) -> MyObjShareable {
             todo!()
         }
     }
@@ -337,7 +340,10 @@ pub async fn test_field_override_directive() {
     #[Object(extends)]
     impl Query {
         #[graphql(entity)]
-        async fn find_obj_field_override(&self, _id: i32) -> MyObjFieldOverride {
+        async fn find_obj_field_override(
+            &self,
+            #[graphql(name = "id")] _id: i32,
+        ) -> MyObjFieldOverride {
             todo!()
         }
     }
@@ -447,29 +453,41 @@ pub async fn test_entity_inaccessible() {
     #[Object(extends)]
     impl Query {
         #[graphql(entity)]
-        async fn find_obj_field_inaccessible(&self, _id: i32) -> MyObjFieldInaccessible {
+        async fn find_obj_field_inaccessible(
+            &self,
+            #[graphql(name = "id")] _id: i32,
+        ) -> MyObjFieldInaccessible {
             todo!()
         }
 
         #[graphql(entity)]
-        async fn find_obj_inaccessible(&self, _id: i32) -> MyObjInaccessible {
+        async fn find_obj_inaccessible(
+            &self,
+            #[graphql(name = "id")] _id: i32,
+        ) -> MyObjInaccessible {
             todo!()
         }
 
-        async fn enum_variant_inaccessible(&self, _id: i32) -> MyEnumVariantInaccessible {
+        async fn enum_variant_inaccessible(
+            &self,
+            #[graphql(name = "id")] _id: i32,
+        ) -> MyEnumVariantInaccessible {
             todo!()
         }
 
-        async fn enum_inaccessible(&self, _id: i32) -> MyEnumInaccessible {
+        async fn enum_inaccessible(&self, #[graphql(name = "id")] _id: i32) -> MyEnumInaccessible {
             todo!()
         }
 
         #[graphql(inaccessible)]
-        async fn inaccessible_field(&self, _id: i32) -> i32 {
+        async fn inaccessible_field(&self, #[graphql(name = "id")] _id: i32) -> i32 {
             todo!()
         }
 
-        async fn inaccessible_argument(&self, #[graphql(inaccessible)] _id: i32) -> i32 {
+        async fn inaccessible_argument(
+            &self,
+            #[graphql(inaccessible, name = "id")] _id: i32,
+        ) -> i32 {
             todo!()
         }
 
@@ -485,11 +503,17 @@ pub async fn test_entity_inaccessible() {
             todo!()
         }
 
-        async fn inaccessible_input_field(&self, _value: MyInputObjFieldInaccessible) -> i32 {
+        async fn inaccessible_input_field(
+            &self,
+            #[graphql(name = "value")] _value: MyInputObjFieldInaccessible,
+        ) -> i32 {
             todo!()
         }
 
-        async fn inaccessible_input(&self, _value: MyInputObjInaccessible) -> i32 {
+        async fn inaccessible_input(
+            &self,
+            #[graphql(name = "value")] _value: MyInputObjInaccessible,
+        ) -> i32 {
             todo!()
         }
 
@@ -729,29 +753,38 @@ pub async fn test_entity_tag() {
     #[Object(extends)]
     impl Query {
         #[graphql(entity)]
-        async fn find_obj_field_tagged(&self, _id: i32) -> MyObjFieldTagged {
+        async fn find_obj_field_tagged(
+            &self,
+            #[graphql(name = "id")] _id: i32,
+        ) -> MyObjFieldTagged {
             todo!()
         }
 
         #[graphql(entity)]
-        async fn find_obj_tagged(&self, _id: i32) -> MyObjTagged {
+        async fn find_obj_tagged(&self, #[graphql(name = "id")] _id: i32) -> MyObjTagged {
             todo!()
         }
 
-        async fn enum_variant_tagged(&self, _id: i32) -> MyEnumVariantTagged {
+        async fn enum_variant_tagged(
+            &self,
+            #[graphql(name = "id")] _id: i32,
+        ) -> MyEnumVariantTagged {
             todo!()
         }
 
-        async fn enum_tagged(&self, _id: i32) -> MyEnumTagged {
+        async fn enum_tagged(&self, #[graphql(name = "id")] _id: i32) -> MyEnumTagged {
             todo!()
         }
 
         #[graphql(tag = "tagged_\"field\"")]
-        async fn tagged_field(&self, _id: i32) -> i32 {
+        async fn tagged_field(&self, #[graphql(name = "id")] _id: i32) -> i32 {
             todo!()
         }
 
-        async fn tagged_argument(&self, #[graphql(tag = "tagged_argument")] _id: i32) -> i32 {
+        async fn tagged_argument(
+            &self,
+            #[graphql(tag = "tagged_argument", name = "id")] _id: i32,
+        ) -> i32 {
             todo!()
         }
 
@@ -767,11 +800,14 @@ pub async fn test_entity_tag() {
             todo!()
         }
 
-        async fn tagged_input_field(&self, _value: MyInputObjFieldTagged) -> i32 {
+        async fn tagged_input_field(
+            &self,
+            #[graphql(name = "value")] _value: MyInputObjFieldTagged,
+        ) -> i32 {
             todo!()
         }
 
-        async fn tagged_input(&self, _value: MyInputObjTagged) -> i32 {
+        async fn tagged_input(&self, #[graphql(name = "value")] _value: MyInputObjTagged) -> i32 {
             todo!()
         }
 
@@ -862,17 +898,23 @@ pub async fn test_interface_object() {
     #[Object(extends)]
     impl Query {
         #[graphql(entity)]
-        async fn my_interface(&self, _id: u64) -> MyInterface {
+        async fn my_interface(&self, #[graphql(name = "id")] _id: u64) -> MyInterface {
             todo!()
         }
 
         #[graphql(entity)]
-        async fn my_interface_object1(&self, _id: u64) -> MyInterfaceObject1 {
+        async fn my_interface_object1(
+            &self,
+            #[graphql(name = "id")] _id: u64,
+        ) -> MyInterfaceObject1 {
             todo!()
         }
 
         #[graphql(entity)]
-        async fn my_interface_object2(&self, _id: u64) -> MyInterfaceObject2 {
+        async fn my_interface_object2(
+            &self,
+            #[graphql(name = "id")] _id: u64,
+        ) -> MyInterfaceObject2 {
             todo!()
         }
     }
@@ -942,24 +984,38 @@ pub async fn test_unresolvable_entity() {
 
     #[Object]
     impl Query {
-        async fn simple_explicit_reference(&self, _id: u64) -> SimpleExplicitUnresolvable {
+        async fn simple_explicit_reference(
+            &self,
+            #[graphql(name = "id")] _id: u64,
+        ) -> SimpleExplicitUnresolvable {
             todo!()
         }
 
-        async fn simple_implicit_reference(&self, _a: u64) -> SimpleImplicitUnresolvable {
+        async fn simple_implicit_reference(
+            &self,
+            #[graphql(name = "a")] _a: u64,
+        ) -> SimpleImplicitUnresolvable {
             todo!()
         }
 
-        async fn explicit_reference(&self, _id1: u64, _id2: u64) -> ExplicitUnresolvable {
+        async fn explicit_reference(
+            &self,
+            #[graphql(name = "id1")] _id1: u64,
+            #[graphql(name = "id2")] _id2: u64,
+        ) -> ExplicitUnresolvable {
             todo!()
         }
 
-        async fn implicit_unresolvable(&self, _a: String, _b: bool) -> ImplicitUnresolvable {
+        async fn implicit_unresolvable(
+            &self,
+            #[graphql(name = "a")] _a: String,
+            #[graphql(name = "b")] _b: bool,
+        ) -> ImplicitUnresolvable {
             todo!()
         }
 
         #[graphql(entity)]
-        async fn object_entity(&self, _id: u64) -> ResolvableObject {
+        async fn object_entity(&self, #[graphql(name = "id")] _id: u64) -> ResolvableObject {
             todo!()
         }
     }

--- a/tests/input_value.rs
+++ b/tests/input_value.rs
@@ -8,7 +8,7 @@ pub async fn test_input_value_custom_error() {
 
     #[Object]
     impl Query {
-        async fn parse_int(&self, _n: i8) -> bool {
+        async fn parse_int(&self, #[graphql(name = "n")] _n: i8) -> bool {
             true
         }
     }

--- a/tests/introspection.rs
+++ b/tests/introspection.rs
@@ -160,7 +160,10 @@ impl Mutation {
     /// simple_mutation description
     /// line2
     /// line3
-    async fn simple_mutation(&self, _input: SimpleInput) -> SimpleObject {
+    async fn simple_mutation(
+        &self,
+        #[graphql(name = "input")] _input: SimpleInput,
+    ) -> SimpleObject {
         unimplemented!()
     }
 }
@@ -1539,7 +1542,7 @@ pub async fn test_introspection_directives() {
           }
         }
       }
-      
+
       fragment InputValue on __InputValue {
         name
         type {
@@ -1547,7 +1550,7 @@ pub async fn test_introspection_directives() {
         }
         defaultValue
       }
-      
+
       fragment TypeRef on __Type {
         kind
         name

--- a/tests/type_directive.rs
+++ b/tests/type_directive.rs
@@ -145,12 +145,13 @@ fn test_type_directive_2() {
     #[ComplexObject]
     impl TestComplexObject {
         #[graphql(directive = type_directive_field_definition::apply("This is FIELD_DEFINITION in ComplexObject".to_string()))]
+        #[allow(unused_variables)]
         async fn test(
             &self,
             #[graphql(directive = type_directive_argument_definition::apply("This is ARGUMENT_DEFINITION in ComplexObject.arg1".to_string()))]
-            _arg1: String,
+            arg1: String,
             #[graphql(directive = type_directive_argument_definition::apply("This is ARGUMENT_DEFINITION in ComplexObject.arg2".to_string()))]
-            _arg2: String,
+            arg2: String,
         ) -> &'static str {
             "test"
         }
@@ -169,12 +170,13 @@ fn test_type_directive_2() {
 
     #[Object]
     impl TestObjectForInterface {
+        #[allow(unused_variables)]
         async fn field(
             &self,
             #[graphql(directive = type_directive_argument_definition::apply("This is ARGUMENT_DEFINITION in Interface.arg1".to_string()))]
-            _arg1: String,
+            arg1: String,
             #[graphql(directive = type_directive_argument_definition::apply("This is ARGUMENT_DEFINITION in Interface.arg2".to_string()))]
-            _arg2: String,
+            arg2: String,
         ) -> &'static str {
             "hello"
         }
@@ -186,12 +188,12 @@ fn test_type_directive_2() {
             ty = "String",
             directive = type_directive_field_definition::apply("This is INTERFACE in Interface".to_string()),
             arg(
-                name = "_arg1",
+                name = "arg1",
                 ty = "String",
                 directive = type_directive_argument_definition::apply("This is ARGUMENT_DEFINITION in Interface.arg1".to_string())
             ),
             arg(
-                name = "_arg2",
+                name = "arg2",
                 ty = "String",
                 directive = type_directive_argument_definition::apply("This is ARGUMENT_DEFINITION in Interface.arg2".to_string())
             )
@@ -206,17 +208,21 @@ fn test_type_directive_2() {
 
     #[Object]
     impl Query {
+        #[allow(unused_variables)]
         pub async fn test_argument(
             &self,
             #[graphql(directive = type_directive_argument_definition::apply("This is ARGUMENT_DEFINITION in Object.arg1".to_string()))]
-            _arg1: String,
+            arg1: String,
             #[graphql(directive = type_directive_argument_definition::apply("This is ARGUMENT_DEFINITION in Object.arg2".to_string()))]
-            _arg2: String,
+            arg2: String,
         ) -> &'static str {
             "hello"
         }
 
-        pub async fn test_input_object(&self, _arg: TestInput) -> &'static str {
+        pub async fn test_input_object(
+            &self,
+            #[graphql(name = "arg")] _arg: TestInput,
+        ) -> &'static str {
             "hello"
         }
 
@@ -232,11 +238,14 @@ fn test_type_directive_2() {
             }
         }
 
-        pub async fn test_one_of_object(&self, _arg: TestOneOfObject) -> &'static str {
+        pub async fn test_one_of_object(
+            &self,
+            #[graphql(name = "arg")] _arg: TestOneOfObject,
+        ) -> &'static str {
             "hello"
         }
 
-        pub async fn test_enum(&self, _arg: TestEnum) -> &'static str {
+        pub async fn test_enum(&self, #[graphql(name = "arg")] _arg: TestEnum) -> &'static str {
             "hello"
         }
 


### PR DESCRIPTION
Fixes https://github.com/async-graphql/async-graphql/issues/1698

I had to change a bunch of places that relied on variable names with underscores not being preserved.

So technically I think this is a breaking change - but I also think it was a bug to not preserve the underscore.

What do you think?