### PR TITLE
Fix `@skip`/`@include` handling for defaulted variables

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,6 @@
 use std::{
     any::{Any, TypeId},
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     ops::Deref,
     sync::Arc,
 };
@@ -886,12 +886,12 @@ fn check_recursive_depth(doc: &ExecutableDocument, max_depth: usize) -> ServerRe
 fn remove_skipped_selection(
     selection_set: &mut SelectionSet,
     variables: &Variables,
-    variable_defaults: &BTreeMap<Name, bool>,
+    variable_defaults: &HashMap<Name, bool>,
 ) {
     fn variable_condition(
         name: &Name,
         variables: &Variables,
-        variable_defaults: &BTreeMap<Name, bool>,
+        variable_defaults: &HashMap<Name, bool>,
     ) -> bool {
         match variables.get(name) {
             Some(async_graphql_value::ConstValue::Boolean(value)) => *value,
@@ -902,7 +902,7 @@ fn remove_skipped_selection(
     fn directive_condition(
         value: &async_graphql_value::Value,
         variables: &Variables,
-        variable_defaults: &BTreeMap<Name, bool>,
+        variable_defaults: &HashMap<Name, bool>,
     ) -> bool {
         match value {
             async_graphql_value::Value::Boolean(value) => *value,
@@ -916,7 +916,7 @@ fn remove_skipped_selection(
     fn is_skipped(
         directives: &[Positioned<Directive>],
         variables: &Variables,
-        variable_defaults: &BTreeMap<Name, bool>,
+        variable_defaults: &HashMap<Name, bool>,
     ) -> bool {
         for directive in directives {
             let include = match &*directive.node.name.node {
@@ -1071,7 +1071,7 @@ pub(crate) async fn prepare_request(
                     _ => None,
                 })
         })
-        .collect::<BTreeMap<_, _>>();
+        .collect::<HashMap<_, _>>();
 
     // remove skipped fields
     for fragment in document.fragments.values_mut() {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -888,31 +888,6 @@ fn remove_skipped_selection(
     variables: &Variables,
     variable_defaults: &HashMap<Name, bool>,
 ) {
-    fn variable_condition(
-        name: &Name,
-        variables: &Variables,
-        variable_defaults: &HashMap<Name, bool>,
-    ) -> bool {
-        match variables.get(name) {
-            Some(async_graphql_value::ConstValue::Boolean(value)) => *value,
-            _ => variable_defaults.get(name).copied().unwrap_or_default(),
-        }
-    }
-
-    fn directive_condition(
-        value: &async_graphql_value::Value,
-        variables: &Variables,
-        variable_defaults: &HashMap<Name, bool>,
-    ) -> bool {
-        match value {
-            async_graphql_value::Value::Boolean(value) => *value,
-            async_graphql_value::Value::Variable(name) => {
-                variable_condition(name, variables, variable_defaults)
-            }
-            _ => false,
-        }
-    }
-
     fn is_skipped(
         directives: &[Positioned<Directive>],
         variables: &Variables,
@@ -926,8 +901,23 @@ fn remove_skipped_selection(
             };
 
             if let Some(condition_input) = directive.node.get_argument("if") {
-                let value =
-                    directive_condition(&condition_input.node, variables, variable_defaults);
+                let value = condition_input
+                    .node
+                    .clone()
+                    .into_const_with(|name| {
+                        variables
+                            .get(&name)
+                            .cloned()
+                            .or_else(|| {
+                                variable_defaults
+                                    .get(&name)
+                                    .copied()
+                                    .map(async_graphql_value::ConstValue::Boolean)
+                            })
+                            .ok_or(())
+                    })
+                    .ok();
+                let value: bool = InputType::parse(value).unwrap_or_default();
                 if include != value {
                     return true;
                 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,6 @@
 use std::{
     any::{Any, TypeId},
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     ops::Deref,
     sync::Arc,
 };
@@ -10,7 +10,7 @@ use futures_util::stream::{self, BoxStream, FuturesOrdered, StreamExt};
 
 use crate::{
     BatchRequest, BatchResponse, CacheControl, ContextBase, EmptyMutation, EmptySubscription,
-    Executor, InputType, ObjectType, OutputType, QueryEnv, Request, Response, ServerError,
+    Executor, InputType, Name, ObjectType, OutputType, QueryEnv, Request, Response, ServerError,
     ServerResult, SubscriptionType, Variables,
     context::{Data, QueryEnvInner},
     custom_directive::CustomDirectiveFactory,
@@ -883,8 +883,41 @@ fn check_recursive_depth(doc: &ExecutableDocument, max_depth: usize) -> ServerRe
     Ok(())
 }
 
-fn remove_skipped_selection(selection_set: &mut SelectionSet, variables: &Variables) {
-    fn is_skipped(directives: &[Positioned<Directive>], variables: &Variables) -> bool {
+fn remove_skipped_selection(
+    selection_set: &mut SelectionSet,
+    variables: &Variables,
+    variable_defaults: &BTreeMap<Name, bool>,
+) {
+    fn variable_condition(
+        name: &Name,
+        variables: &Variables,
+        variable_defaults: &BTreeMap<Name, bool>,
+    ) -> bool {
+        match variables.get(name) {
+            Some(async_graphql_value::ConstValue::Boolean(value)) => *value,
+            _ => variable_defaults.get(name).copied().unwrap_or_default(),
+        }
+    }
+
+    fn directive_condition(
+        value: &async_graphql_value::Value,
+        variables: &Variables,
+        variable_defaults: &BTreeMap<Name, bool>,
+    ) -> bool {
+        match value {
+            async_graphql_value::Value::Boolean(value) => *value,
+            async_graphql_value::Value::Variable(name) => {
+                variable_condition(name, variables, variable_defaults)
+            }
+            _ => false,
+        }
+    }
+
+    fn is_skipped(
+        directives: &[Positioned<Directive>],
+        variables: &Variables,
+        variable_defaults: &BTreeMap<Name, bool>,
+    ) -> bool {
         for directive in directives {
             let include = match &*directive.node.name.node {
                 "skip" => false,
@@ -893,12 +926,8 @@ fn remove_skipped_selection(selection_set: &mut SelectionSet, variables: &Variab
             };
 
             if let Some(condition_input) = directive.node.get_argument("if") {
-                let value = condition_input
-                    .node
-                    .clone()
-                    .into_const_with(|name| variables.get(&name).cloned().ok_or(()))
-                    .unwrap_or_default();
-                let value: bool = InputType::parse(Some(value)).unwrap_or_default();
+                let value =
+                    directive_condition(&condition_input.node, variables, variable_defaults);
                 if include != value {
                     return true;
                 }
@@ -910,7 +939,7 @@ fn remove_skipped_selection(selection_set: &mut SelectionSet, variables: &Variab
 
     selection_set
         .items
-        .retain(|selection| !is_skipped(selection.node.directives(), variables));
+        .retain(|selection| !is_skipped(selection.node.directives(), variables, variable_defaults));
 
     for selection in &mut selection_set.items {
         selection.node.directives_mut().retain(|directive| {
@@ -921,11 +950,19 @@ fn remove_skipped_selection(selection_set: &mut SelectionSet, variables: &Variab
     for selection in &mut selection_set.items {
         match &mut selection.node {
             Selection::Field(field) => {
-                remove_skipped_selection(&mut field.node.selection_set.node, variables);
+                remove_skipped_selection(
+                    &mut field.node.selection_set.node,
+                    variables,
+                    variable_defaults,
+                );
             }
             Selection::FragmentSpread(_) => {}
             Selection::InlineFragment(inline_fragment) => {
-                remove_skipped_selection(&mut inline_fragment.node.selection_set.node, variables);
+                remove_skipped_selection(
+                    &mut inline_fragment.node.selection_set.node,
+                    variables,
+                    variable_defaults,
+                );
             }
         }
     }
@@ -1019,11 +1056,36 @@ pub(crate) async fn prepare_request(
 
     let (operation_name, mut operation) = operation.map_err(|err| vec![err])?;
 
+    let variable_defaults = operation
+        .node
+        .variable_definitions
+        .iter()
+        .filter_map(|def| {
+            def.node
+                .default_value
+                .as_ref()
+                .and_then(|value| match &value.node {
+                    async_graphql_value::ConstValue::Boolean(value) => {
+                        Some((def.node.name.node.clone(), *value))
+                    }
+                    _ => None,
+                })
+        })
+        .collect::<BTreeMap<_, _>>();
+
     // remove skipped fields
     for fragment in document.fragments.values_mut() {
-        remove_skipped_selection(&mut fragment.node.selection_set.node, &request.variables);
+        remove_skipped_selection(
+            &mut fragment.node.selection_set.node,
+            &request.variables,
+            &variable_defaults,
+        );
     }
-    remove_skipped_selection(&mut operation.node.selection_set.node, &request.variables);
+    remove_skipped_selection(
+        &mut operation.node.selection_set.node,
+        &request.variables,
+        &variable_defaults,
+    );
 
     let env = QueryEnvInner {
         extensions,

--- a/tests/directive.rs
+++ b/tests/directive.rs
@@ -79,6 +79,107 @@ pub async fn test_directive_include() {
 }
 
 #[tokio::test]
+pub async fn test_directive_skip_and_include() {
+    struct Query;
+
+    #[Object]
+    impl Query {
+        pub async fn value(&self) -> i32 {
+            10
+        }
+    }
+
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+    let data = schema
+        .execute(
+            r#"
+            fragment A on Query {
+                value5: value @skip(if: false) @include(if: true)
+                value6: value @skip(if: true) @include(if: true)
+                value7: value @skip(if: false) @include(if: false)
+                value8: value @skip(if: true) @include(if: false)
+            }
+
+            query {
+                value1: value @skip(if: false) @include(if: true)
+                value2: value @skip(if: true) @include(if: true)
+                value3: value @skip(if: false) @include(if: false)
+                value4: value @skip(if: true) @include(if: false)
+                ... @skip(if: false) @include(if: true) {
+                    value9: value
+                }
+                ... @skip(if: true) @include(if: true) {
+                    value10: value
+                }
+                ... @skip(if: false) @include(if: false) {
+                    value11: value
+                }
+                ... @skip(if: true) @include(if: false) {
+                    value12: value
+                }
+                ... A
+            }
+        "#,
+        )
+        .await
+        .into_result()
+        .unwrap()
+        .data;
+    assert_eq!(
+        data,
+        value!({
+            "value1": 10,
+            "value5": 10,
+            "value9": 10,
+        })
+    );
+}
+
+#[tokio::test]
+pub async fn test_directive_skip_and_include_with_variable_defaults() {
+    struct Query;
+
+    #[Object]
+    impl Query {
+        pub async fn value(&self) -> i32 {
+            10
+        }
+    }
+
+    let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+    let data = schema
+        .execute(Request::new(
+            r#"
+            query($skip: Boolean = false, $include: Boolean = true) {
+                value1: value @skip(if: $skip) @include(if: $include)
+                value2: value @skip(if: true) @include(if: $include)
+                value3: value @skip(if: $skip) @include(if: false)
+                ... @skip(if: $skip) @include(if: $include) {
+                    value4: value
+                }
+                ... @skip(if: true) @include(if: $include) {
+                    value5: value
+                }
+                ... @skip(if: $skip) @include(if: false) {
+                    value6: value
+                }
+            }
+        "#,
+        ))
+        .await
+        .into_result()
+        .unwrap()
+        .data;
+    assert_eq!(
+        data,
+        value!({
+            "value1": 10,
+            "value4": 10,
+        })
+    );
+}
+
+#[tokio::test]
 pub async fn test_custom_directive() {
     struct Concat {
         prefix: String,


### PR DESCRIPTION
Fixes handling of `@skip` and `@include` when their `if` argument references a variable with a default value.

Previously, `remove_skipped_selection` only looked at values explicitly provided in the request variables. If a directive used an omitted variable with a default value, the directive condition was evaluated using the fallback boolean value (`false`) instead of the operation-defined default.

For example:

```
query($skip: Boolean = false, $include: Boolean = true) {
  value @skip(if: $skip) @include(if: $include)
}
```

When no variables are provided, `value` should still be included because `$skip` defaults to `false` and `$include` defaults to `true`.