### PR TITLE
Implement Default, Clone, Copy for EmptyFields

### DIFF
--- a/src/types/connection/mod.rs
+++ b/src/types/connection/mod.rs
@@ -15,7 +15,7 @@ pub use page_info::PageInfo;
 use crate::{Error, ObjectType, OutputType, Result, SimpleObject};
 
 /// Empty additional fields
-#[derive(SimpleObject)]
+#[derive(Default, Copy, Clone, SimpleObject)]
 #[graphql(internal, fake)]
 pub struct EmptyFields;
 
@@ -258,7 +258,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// 
+///
 /// use async_graphql::*;
 /// use async_graphql::types::connection::*;
 ///


### PR DESCRIPTION
This adds implementations of Default, Clone, and Copy to `EmptyFields`, making it consistent with `EmptyMutation` and `EmptySubscription`.