### PR TITLE
fix: match Schema::execute_stream_with_session_data constraints

### DIFF
--- a/src/dynamic/schema.rs
+++ b/src/dynamic/schema.rs
@@ -473,7 +473,7 @@ impl Schema {
     pub fn execute_stream(
         &self,
         request: impl Into<DynamicRequest>,
-    ) -> impl Stream<Item = Response> + Send + Unpin {
+    ) -> impl Stream<Item = Response> + Send + Unpin + 'static {
         self.execute_stream_with_session_data(request, Default::default())
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -645,7 +645,7 @@ where
     pub fn execute_stream(
         &self,
         request: impl Into<Request>,
-    ) -> impl Stream<Item = Response> + Send + Unpin {
+    ) -> impl Stream<Item = Response> + Send + Unpin + 'static {
         self.execute_stream_with_session_data(request, Default::default())
     }
 }


### PR DESCRIPTION
In https://github.com/async-graphql/async-graphql/commit/07c9b985d474673bd0c0fdec37f7b03a389e2906, both versions of `Schema::execute_stream_with_session_data` added a `'static` lifetime constraint to the return type. The `Schema::execute_stream` function calls through to that with `Default::default()` for the session data parameter, but it doesn't have the same `'static` lifetime constraint, so the borrow checker doesn't like it, for example:

```
|                 let stream = span.in_scope(move || schema.execute_stream(request).fuse());
|                                                    ------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
|                                                    |
|                                                    returns a value referencing data owned by the current function
|                                                    `schema` is borrowed here
|
```

I was able to workaround the change by replacing my call to `execute_stream` with `execute_stream_with_session_data` and passing `Default::default()` for the session data myself, but I'd rather switch back to `execute_stream` for the sake of brevity.