### PR TITLE
Add From Option<T> impl for ConstValue

### DIFF
--- a/value/src/lib.rs
+++ b/value/src/lib.rs
@@ -263,6 +263,16 @@ impl<'a> From<Cow<'a, str>> for ConstValue {
     }
 }
 
+impl<T: Into<ConstValue>> From<Option<T>> for ConstValue {
+    #[inline]
+    fn from(nullable: Option<T>) -> Self {
+        match nullable {
+            Some(value) => value.into(),
+            None => ConstValue::Null,
+        }
+    }
+}
+
 impl<T: Into<ConstValue>> FromIterator<T> for ConstValue {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         ConstValue::List(iter.into_iter().map(Into::into).collect())


### PR DESCRIPTION
This allows users of the dynamic schema creation method to just use the same syntax for `Option<T>` as for `T`, which is especially handy for lists with nullable items.

Example
```rust
// ...
Ok(Some(Value::from(vec![Some(char.id), None])))
```