### PR TITLE
fix dynamic fragment type matching

### DIFF
--- a/src/dynamic/resolve.rs
+++ b/src/dynamic/resolve.rs
@@ -295,6 +295,22 @@ fn collect_field<'a>(
     );
 }
 
+fn does_fragment_type_apply(
+    schema: &Schema,
+    object: &Object,
+    type_condition: Option<&str>,
+) -> bool {
+    type_condition.is_none_or(|type_condition| {
+        schema
+            .0
+            .env
+            .registry
+            .types
+            .get(type_condition)
+            .is_some_and(|ty| ty.is_possible_type(&object.name))
+    })
+}
+
 fn collect_fields<'a>(
     fields: &mut Vec<BoxFieldFuture<'a>>,
     schema: &'a Schema,
@@ -385,15 +401,7 @@ fn collect_fields<'a>(
 
                 let type_condition =
                     type_condition.map(|condition| condition.node.on.node.as_str());
-                let introspection_type_name = &object.name;
-
-                let type_condition_matched = match type_condition {
-                    None => true,
-                    Some(type_condition) if type_condition == introspection_type_name => true,
-                    Some(type_condition) if object.implements.contains(type_condition) => true,
-                    _ => false,
-                };
-                if type_condition_matched {
+                if does_fragment_type_apply(schema, object, type_condition) {
                     collect_fields(
                         fields,
                         schema,

--- a/src/dynamic/union.rs
+++ b/src/dynamic/union.rs
@@ -210,6 +210,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn abstract_spread_in_object_scope() {
+        let query = Object::new("Query")
+            .implement("Interface")
+            .field(Field::new("field", TypeRef::named(TypeRef::INT), |_| {
+                FieldFuture::new(async { Ok(Some(Value::from(1))) })
+            }))
+            .field(Field::new(
+                "interfaceField",
+                TypeRef::named(TypeRef::INT),
+                |_| FieldFuture::new(async { Ok(Some(Value::from(2))) }),
+            ));
+        let interface = Interface::new("Interface").field(InterfaceField::new(
+            "interfaceField",
+            TypeRef::named(TypeRef::INT),
+        ));
+        let union = Union::new("Union").possible_type(query.type_name());
+
+        let schema = Schema::build(query.type_name(), None, None)
+            .register(query)
+            .register(interface)
+            .register(union)
+            .finish()
+            .unwrap();
+
+        let query = r#"
+            {
+                ... on Union {
+                    ... on Query {
+                        field
+                    }
+                    ... on Interface {
+                        interfaceField
+                    }
+                }
+            }
+        "#;
+        assert_eq!(
+            schema.execute(query).await.into_result().unwrap().data,
+            value!({
+                "field": 1,
+                "interfaceField": 2,
+            })
+        );
+    }
+
+    #[tokio::test]
     async fn does_not_contain() {
         let obj_a = Object::new("MyObjA")
             .field(Field::new("a", TypeRef::named_nn(TypeRef::INT), |_| {


### PR DESCRIPTION
## Summary
Hello! I'm one of the maintainers of the graphql-conformance project, which verifies the spec conformance of popular graphql implementations.

In the [conformance results for async-graphql](https://jbellenger.github.io/graphql-conformance/impl/async-graphql), I noticed that there are a number of issues that seem rooted in how [DoesFragmentTypeApply](https://spec.graphql.org/draft/#DoesFragmentTypeApply()) is implemented for dynamic schemas.

I was looking at the code and thought that this might be a straightforward fix (... for codex). This PR fixes application of fragments to support spreading an abstract type in an object scope. I believe (but haven't verified) that this should also fix abstract spreads in an abstract scope.

When you have time, I encourage you to check [the conformance results for async-graphql](https://jbellenger.github.io/graphql-conformance/impl/async-graphql), which shows some other test failures in this library that need investigation.

## Changes
- Add `does_fragment_type_apply` for dynamic schema execution.
- Use `MetaType::is_possible_type` so object, interface, and union fragment type conditions are handled consistently.
- Add a regression test covering abstract spreads in object scope, including both union and interface spreads.

## Validation
- `rustfmt --check src/dynamic/resolve.rs src/dynamic/union.rs`
- `cargo check -p async-graphql`
- `cargo test -p async-graphql dynamic::union::tests::abstract_spread_in_object_scope`
- verified the regression test fails against the previous resolver behavior with `{}` instead of the selected fields.