### PR TITLE
feat: support `directive` on `#[Scalar]` attribute macro

### DIFF
--- a/derive/src/args.rs
+++ b/derive/src/args.rs
@@ -743,6 +743,8 @@ pub struct Scalar {
     pub specified_by_url: Option<String>,
     #[darling(default, multiple)]
     pub requires_scopes: Vec<String>,
+    #[darling(default, multiple, rename = "directive")]
+    pub directives: Vec<Expr>,
     #[darling(rename = "crate")]
     pub crate_path: Option<Path>,
 }
@@ -1079,6 +1081,7 @@ pub enum TypeDirectiveLocation {
     Object,
     InputObject,
     Interface,
+    Scalar,
 }
 
 impl TypeDirectiveLocation {

--- a/derive/src/scalar.rs
+++ b/derive/src/scalar.rs
@@ -3,10 +3,10 @@ use quote::quote;
 use syn::ItemImpl;
 
 use crate::{
-    args::{self, RenameTarget},
+    args::{self, RenameTarget, TypeDirectiveLocation},
     utils::{
-        GeneratorResult, gen_boxed_trait, get_crate_path, get_rustdoc, get_type_path_and_name,
-        visible_fn,
+        GeneratorResult, gen_boxed_trait, gen_directive_calls, get_crate_path, get_rustdoc,
+        get_type_path_and_name, visible_fn,
     },
 };
 
@@ -65,6 +65,11 @@ pub fn generate(
         }
         None => quote! { ::std::option::Option::None },
     };
+    let directives = gen_directive_calls(
+        &crate_name,
+        &scalar_args.directives,
+        TypeDirectiveLocation::Scalar,
+    );
 
     let expanded = quote! {
         #item_impl
@@ -78,7 +83,7 @@ pub fn generate(
             }
 
             fn create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
-                registry.create_input_type::<#self_ty, _>(#crate_name::registry::MetaTypeId::Scalar, |_| #crate_name::registry::MetaType::Scalar {
+                registry.create_input_type::<#self_ty, _>(#crate_name::registry::MetaTypeId::Scalar, |registry| #crate_name::registry::MetaType::Scalar {
                     name: #gql_typename_string,
                     description: #desc,
                     is_valid: ::std::option::Option::Some(::std::sync::Arc::new(|value| <#self_ty as #crate_name::ScalarType>::is_valid(value))),
@@ -86,7 +91,7 @@ pub fn generate(
                     inaccessible: #inaccessible,
                     tags: ::std::vec![ #(#tags),* ],
                     specified_by_url: #specified_by_url,
-                    directive_invocations: ::std::vec::Vec::new(),
+                    directive_invocations: ::std::vec![ #(#directives),* ],
                     requires_scopes: ::std::vec![ #(#requires_scopes),* ],
                 })
             }
@@ -112,7 +117,7 @@ pub fn generate(
             }
 
             fn create_type_info(registry: &mut #crate_name::registry::Registry) -> ::std::string::String {
-                registry.create_output_type::<#self_ty, _>(#crate_name::registry::MetaTypeId::Scalar, |_| #crate_name::registry::MetaType::Scalar {
+                registry.create_output_type::<#self_ty, _>(#crate_name::registry::MetaTypeId::Scalar, |registry| #crate_name::registry::MetaType::Scalar {
                     name: #gql_typename_string,
                     description: #desc,
                     is_valid: ::std::option::Option::Some(::std::sync::Arc::new(|value| <#self_ty as #crate_name::ScalarType>::is_valid(value))),
@@ -120,7 +125,7 @@ pub fn generate(
                     inaccessible: #inaccessible,
                     tags: ::std::vec![ #(#tags),* ],
                     specified_by_url: #specified_by_url,
-                    directive_invocations: ::std::vec::Vec::new(),
+                    directive_invocations: ::std::vec![ #(#directives),* ],
                     requires_scopes: ::std::vec![ #(#requires_scopes),* ],
                 })
             }

--- a/src/model/directive.rs
+++ b/src/model/directive.rs
@@ -103,6 +103,10 @@ pub mod location_traits {
     pub trait Directive_At_ENUM_VALUE {
         fn check() {}
     }
+
+    pub trait Directive_At_SCALAR {
+        fn check() {}
+    }
 }
 
 pub struct __Directive<'a> {

--- a/tests/type_directive.rs
+++ b/tests/type_directive.rs
@@ -253,6 +253,54 @@ fn test_type_directive_2() {
     assert_eq!(expected, sdl);
 }
 
+#[test]
+fn test_type_directive_on_scalar() {
+    use async_graphql::{InputValueResult, Scalar, ScalarType, Value};
+
+    #[TypeDirective(location = "Scalar")]
+    fn type_directive_scalar(description: String) {}
+
+    struct MyScalar(String);
+
+    #[Scalar(
+        directive = type_directive_scalar::apply("This is SCALAR in Scalar".to_string())
+    )]
+    impl ScalarType for MyScalar {
+        fn parse(value: Value) -> InputValueResult<Self> {
+            match value {
+                Value::String(s) => Ok(MyScalar(s)),
+                _ => Err(async_graphql::InputValueError::expected_type(value)),
+            }
+        }
+
+        fn to_value(&self) -> Value {
+            Value::String(self.0.clone())
+        }
+    }
+
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn value(&self) -> MyScalar {
+            MyScalar("hello".to_string())
+        }
+    }
+
+    let schema = Schema::build(Query, EmptyMutation, EmptySubscription).finish();
+    let sdl = schema.sdl();
+    assert!(
+        sdl.contains(
+            r#"scalar MyScalar @type_directive_scalar(description: "This is SCALAR in Scalar")"#
+        ),
+        "expected scalar directive in SDL, got:\n{sdl}"
+    );
+    assert!(
+        sdl.contains("directive @type_directive_scalar(description: String!) on SCALAR"),
+        "expected directive declaration in SDL, got:\n{sdl}"
+    );
+}
+
 /// Some module docs
 #[deny(missing_docs)]
 pub mod test_type_directive_docs {


### PR DESCRIPTION
## Summary

Bring custom `@directive` support to `#[Scalar]`, matching what `#[Object]`, `#[derive(SimpleObject)]`, `#[derive(InputObject)]`, `#[derive(Enum)]`, `#[derive(Interface)]` and friends already accept.

Today the only way to attach a directive to a scalar definition was via `specified_by_url` (which only emits `@specifiedBy`). With this PR you can declare any `#[TypeDirective(location = "Scalar")]` and apply it on a custom scalar:

```rust
#[TypeDirective(location = "Scalar")]
fn my_scalar_directive(description: String) {}

#[Scalar(directive = my_scalar_directive::apply("...".to_string()))]
impl ScalarType for MyScalar {
    fn parse(value: Value) -> InputValueResult<Self> { /* ... */ }
    fn to_value(&self) -> Value { /* ... */ }
}
```

Generated SDL:

```graphql
scalar MyScalar @my_scalar_directive(description: "...")
directive @my_scalar_directive(description: String!) on SCALAR
```

## Changes

- `TypeDirectiveLocation::Scalar` added (resolves to the `Directive_At_SCALAR` location trait, matching the existing pattern for `OBJECT`, `INTERFACE`, …).
- `location_traits::Directive_At_SCALAR` trait introduced in `src/model/directive.rs` — used by the compile-time check that a directive is applied to a supported location.
- `args::Scalar` gains `#[darling(default, multiple, rename = "directive")] directives: Vec<Expr>`.
- `derive/src/scalar.rs` calls `gen_directive_calls(...)` and feeds the result into `MetaType::Scalar { directive_invocations, .. }` for both `InputType` and `OutputType`. The closure passed to `create_{input,output}_type` had to be changed from `|_|` to `|registry|` so directive `register(...)` can use it without conflicting with the outer `&mut registry` borrow.

SDL rendering already handled `MetaType::Scalar::directive_invocations` in `registry/export_sdl.rs`, so no runtime changes were required.

## Backport request (v7.2.x)

If at all possible, I'd love to see this land in the **7.2.x** line as well. We rely on the stable 7.2 release in production and the 8.0 RC isn't yet a viable target for us. The change is small, additive, and applies cleanly on top of `release` (= v7.2.1) — I've already verified it locally on a branch cut from `86a19327`. Happy to open a parallel PR against `release` (or whichever branch the maintainers prefer for v7 patches) if that helps.

## Test plan

- [x] New test `test_type_directive_on_scalar` in `tests/type_directive.rs` asserts the directive appears on the scalar definition and that the directive itself is declared with `on SCALAR`.
- [x] `cargo test --test type_directive` — 3 passed.
- [x] `cargo check -p async-graphql` — clean.