### PR TITLE
fix: Guard on nullable field returns null instead of bubbling up

### DIFF
--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -548,7 +548,12 @@ pub fn generate(
                 .map_err(|err| err.into_server_error(ctx.item.pos))
             };
             let async_guard = match method_args.guard.as_ref().or(object_args.guard.as_ref()) {
-                Some(code) => Some(generate_guards(&crate_name, code, async_guard_map_err, false)?),
+                Some(code) => Some(generate_guards(
+                    &crate_name,
+                    code,
+                    async_guard_map_err,
+                    false,
+                )?),
                 None => None,
             };
 

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -14,8 +14,8 @@ use crate::{
     utils::{
         GeneratorResult, extract_input_args, gen_boxed_trait, gen_deprecation, gen_directive_calls,
         generate_default, generate_guards, get_cfg_attrs, get_crate_path, get_rustdoc,
-        get_type_path_and_name, parse_complexity_expr, parse_graphql_attrs, remove_graphql_attrs,
-        visible_fn,
+        get_type_path_and_name, is_option_type, parse_complexity_expr, parse_graphql_attrs,
+        remove_graphql_attrs, visible_fn,
     },
 };
 
@@ -539,31 +539,68 @@ pub fn generate(
                 }
             };
 
-            let guard_map_err = quote! {
+            let field_nullable = is_option_type(&schema_ty);
+
+            // For the async case, the guard lives inside `async move { ... }`, so
+            // it must always use the non-nullable `?` form.  Nullable error
+            // catching is done *after* the async block for the async path.
+            let async_guard_map_err = quote! {
                 .map_err(|err| err.into_server_error(ctx.item.pos))
             };
-            let guard = match method_args.guard.as_ref().or(object_args.guard.as_ref()) {
-                Some(code) => Some(generate_guards(&crate_name, code, guard_map_err)?),
+            let async_guard = match method_args.guard.as_ref().or(object_args.guard.as_ref()) {
+                Some(code) => Some(generate_guards(&crate_name, code, async_guard_map_err, false)?),
+                None => None,
+            };
+
+            // For the non-async case, the guard is at the resolve_field level,
+            // so the nullable form (if let Err …) works directly.
+            let sync_guard_map_err = quote! {
+                .map_err(|err| ctx.set_error_path(err.into_server_error(ctx.item.pos)))
+            };
+            let sync_guard = match method_args.guard.as_ref().or(object_args.guard.as_ref()) {
+                Some(code) => Some(generate_guards(&crate_name, code, sync_guard_map_err, field_nullable)?),
                 None => None,
             };
 
             let resolve_block = if is_async {
-                quote! {
-                    let f = async move {
-                        #(#get_params)*
-                        #guard
-                        #resolve_obj
-                    };
-                    let obj = f.await.map_err(|err| ctx.set_error_path(err))?;
-                    let ctx_obj = ctx.with_selection_set(&ctx.item.node.selection_set);
-                    return #crate_name::OutputType::resolve(&obj, &ctx_obj, ctx.item)
-                        .await
-                        .map(::std::option::Option::Some);
+                if field_nullable && async_guard.is_some() {
+                    quote! {
+                        let f = async move {
+                            #(#get_params)*
+                            #async_guard
+                            #resolve_obj
+                        };
+                        match f.await.map_err(|err| ctx.set_error_path(err)) {
+                            ::std::result::Result::Ok(obj) => {
+                                let ctx_obj = ctx.with_selection_set(&ctx.item.node.selection_set);
+                                return #crate_name::OutputType::resolve(&obj, &ctx_obj, ctx.item)
+                                    .await
+                                    .map(::std::option::Option::Some);
+                            }
+                            ::std::result::Result::Err(err) => {
+                                ctx.add_error(err);
+                                return ::std::result::Result::Ok(::std::option::Option::Some(#crate_name::Value::Null));
+                            }
+                        }
+                    }
+                } else {
+                    quote! {
+                        let f = async move {
+                            #(#get_params)*
+                            #async_guard
+                            #resolve_obj
+                        };
+                        let obj = f.await.map_err(|err| ctx.set_error_path(err))?;
+                        let ctx_obj = ctx.with_selection_set(&ctx.item.node.selection_set);
+                        return #crate_name::OutputType::resolve(&obj, &ctx_obj, ctx.item)
+                            .await
+                            .map(::std::option::Option::Some);
+                    }
                 }
             } else {
                 quote! {
                     #(#get_params)*
-                    #guard
+                    #sync_guard
                     let obj = #resolve_obj.map_err(|err| ctx.set_error_path(err))?;
                     return #crate_name::resolver_utils::resolve_simple_field_value(ctx, &obj).await;
                 }

--- a/derive/src/complex_object.rs
+++ b/derive/src/complex_object.rs
@@ -558,7 +558,12 @@ pub fn generate(
                 .map_err(|err| ctx.set_error_path(err.into_server_error(ctx.item.pos)))
             };
             let sync_guard = match method_args.guard.as_ref().or(object_args.guard.as_ref()) {
-                Some(code) => Some(generate_guards(&crate_name, code, sync_guard_map_err, field_nullable)?),
+                Some(code) => Some(generate_guards(
+                    &crate_name,
+                    code,
+                    sync_guard_map_err,
+                    field_nullable,
+                )?),
                 None => None,
             };
 

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -14,8 +14,8 @@ use crate::{
     utils::{
         GeneratorResult, extract_input_args, gen_boxed_trait, gen_deprecation, gen_directive_calls,
         generate_default, generate_guards, get_cfg_attrs, get_crate_path, get_rustdoc,
-        get_type_path_and_name, parse_complexity_expr, parse_graphql_attrs, remove_graphql_attrs,
-        visible_fn,
+        get_type_path_and_name, is_option_type, parse_complexity_expr, parse_graphql_attrs,
+        remove_graphql_attrs, visible_fn,
     },
     validators::Validators,
 };
@@ -685,8 +685,9 @@ pub fn generate(
                 let guard_map_err = quote! {
                     .map_err(|err| ctx.set_error_path(err.into_server_error(ctx.item.pos)))
                 };
+                let field_nullable = is_option_type(&schema_ty);
                 let guard = match method_args.guard.as_ref().or(object_args.guard.as_ref()) {
-                    Some(code) => generate_guards(&crate_name, code, guard_map_err)?,
+                    Some(code) => generate_guards(&crate_name, code, guard_map_err, field_nullable)?,
                     None => Default::default(),
                 };
 

--- a/derive/src/object.rs
+++ b/derive/src/object.rs
@@ -687,7 +687,9 @@ pub fn generate(
                 };
                 let field_nullable = is_option_type(&schema_ty);
                 let guard = match method_args.guard.as_ref().or(object_args.guard.as_ref()) {
-                    Some(code) => generate_guards(&crate_name, code, guard_map_err, field_nullable)?,
+                    Some(code) => {
+                        generate_guards(&crate_name, code, guard_map_err, field_nullable)?
+                    }
                     None => Default::default(),
                 };
 

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -326,7 +326,12 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
         };
         let field_nullable = is_option_type(ty);
         let guard = match field.guard.as_ref().or(object_args.guard.as_ref()) {
-            Some(code) => Some(generate_guards(&crate_name, code, guard_map_err, field_nullable)?),
+            Some(code) => Some(generate_guards(
+                &crate_name,
+                code,
+                guard_map_err,
+                field_nullable,
+            )?),
             None => None,
         };
 

--- a/derive/src/simple_object.rs
+++ b/derive/src/simple_object.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     utils::{
         GeneratorResult, gen_boxed_trait, gen_deprecation, gen_directive_calls, generate_guards,
-        get_crate_path, get_rustdoc, parse_complexity_expr, visible_fn,
+        get_crate_path, get_rustdoc, is_option_type, parse_complexity_expr, visible_fn,
     },
 };
 
@@ -324,8 +324,9 @@ pub fn generate(object_args: &args::SimpleObject) -> GeneratorResult<TokenStream
         let guard_map_err = quote! {
             .map_err(|err| ctx.set_error_path(err.into_server_error(ctx.item.pos)))
         };
+        let field_nullable = is_option_type(ty);
         let guard = match field.guard.as_ref().or(object_args.guard.as_ref()) {
-            Some(code) => Some(generate_guards(&crate_name, code, guard_map_err)?),
+            Some(code) => Some(generate_guards(&crate_name, code, guard_map_err, field_nullable)?),
             None => None,
         };
 

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -335,7 +335,7 @@ pub fn generate(
                 })
             };
             let guard = match field.guard.as_ref().or(subscription_args.guard.as_ref()) {
-                Some(code) => Some(generate_guards(&crate_name, code, guard_map_err)?),
+                Some(code) => Some(generate_guards(&crate_name, code, guard_map_err, false)?),
                 None => None,
             };
             let stream_fn = quote! {

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -335,12 +335,7 @@ pub fn generate(
                 })
             };
             let guard = match field.guard.as_ref().or(subscription_args.guard.as_ref()) {
-                Some(code) => Some(generate_guards(
-                    &crate_name,
-                    code,
-                    guard_map_err,
-                    false,
-                )?),
+                Some(code) => Some(generate_guards(&crate_name, code, guard_map_err, false)?),
                 None => None,
             };
             let stream_fn = quote! {

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -335,7 +335,12 @@ pub fn generate(
                 })
             };
             let guard = match field.guard.as_ref().or(subscription_args.guard.as_ref()) {
-                Some(code) => Some(generate_guards(&crate_name, code, guard_map_err, false)?),
+                Some(code) => Some(generate_guards(
+                    &crate_name,
+                    code,
+                    guard_map_err,
+                    false,
+                )?),
                 None => None,
             };
             let stream_fn = quote! {

--- a/derive/src/utils.rs
+++ b/derive/src/utils.rs
@@ -53,14 +53,33 @@ pub fn generate_guards(
     crate_name: &syn::Path,
     expr: &Expr,
     map_err: TokenStream,
+    nullable: bool,
 ) -> GeneratorResult<TokenStream> {
     let code = quote! {{
         use #crate_name::GuardExt;
         #expr
     }};
-    Ok(quote! {
-        #crate_name::Guard::check(&#code, &ctx).await #map_err ?;
-    })
+    if nullable {
+        Ok(quote! {
+            if let ::std::result::Result::Err(err) = #crate_name::Guard::check(&#code, &ctx).await #map_err {
+                ctx.add_error(err);
+                return ::std::result::Result::Ok(::std::option::Option::Some(#crate_name::Value::Null));
+            }
+        })
+    } else {
+        Ok(quote! {
+            #crate_name::Guard::check(&#code, &ctx).await #map_err ?;
+        })
+    }
+}
+
+pub fn is_option_type(ty: &Type) -> bool {
+    if let Type::Path(path) = ty {
+        if let Some(segment) = path.path.segments.last() {
+            return segment.ident == "Option";
+        }
+    }
+    false
 }
 
 pub fn get_rustdoc(attrs: &[Attribute]) -> GeneratorResult<Option<TokenStream>> {

--- a/tests/guard.rs
+++ b/tests/guard.rs
@@ -626,3 +626,177 @@ pub async fn test_guard_with_fn() {
         }]
     );
 }
+
+#[tokio::test]
+pub async fn test_guard_on_nullable_field_simple_object() {
+    #[derive(SimpleObject)]
+    struct Author {
+        id: String,
+        #[graphql(guard = "RoleGuard::new(Role::Admin)")]
+        age: Option<i32>,
+    }
+
+    #[derive(SimpleObject)]
+    struct Query {
+        post_id: String,
+        author: Author,
+    }
+
+    let schema = Schema::new(
+        Query {
+            post_id: "1".to_string(),
+            author: Author {
+                id: "2".to_string(),
+                age: Some(42),
+            },
+        },
+        EmptyMutation,
+        EmptySubscription,
+    );
+
+    // Admin can see age
+    let res = schema
+        .execute(Request::new("{ postId author { id age } }").data(Role::Admin))
+        .await;
+    assert_eq!(
+        res.data,
+        value!({"postId": "1", "author": {"id": "2", "age": 42}})
+    );
+
+    // Guest: age should be null, but the rest of the data should be intact
+    let res = schema
+        .execute(Request::new("{ postId author { id age } }").data(Role::Guest))
+        .await;
+    assert_eq!(
+        res.data,
+        value!({"postId": "1", "author": {"id": "2", "age": null}})
+    );
+    assert_eq!(res.errors.len(), 1);
+    assert_eq!(res.errors[0].message, "Forbidden");
+    assert_eq!(
+        res.errors[0].path,
+        vec![
+            PathSegment::Field("author".to_owned()),
+            PathSegment::Field("age".to_owned()),
+        ]
+    );
+}
+
+#[tokio::test]
+pub async fn test_guard_on_nullable_field_object() {
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn author(&self) -> Author {
+            Author {
+                id: "2".to_string(),
+                age: Some(42),
+            }
+        }
+    }
+
+    struct Author {
+        id: String,
+        age: Option<i32>,
+    }
+
+    #[Object]
+    impl Author {
+        async fn id(&self) -> &str {
+            &self.id
+        }
+
+        #[graphql(guard = "RoleGuard::new(Role::Admin)")]
+        async fn age(&self) -> Option<i32> {
+            self.age
+        }
+    }
+
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+
+    // Admin can see age
+    let res = schema
+        .execute(Request::new("{ author { id age } }").data(Role::Admin))
+        .await;
+    assert_eq!(res.data, value!({"author": {"id": "2", "age": 42}}));
+
+    // Guest: age should be null, rest of data intact
+    let res = schema
+        .execute(Request::new("{ author { id age } }").data(Role::Guest))
+        .await;
+    assert_eq!(res.data, value!({"author": {"id": "2", "age": null}}));
+    assert_eq!(res.errors.len(), 1);
+    assert_eq!(res.errors[0].message, "Forbidden");
+}
+
+#[tokio::test]
+pub async fn test_guard_on_nullable_field_complex_object() {
+    #[derive(SimpleObject)]
+    #[graphql(complex)]
+    struct Author {
+        id: String,
+    }
+
+    #[ComplexObject]
+    impl Author {
+        #[graphql(guard = "RoleGuard::new(Role::Admin)")]
+        async fn age(&self) -> Option<i32> {
+            Some(42)
+        }
+    }
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn author(&self) -> Author {
+            Author {
+                id: "2".to_string(),
+            }
+        }
+    }
+
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+
+    // Admin can see age
+    let res = schema
+        .execute(Request::new("{ author { id age } }").data(Role::Admin))
+        .await;
+    assert_eq!(res.data, value!({"author": {"id": "2", "age": 42}}));
+
+    // Guest: age should be null, rest of data intact
+    let res = schema
+        .execute(Request::new("{ author { id age } }").data(Role::Guest))
+        .await;
+    assert_eq!(res.data, value!({"author": {"id": "2", "age": null}}));
+    assert_eq!(res.errors.len(), 1);
+    assert_eq!(res.errors[0].message, "Forbidden");
+}
+
+#[tokio::test]
+pub async fn test_guard_on_non_nullable_field_still_propagates() {
+    #[derive(SimpleObject)]
+    struct Query {
+        #[graphql(guard = "RoleGuard::new(Role::Admin)")]
+        value: i32,
+        other: String,
+    }
+
+    let schema = Schema::new(
+        Query {
+            value: 10,
+            other: "hello".to_string(),
+        },
+        EmptyMutation,
+        EmptySubscription,
+    );
+
+    // Non-nullable field guard failure should still propagate
+    let res = schema
+        .execute(Request::new("{ value other }").data(Role::Guest))
+        .await;
+    assert_eq!(res.data, value!(null));
+    assert_eq!(res.errors.len(), 1);
+    assert_eq!(res.errors[0].message, "Forbidden");
+}


### PR DESCRIPTION
Fixes #798
Fixes #1532

## Problem

When a guard fails on a nullable (`Option<T>`) field, the error propagates via `?` and
causes null-bubbling to the nearest non-nullable parent, wiping out sibling field data.
Per the GraphQL spec, a field error on a nullable field should resolve that field to
`null` without affecting its parent.

## Solution

- Add an `is_option_type` helper to detect `Option<T>` return types at derive time.
- Pass a `nullable` flag into `generate_guards`.
- For nullable fields, emit `if let Err` + `ctx.add_error` + return `Value::Null`
  instead of `?`.
- Non-nullable fields retain the existing `?` propagation behaviour.

Covers `SimpleObject`, `Object`, `ComplexObject`; subscriptions always use the
non-nullable path.

## Test plan

- `test_guard_on_nullable_field_simple_object`
- `test_guard_on_nullable_field_object`
- `test_guard_on_nullable_field_complex_object`
- `test_guard_on_non_nullable_field_still_propagates`