### PR TITLE
fix: repeatable Directive Output in SDL Generation

### DIFF
--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -775,6 +775,11 @@ impl MetaDirective {
             .map(|location| location.to_value().to_string())
             .collect::<Vec<_>>()
             .join(" | ");
+
+        if self.is_repeatable {
+            write!(sdl, " repeatable").ok();
+        }
+
         write!(sdl, " on {}", locations).ok();
         sdl
     }
@@ -1678,7 +1683,9 @@ fn is_system_type(name: &str) -> bool {
 
 #[cfg(test)]
 mod test {
-    use crate::registry::MetaDirectiveInvocation;
+    use crate::SDLExportOptions;
+    use crate::registry::MetaDirective;
+    use crate::registry::{__DirectiveLocation, MetaDirectiveInvocation};
 
     #[test]
     fn test_directive_invocation_dsl() {
@@ -1694,6 +1701,46 @@ mod test {
                 .into(),
             }
             .sdl()
+        )
+    }
+
+    #[test]
+    fn test_repeatable_directive_dsl() {
+        let expected = r#"directive @testDirective repeatable on OBJECT | INTERFACE"#;
+        let export_options = SDLExportOptions::default();
+
+        assert_eq!(
+            expected.to_string(),
+            MetaDirective {
+                name: "testDirective".to_string(),
+                description: None,
+                locations: vec![__DirectiveLocation::OBJECT, __DirectiveLocation::INTERFACE,],
+                args:Default::default(),
+                is_repeatable: true,
+                visible: None,
+                composable: None,
+            }
+            .sdl(&export_options)
+        )
+    }
+
+    #[test]
+    fn test_non_repeatable_directive_dsl() {
+        let expected = r#"directive @testDirective on OBJECT | INTERFACE"#;
+        let export_options = SDLExportOptions::default();
+
+        assert_eq!(
+            expected.to_string(),
+            MetaDirective {
+                name: "testDirective".to_string(),
+                description: None,
+                locations: vec![__DirectiveLocation::OBJECT, __DirectiveLocation::INTERFACE,],
+                args:Default::default(),
+                is_repeatable: false,
+                visible: None,
+                composable: None,
+            }
+                .sdl(&export_options)
         )
     }
 }


### PR DESCRIPTION
### Summary

This PR corrects the SDL (Schema Definition Language) output for directives that are marked as **repeatable**.

### Details

- Ensures that the keyword `repeatable` is correctly included in the directive SDL representation when `is_repeatable` is set to `true`.
- The output now conforms to the GraphQL specification for repeatable directives.

### Additions

- Added unit tests to verify correct SDL rendering:
  - ✅ `test_repeatable_directive_dsl`
  - ✅ `test_non_repeatable_directive_dsl`

### Motivation

Previously, the SDL output omitted the `repeatable` keyword even when the directive was defined as repeatable. This led to incorrect or incomplete schema definitions. With this fix, the SDL generation is now accurate and spec-compliant.