### PR TITLE
Switch from `Inflector` to `convert_case`

### DIFF
--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -20,7 +20,7 @@ boxed-trait = []
 [dependencies]
 async-graphql-parser.workspace = true
 
-Inflector = "0.11.4"
+convert_case = "0.8.0"
 darling = "0.20.10"
 proc-macro-crate = "3.1.0"
 proc-macro2 = "1.0.79"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -28,3 +28,6 @@ quote = "1.0.35"
 syn = { version = "2.0", features = ["extra-traits", "visit-mut", "visit"] }
 thiserror.workspace = true
 strum = { version = "0.26.2", features = ["derive"] }
+
+[dev-dependencies]
+Inflector = "0.11.4"

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -859,12 +859,57 @@ pub enum RenameRule {
 impl RenameRule {
     fn rename(&self, name: impl AsRef<str>) -> String {
         match self {
-            Self::Lower => name.as_ref().to_case(Case::Lower),
-            Self::Upper => name.as_ref().to_case(Case::Upper),
+            Self::Lower => name.as_ref().to_lowercase(),
+            Self::Upper => name.as_ref().to_uppercase(),
             Self::Pascal => name.as_ref().to_case(Case::Pascal),
             Self::Camel => name.as_ref().to_case(Case::Camel),
             Self::Snake => name.as_ref().to_case(Case::Snake),
             Self::ScreamingSnake => name.as_ref().to_case(Case::UpperSnake),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_rename_rule_transition_to_convert_case {
+    use super::RenameRule;
+    use inflector::Inflector;
+
+    impl RenameRule {
+        /// Before `convert_case`, the `Inflector` crate was used for renames,
+        /// and this was the previous implementation of `RenameRule::rename`.
+        fn rename_with_inflector(&self, name: impl AsRef<str>) -> String {
+            match self {
+                Self::Lower => name.as_ref().to_lowercase(),
+                Self::Upper => name.as_ref().to_uppercase(),
+                Self::Pascal => name.as_ref().to_pascal_case(),
+                Self::Camel => name.as_ref().to_camel_case(),
+                Self::Snake => name.as_ref().to_snake_case(),
+                Self::ScreamingSnake => name.as_ref().to_screaming_snake_case(),
+            }
+        }
+    }
+
+    #[test]
+    fn test_convert_case_vs_inflector() {
+        let inputs = [
+            "foobar", "foo_bar", "FooBar", "fooBar", "FOOBAR", "FOO_BAR", "foo-bar", "FOO-BAR",
+            "Foo-Bar", "foo bar", "Foo Bar",
+        ];
+        let rules = [
+            RenameRule::Lower,
+            RenameRule::Upper,
+            RenameRule::Pascal,
+            RenameRule::Camel,
+            RenameRule::Snake,
+            RenameRule::ScreamingSnake,
+        ];
+
+        for input in inputs {
+            for rule in rules {
+                let expected = rule.rename_with_inflector(input);
+                let observed = rule.rename(input);
+                assert_eq!(expected, observed, "input {:?}; rule {:?}", input, rule);
+            }
         }
     }
 }

--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -1,11 +1,11 @@
 #![allow(dead_code)]
 
+use convert_case::{Case, Casing};
 use darling::{
     FromDeriveInput, FromField, FromMeta, FromVariant,
     ast::{Data, Fields, NestedMeta},
     util::{Ignored, SpannedValue},
 };
-use inflector::Inflector;
 use quote::format_ident;
 use syn::{
     Attribute, Expr, GenericParam, Generics, Ident, Lit, LitBool, LitStr, Meta, Path, Type,
@@ -859,12 +859,12 @@ pub enum RenameRule {
 impl RenameRule {
     fn rename(&self, name: impl AsRef<str>) -> String {
         match self {
-            Self::Lower => name.as_ref().to_lowercase(),
-            Self::Upper => name.as_ref().to_uppercase(),
-            Self::Pascal => name.as_ref().to_pascal_case(),
-            Self::Camel => name.as_ref().to_camel_case(),
-            Self::Snake => name.as_ref().to_snake_case(),
-            Self::ScreamingSnake => name.as_ref().to_screaming_snake_case(),
+            Self::Lower => name.as_ref().to_case(Case::Lower),
+            Self::Upper => name.as_ref().to_case(Case::Upper),
+            Self::Pascal => name.as_ref().to_case(Case::Pascal),
+            Self::Camel => name.as_ref().to_case(Case::Camel),
+            Self::Snake => name.as_ref().to_case(Case::Snake),
+            Self::ScreamingSnake => name.as_ref().to_case(Case::UpperSnake),
         }
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -138,6 +138,7 @@ impl<Query, Mutation, Subscription> SchemaBuilder<Query, Mutation, Subscription>
     ///     }
     /// }
     ///
+    /// #[cfg(feature = "log")]
     /// let schema = Schema::build(Query, EmptyMutation, EmptySubscription)
     ///     .extension(extensions::Logger)
     ///     .finish();

--- a/tests/federation.rs
+++ b/tests/federation.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "dataloader")]
 #![allow(unreachable_code)]
 #![allow(dead_code)]
 #![allow(clippy::diverging_sub_expression)]

--- a/tests/introspection.rs
+++ b/tests/introspection.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "chrono")]
 #![allow(clippy::uninlined_format_args)]
 #![allow(clippy::diverging_sub_expression)]
 

--- a/tests/serializer_uuid.rs
+++ b/tests/serializer_uuid.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "uuid")]
+
 use async_graphql::*;
 use serde::{Deserialize, Serialize};
 

--- a/tests/use_type_description.rs
+++ b/tests/use_type_description.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "chrono")]
 #![allow(clippy::diverging_sub_expression)]
 
 use async_graphql::*;


### PR DESCRIPTION
`Inflector` is abandoned; its [repository](https://github.com/whatisinternet/inflector) was archived Oct 7, 2024.

This also gets `cargo test` passing with default features.
