### PR TITLE
Introduce serialization for `u128` and `i128` via `serde_json/arbitrary_precision`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ raw_value = ["async-graphql-value/raw_value"]
 uuid-validator = ["uuid"]
 boxed-trait = ["async-graphql-derive/boxed-trait"]
 custom-error-conversion = []
+arbitrary_precision = ["async-graphql-value/arbitrary_precision"]
 
 [[bench]]
 harness = false

--- a/value/Cargo.toml
+++ b/value/Cargo.toml
@@ -19,3 +19,4 @@ indexmap.workspace = true
 
 [features]
 raw_value = ["serde_json/raw_value"]
+arbitrary_precision = ["serde_json/arbitrary_precision"]

--- a/value/src/serializer.rs
+++ b/value/src/serializer.rs
@@ -77,6 +77,11 @@ impl ser::Serializer for Serializer {
         Ok(ConstValue::Number(v.into()))
     }
 
+    #[cfg(feature = "arbitrary_precision")]
+    fn serialize_i128(self, v: i128) -> Result<Self::Ok, Self::Error> {
+        Ok(ConstValue::Number(v.into()))
+    }
+
     #[inline]
     fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
         Ok(ConstValue::Number(v.into()))
@@ -94,6 +99,11 @@ impl ser::Serializer for Serializer {
 
     #[inline]
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(ConstValue::Number(v.into()))
+    }
+
+    #[cfg(feature = "arbitrary_precision")]
+    fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
         Ok(ConstValue::Number(v.into()))
     }
 


### PR DESCRIPTION
This PR adds serializer functions to support `u128` and `i128`. The new functionality is feature-gated under `arbitrary_precision`, which also enables `serde_json/arbitrary_precision` to avoid lossy conversion when targeting JSON.

Deserializer changes are not required: the present deserializer _already_ accepts `u128` and `i128` via [the existing forwarding macro](https://github.com/async-graphql/async-graphql/blob/082201ccd040726410ac1b8a6cf6dc4a1c5179ec/value/src/deserializer.rs#L125-L129):
```rust
forward_to_deserialize_any! {
    bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
    bytes byte_buf unit unit_struct seq tuple
    tuple_struct map struct identifier ignored_any
}
```