### PR TITLE
WIP: Wrap the `Upload` buffer with an AsyncRead cursor (fix #1263)

### DIFF
--- a/src/types/upload.rs
+++ b/src/types/upload.rs
@@ -74,7 +74,7 @@ impl UploadValue {
 
         #[cfg(not(feature = "tempfile"))]
         {
-            std::io::Cursor::new(self.content)
+            futures_util::io::Cursor::new(self.content)
         }
     }
 


### PR DESCRIPTION
This crate when being compiled with:
- `unblock` feature on
- `tempfile` feature off

Gets an error message:
> std::io::Cursor::new(self.content)
> the trait `AsyncRead` is not implemented for `std::io::Cursor<bytes::Bytes>`

Lucky us, `futures_util` has a wrapper type just for that.