### PR TITLE
use preferred mime-type

### DIFF
--- a/integrations/actix-web/src/request.rs
+++ b/integrations/actix-web/src/request.rs
@@ -216,7 +216,7 @@ impl Responder for GraphQLResponse {
                 },
             ),
             _ => (
-                "application/json",
+                "application/graphql-response+json",
                 match serde_json::to_vec(&self.0) {
                     Ok(body) => body,
                     Err(e) => return HttpResponse::from_error(JsonPayloadError::Serialize(e)),

--- a/integrations/axum/src/response.rs
+++ b/integrations/axum/src/response.rs
@@ -29,7 +29,7 @@ impl IntoResponse for GraphQLResponse {
         let mut resp = Response::new(body);
         resp.headers_mut().insert(
             http::header::CONTENT_TYPE,
-            HeaderValue::from_static("application/json"),
+            HeaderValue::from_static("application/graphql-response+json"),
         );
         if self.0.is_ok() {
             if let Some(cache_control) = self.0.cache_control().value() {

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -97,7 +97,7 @@ pub async fn receive_batch_body(
     let content_type = content_type
         .as_ref()
         .map(AsRef::as_ref)
-        .unwrap_or("application/json");
+        .unwrap_or("application/graphql-response+json");
 
     let content_type: mime::Mime = content_type.parse()?;
 


### PR DESCRIPTION
This is a simple patch that replaces the `application/json` mime-type with the preferred `application/graphql-response+json` for graphql responses.

Closes #1708