### PR TITLE
Add configurable concurrent resolution of subscription items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+
+- Add `SchemaBuilder::subscription_resolution_concurrency` to resolve subscription payloads concurrently while preserving output order (default 1, i.e. serial) [#1833](https://github.com/async-graphql/async-graphql/pull/1833)
+
 # [8.0.0-rc.5] 2026-04-22
 
 - Fix MergedObject exceeding compiler recursion limit by using flat dispatch instead of nested async delegation in `resolve_field`/`find_entity`, which overflows when cross-crate types amplify monomorphization depth

--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -352,11 +352,13 @@ pub fn generate(
                 let pos = ctx.item.pos;
                 let schema_env = ::std::clone::Clone::clone(&ctx.schema_env);
                 let query_env = ::std::clone::Clone::clone(&ctx.query_env);
-                let stream = #crate_name::futures_util::stream::StreamExt::then(stream, {
+                let subscription_concurrency = ctx.schema_env.subscription_resolution_concurrency;
+                let stream = #crate_name::futures_util::stream::StreamExt::map(stream, {
                     let field_name = ::std::clone::Clone::clone(&field_name);
                     move |msg| {
                         let schema_env = ::std::clone::Clone::clone(&schema_env);
-                        let query_env = ::std::clone::Clone::clone(&query_env);
+                        // Each payload resolves concurrently (see `buffered` above), so give it its own error sink; otherwise concurrent payloads would drain one another's errors from a shared sink.
+                        let query_env = query_env.fork_errors();
                         let field = ::std::clone::Clone::clone(&field);
                         let field_name = ::std::clone::Clone::clone(&field_name);
                         async move {
@@ -407,6 +409,7 @@ pub fn generate(
                         }
                     }
                 });
+                let stream = #crate_name::futures_util::stream::StreamExt::buffered(stream, subscription_concurrency);
                 #crate_name::ServerResult::Ok(stream)
             };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -258,25 +258,45 @@ pub struct QueryEnvInner {
     pub query_data: Arc<Data>,
     pub http_headers: Mutex<http::HeaderMap>,
     pub introspection_mode: IntrospectionMode,
-    pub errors: Mutex<Vec<ServerError>>,
 }
 
 #[doc(hidden)]
 #[derive(Clone)]
-pub struct QueryEnv(Arc<QueryEnvInner>);
+pub struct QueryEnv {
+    inner: Arc<QueryEnvInner>,
+    // Error sink held outside the shared inner so a subscription can give each payload its own
+    // sink (via `fork_errors`) when items resolve concurrently, while still sharing
+    // data/loaders.
+    pub errors: Arc<Mutex<Vec<ServerError>>>,
+}
 
 impl Deref for QueryEnv {
     type Target = QueryEnvInner;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.inner
     }
 }
 
 impl QueryEnv {
     #[doc(hidden)]
     pub fn new(inner: QueryEnvInner) -> QueryEnv {
-        QueryEnv(Arc::new(inner))
+        QueryEnv {
+            inner: Arc::new(inner),
+            errors: Default::default(),
+        }
+    }
+
+    /// Return a clone that shares the same request data, schema, extensions,
+    /// and operation, but resolves errors into its own fresh sink. Used so
+    /// concurrently-resolved subscription payloads don't cross-contaminate
+    /// each other's errors.
+    #[doc(hidden)]
+    pub fn fork_errors(&self) -> QueryEnv {
+        QueryEnv {
+            inner: self.inner.clone(),
+            errors: Default::default(),
+        }
     }
 
     #[doc(hidden)]

--- a/src/dynamic/schema.rs
+++ b/src/dynamic/schema.rs
@@ -216,6 +216,7 @@ impl SchemaBuilder {
                 registry,
                 data: self.data,
                 custom_directives: Default::default(),
+                subscription_resolution_concurrency: 1,
             })),
             extensions: self.extensions,
             types: self.types,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -51,6 +51,7 @@ pub struct SchemaBuilder<Query, Mutation, Subscription> {
     recursive_depth: usize,
     max_directives: Option<usize>,
     max_aliases: Option<usize>,
+    subscription_resolution_concurrency: usize,
     extensions: Vec<Box<dyn ExtensionFactory>>,
     custom_directives: HashMap<String, Box<dyn CustomDirectiveFactory>>,
 }
@@ -128,6 +129,19 @@ impl<Query, Mutation, Subscription> SchemaBuilder<Query, Mutation, Subscription>
     /// limit)
     pub fn limit_directives(mut self, max_directives: usize) -> Self {
         self.max_directives = Some(max_directives);
+        self
+    }
+
+    /// Set how many subscription payloads may be resolved concurrently
+    /// (default: 1, i.e. serial).
+    ///
+    /// A subscription resolves its payloads one at a time by default. Raising
+    /// this lets up to `n` payloads resolve at once, with output order
+    /// preserved, so their `DataLoader` reads coalesce instead of running
+    /// one round trip per payload. Values below 1 are clamped to 1.
+    #[must_use]
+    pub fn subscription_resolution_concurrency(mut self, n: usize) -> Self {
+        self.subscription_resolution_concurrency = n.max(1);
         self
     }
 
@@ -288,6 +302,7 @@ impl<Query, Mutation, Subscription> SchemaBuilder<Query, Mutation, Subscription>
                 registry: self.registry,
                 data: self.data,
                 custom_directives: self.custom_directives,
+                subscription_resolution_concurrency: self.subscription_resolution_concurrency,
             })),
         }))
     }
@@ -298,6 +313,10 @@ pub struct SchemaEnvInner {
     pub registry: Registry,
     pub data: Data,
     pub custom_directives: HashMap<String, Box<dyn CustomDirectiveFactory>>,
+    /// How many subscription payloads may be resolved concurrently (>= 1). Read
+    /// by the subscription derive to buffer item resolution. Default 1
+    /// (serial).
+    pub subscription_resolution_concurrency: usize,
 }
 
 #[doc(hidden)]
@@ -403,6 +422,7 @@ where
             recursive_depth: 32,
             max_directives: None,
             max_aliases: None,
+            subscription_resolution_concurrency: 1,
             extensions: Default::default(),
             custom_directives: Default::default(),
         }
@@ -1036,7 +1056,6 @@ pub(crate) async fn prepare_request(
         query_data,
         http_headers: Default::default(),
         introspection_mode: request.introspection_mode,
-        errors: Default::default(),
     };
     Ok((QueryEnv::new(env), validation_result.cache_control))
 }

--- a/tests/subscription.rs
+++ b/tests/subscription.rs
@@ -422,3 +422,123 @@ pub async fn test_subscription_fieldresult() {
 
     assert!(stream.next().await.is_none());
 }
+
+#[tokio::test]
+pub async fn test_subscription_resolution_concurrency() {
+    use std::{sync::Arc, time::Duration};
+
+    use tokio::sync::Barrier;
+
+    const COUNT: usize = 8;
+
+    struct Item(usize);
+
+    #[Object]
+    impl Item {
+        async fn value(&self, ctx: &Context<'_>) -> usize {
+            // Every payload blocks here until all COUNT have arrived. The barrier can only
+            // release if the payloads resolve concurrently; under serial
+            // resolution the first payload would wait here forever.
+            ctx.data_unchecked::<Arc<Barrier>>().wait().await;
+            self.0
+        }
+    }
+
+    struct Subscription;
+
+    #[Subscription]
+    impl Subscription {
+        async fn items(&self) -> impl Stream<Item = Item> {
+            futures_util::stream::iter((0..COUNT).map(Item))
+        }
+    }
+
+    let schema = Schema::build(Query, EmptyMutation, Subscription)
+        .subscription_resolution_concurrency(COUNT)
+        .data(Arc::new(Barrier::new(COUNT)))
+        .finish();
+
+    // Serial resolution would never release the barrier and hang; the timeout turns
+    // that into a clean failure instead of a stuck test. (Default serial
+    // resolution is covered by the other subscription tests, which all run at
+    // the default concurrency of 1.)
+    let values: Vec<_> = tokio::time::timeout(Duration::from_secs(5), async {
+        schema
+            .execute_stream("subscription { items { value } }")
+            .map(|resp| resp.into_result().unwrap().data)
+            .collect()
+            .await
+    })
+    .await
+    .expect("payloads did not resolve concurrently (barrier never released)");
+
+    // The barrier released, so all COUNT resolved at once, and `buffered` kept the
+    // output in submission order.
+    assert_eq!(values.len(), COUNT);
+    for (i, v) in values.iter().enumerate() {
+        assert_eq!(*v, value!({ "items": { "value": i } }));
+    }
+}
+
+#[tokio::test]
+pub async fn test_subscription_resolution_error_isolation() {
+    use std::sync::Arc;
+
+    use tokio::sync::Barrier;
+
+    const COUNT: usize = 8;
+
+    struct Item(usize);
+
+    #[Object]
+    impl Item {
+        async fn value(&self, ctx: &Context<'_>) -> usize {
+            // Record this item's error, then wait until every payload has recorded its own.
+            // This holds all COUNT payloads in flight together with their
+            // errors in the sink, so if the sink were shared the first payload
+            // to drain would scoop up everyone's errors. With `fork_errors`
+            // each payload drains only its own sink. (The barrier also requires the
+            // payloads to actually resolve concurrently, or it would never release.)
+            ctx.add_error(ServerError::new(format!("boom {}", self.0), None));
+            ctx.data_unchecked::<Arc<Barrier>>().wait().await;
+            self.0
+        }
+    }
+
+    struct Subscription;
+
+    #[Subscription]
+    impl Subscription {
+        async fn items(&self) -> impl Stream<Item = Item> {
+            futures_util::stream::iter((0..COUNT).map(Item))
+        }
+    }
+
+    let schema = Schema::build(Query, EmptyMutation, Subscription)
+        .subscription_resolution_concurrency(COUNT)
+        .data(Arc::new(Barrier::new(COUNT)))
+        .finish();
+
+    let responses: Vec<_> = schema
+        .execute_stream("subscription { items { value } }")
+        .collect()
+        .await;
+
+    assert_eq!(responses.len(), COUNT);
+    // Payload `i` must carry item `i`'s data *and* exactly item `i`'s own error,
+    // never a sibling's.
+    for (i, resp) in responses.into_iter().enumerate() {
+        assert_eq!(resp.data, value!({ "items": { "value": i } }));
+        assert_eq!(
+            resp.errors.len(),
+            1,
+            "payload {i} should carry exactly one error, got {:?}",
+            resp.errors
+        );
+        assert_eq!(
+            resp.errors[0].message,
+            format!("boom {i}"),
+            "payload {i} carried a sibling's error",
+        );
+    }
+}


### PR DESCRIPTION
## Description

Subscription payloads are resolved one at a time: the selection set for each
yielded value is fully resolved before the next value is polled from the stream.
When resolving a payload involves async work (for example, fetching nested
fields from a database or another service), that work is serialized across
payloads, so a fast-producing subscription ends up bottlenecked on resolving a
single payload at a time.

This adds a schema-level option to resolve multiple subscription payloads
concurrently while preserving output order:

```rust
let schema = Schema::build(Query, EmptyMutation, Subscription)
    .subscription_resolution_concurrency(16)
    .finish();
```

The default is `1`, which keeps the current behavior of resolving one payload at
a time, so the change is fully backwards compatible.

Internally the subscription resolver switches from `StreamExt::then` (serial) to
`StreamExt::map` followed by `StreamExt::buffered(n)`, so up to `n` payloads
resolve in flight while results are still yielded in stream order. Each in-flight
payload resolves against its own error sink, so concurrent payloads do not drain
one another's errors.

Output ordering is unchanged, and a test covers that N payloads resolve
concurrently and are still delivered in order.

This mirrors [amnn/async-graphql#2](https://github.com/amnn/async-graphql/pull/2),
which has already been reviewed; opening here to upstream it.
