### PR TITLE
Don't double box subscription streams

### DIFF
--- a/src/dynamic/schema.rs
+++ b/src/dynamic/schema.rs
@@ -1,7 +1,7 @@
 use std::{any::Any, collections::HashMap, fmt::Debug, sync::Arc};
 
 use async_graphql_parser::types::OperationType;
-use futures_util::{Stream, StreamExt, TryFutureExt, stream::BoxStream};
+use futures_util::{StreamExt, TryFutureExt, stream::BoxStream};
 use indexmap::IndexMap;
 
 use crate::{
@@ -410,7 +410,7 @@ impl Schema {
         &self,
         request: impl Into<DynamicRequest>,
         session_data: Arc<Data>,
-    ) -> impl Stream<Item = Response> + Send + Unpin + 'static {
+    ) -> BoxStream<'static, Response> {
         let schema = self.clone();
         let request = request.into();
         let extensions = self.create_extensions(session_data.clone());
@@ -473,7 +473,7 @@ impl Schema {
     pub fn execute_stream(
         &self,
         request: impl Into<DynamicRequest>,
-    ) -> impl Stream<Item = Response> + Send + Unpin {
+    ) -> BoxStream<'static, Response> {
         self.execute_stream_with_session_data(request, Default::default())
     }
 
@@ -495,7 +495,6 @@ impl Executor for Schema {
         session_data: Option<Arc<Data>>,
     ) -> BoxStream<'static, Response> {
         Schema::execute_stream_with_session_data(self, request, session_data.unwrap_or_default())
-            .boxed()
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use async_graphql_parser::types::ExecutableDocument;
-use futures_util::stream::{self, BoxStream, FuturesOrdered, Stream, StreamExt};
+use futures_util::stream::{self, BoxStream, FuturesOrdered, StreamExt};
 
 use crate::{
     BatchRequest, BatchResponse, CacheControl, ContextBase, EmptyMutation, EmptySubscription,
@@ -574,7 +574,7 @@ where
         &self,
         request: impl Into<Request>,
         session_data: Arc<Data>,
-    ) -> impl Stream<Item = Response> + Send + Unpin + 'static {
+    ) -> BoxStream<'static, Response> {
         let schema = self.clone();
         let request = request.into();
         let extensions = self.create_extensions(session_data.clone());
@@ -642,10 +642,7 @@ where
     }
 
     /// Execute a GraphQL subscription.
-    pub fn execute_stream(
-        &self,
-        request: impl Into<Request>,
-    ) -> impl Stream<Item = Response> + Send + Unpin {
+    pub fn execute_stream(&self, request: impl Into<Request>) -> BoxStream<'static, Response> {
         self.execute_stream_with_session_data(request, Default::default())
     }
 }
@@ -667,7 +664,6 @@ where
         session_data: Option<Arc<Data>>,
     ) -> BoxStream<'static, Response> {
         Schema::execute_stream_with_session_data(&self, request, session_data.unwrap_or_default())
-            .boxed()
     }
 }
 


### PR DESCRIPTION
Constructing a new stream internally will produce a boxed stream, except the type signatures were written as returning `impl Stream` which requires calling `.boxed()` another time (when implementing `Executor`) to satisfy the type system, but it results in two allocations (and two pointer chases during polling) at runtime unnecessarily