### PR TITLE
Fix numeric GraphQL variables under serde_json's arbitrary_precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix MergedObject exceeding compiler recursion limit by using flat dispatch instead of nested async delegation in `resolve_field`/`find_entity`, which overflows when cross-crate types amplify monomorphization depth
 - Replace `mdbook test` with `cargo test --doc` via a `book-tests` crate to fix E0464 duplicate rlib errors in CI [#1794](https://github.com/async-graphql/async-graphql/issues/1794)
 - Add option to restrict potential DoS vector [#1822](https://github.com/async-graphql/async-graphql/pull/1822)
+- Fix GraphQL variables carrying a fractional number failing with `Invalid value for argument..., expected type Float/Int` when `serde_json`'s `arbitrary_precision` feature is active anywhere in the dependency graph [#1719](https://github.com/async-graphql/async-graphql/issues/1719)
 
 # [8.0.0-rc.4] 2026-03-08
 

--- a/value/Cargo.toml
+++ b/value/Cargo.toml
@@ -17,5 +17,16 @@ serde.workspace = true
 bytes.workspace = true
 indexmap.workspace = true
 
+[dev-dependencies]
+# Enabled only for this crate's tests, to reproduce
+# https://github.com/async-graphql/async-graphql/issues/1719, which only
+# manifests when `serde_json`'s `arbitrary_precision` feature is active.
+# Note: because Cargo unifies dev-dependency features across a workspace
+# `cargo test --workspace` run, this also turns `arbitrary_precision` on for
+# every other workspace member's use of `serde_json` for the duration of
+# that command — the same feature-unification behavior that causes the bug
+# itself. `cargo test -p async-graphql-value` is unaffected by this concern.
+serde_json = { workspace = true, features = ["arbitrary_precision"] }
+
 [features]
 raw_value = ["serde_json/raw_value"]

--- a/value/src/value_serde.rs
+++ b/value/src/value_serde.rs
@@ -16,6 +16,16 @@ use crate::{ConstValue, Name, Number, Value};
 #[cfg(feature = "raw_value")]
 pub const RAW_VALUE_TOKEN: &str = "$serde_json::private::RawValue";
 
+/// The token used by `serde_json` to represent arbitrary-precision numbers
+/// when its `arbitrary_precision` feature is enabled. Because Cargo unifies
+/// features across the whole dependency graph, this can be active even if
+/// this crate's own `serde_json` dependency does not request it, so the
+/// token is handled unconditionally rather than behind a feature of our own.
+///
+/// It should be kept in sync with the following original until made public:
+/// https://github.com/serde-rs/json/blob/b48b9a3a0c09952579e98c8940fe0d1ee4aae588/src/number.rs#L18
+const NUMBER_TOKEN: &str = "$serde_json::private::Number";
+
 impl Serialize for ConstValue {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
@@ -159,6 +169,22 @@ impl<'de> Deserialize<'de> for ConstValue {
                 while let Some((name, value)) = visitor.next_entry()? {
                     map.insert(name, value);
                 }
+
+                // `serde_json`'s `arbitrary_precision` feature represents every
+                // fractional (and out-of-range integer) number as a single-entry
+                // map keyed by `NUMBER_TOKEN` instead of calling
+                // `visit_f64`/`visit_i64`/`visit_u64`, because serde's data model
+                // has no arbitrary-precision-number primitive. Unwrap that shape
+                // back into a `Number` here.
+                if map.len() == 1
+                    && let Some(ConstValue::String(number)) = map.get(NUMBER_TOKEN)
+                {
+                    return number
+                        .parse::<Number>()
+                        .map(ConstValue::Number)
+                        .map_err(DeError::custom);
+                }
+
                 Ok(ConstValue::Object(map))
             }
         }
@@ -320,6 +346,17 @@ impl<'de> Deserialize<'de> for Value {
                         }
                     }
                 }
+
+                // See the equivalent check in `ConstValue`'s `visit_map` above.
+                if map.len() == 1
+                    && let Some(Value::String(number)) = map.get(NUMBER_TOKEN)
+                {
+                    return number
+                        .parse::<Number>()
+                        .map(Value::Number)
+                        .map_err(DeError::custom);
+                }
+
                 Ok(Value::Object(map))
             }
         }

--- a/value/tests/test_serde.rs
+++ b/value/tests/test_serde.rs
@@ -105,3 +105,50 @@ fn test_raw_value() {
     let value = serde_json::to_string(&value).unwrap();
     assert_eq!(value, r#"{"field":[0, 1, 2]}"#);
 }
+
+// Regression test for https://github.com/async-graphql/async-graphql/issues/1719.
+//
+// This crate's `dev-dependencies` enable `serde_json`'s `arbitrary_precision`
+// feature (see `Cargo.toml`), which is what actually reproduces the bug: with
+// it on, `serde_json` hands every fractional number to the `Deserialize`
+// implementation as a single-entry map keyed by
+// `$serde_json::private::Number` rather than calling `visit_f64`, since
+// serde's data model has no arbitrary-precision-number primitive. Before the
+// fix, `ConstValue`/`Value`'s `visit_map` had no case for that token and
+// produced an `Object` wrapping the number's text instead of a `Number`,
+// which is exactly what made GraphQL variables carrying a fractional number
+// fail with "Invalid value for argument ..., expected type Float".
+#[test]
+fn test_arbitrary_precision_fractional_number() {
+    let json = r#"{"latitude": 12.34, "count": 5, "negative": -0.5}"#;
+
+    let value: ConstValue = serde_json::from_str(json).unwrap();
+    let ConstValue::Object(map) = &value else {
+        panic!("expected an object, got {value:?}");
+    };
+    assert_eq!(
+        map.get("latitude"),
+        Some(&ConstValue::Number(Number::from_f64(12.34).unwrap()))
+    );
+    assert_eq!(map.get("count"), Some(&ConstValue::Number(5.into())));
+    assert_eq!(
+        map.get("negative"),
+        Some(&ConstValue::Number(Number::from_f64(-0.5).unwrap()))
+    );
+
+    // `Value` (the non-const variant used while parsing queries/variables)
+    // must be fixed identically.
+    let value: Value = serde_json::from_str(json).unwrap();
+    let Value::Object(map) = &value else {
+        panic!("expected an object, got {value:?}");
+    };
+    assert_eq!(
+        map.get("latitude"),
+        Some(&Value::Number(Number::from_f64(12.34).unwrap()))
+    );
+
+    // A bare top-level fractional number (as would arrive for a single
+    // variable value) must also round-trip to a `Number`, not an `Object`.
+    let value: ConstValue = serde_json::from_str("42.5").unwrap();
+    assert_eq!(value, ConstValue::Number(Number::from_f64(42.5).unwrap()));
+}


### PR DESCRIPTION
Fixes #1719.

## Symptom

When `serde_json`'s `arbitrary_precision` feature is enabled anywhere in a binary's dependency graph (Cargo unifies features additively, so any transitive dependency turns it on for everyone), every **fractional** number passed as a GraphQL **variable** fails with:

```
Invalid value for argument "latitude", expected type "Float"
```

Integers still work. Inline query literals still work. Only variables carrying non-integer numbers fail.

## Root cause

With `arbitrary_precision` on, `serde_json`'s parser represents a fractional number internally as:

```rust
pub(crate) enum ParserNumber {
    F64(f64), U64(u64), I64(i64),
    #[cfg(feature = "arbitrary_precision")]
    String(String),
}
```

and, for the `String` variant, calls `visitor.visit_map(NumberDeserializer { number: x.into() })` instead of `visit_f64`/`visit_i64`/`visit_u64` — because serde's data model has no arbitrary-precision-number primitive. `NumberDeserializer` presents itself as a single-entry `MapAccess` keyed by the private token `$serde_json::private::Number` (`serde_json/src/number.rs`), whose value is the number's exact text.

`async-graphql-value`'s `Deserialize` impls for `ConstValue`/`Value` already special-case the sibling `$serde_json::private::RawValue` token constant (`RAW_VALUE_TOKEN`) elsewhere in `value_serde.rs`, but `ValueVisitor::visit_map` had no case for the number token, so it fell through to the generic path and built an `Object` wrapping the number as a string under that key. Any variable carrying a fractional number then failed argument type-checking against `Float`/`Int` with the error above.

## Fix

This implements approach (2) from the issue — handle serde's internal number representation directly, rather than approach (1) (round-tripping through `serde_json::Value`), which the issue notes costs an extra allocation and pass per value.

In `value_serde.rs`:
- Added a `NUMBER_TOKEN` constant next to `RAW_VALUE_TOKEN`, kept in sync with `serde_json::number::TOKEN` the same way `RAW_VALUE_TOKEN` is kept in sync with `serde_json::raw::TOKEN`.
- In both `ConstValue`'s and `Value`'s `visit_map` (the two "sibling visitors" in this file), after building the map: if it has exactly one entry keyed by `NUMBER_TOKEN`, parse its string value into a `Number`/`ConstValue::Number`/`Value::Number` instead of returning an `Object`. This mirrors the existing `RAW_VALUE_TOKEN` handling's structure (single-entry-map check by key) already present in this file's `Serialize for ConstValue` impl.
- The check is **unconditional** — not gated behind a feature of this crate. `async-graphql-value` has no way to know whether `arbitrary_precision` was enabled elsewhere in a downstream build (that's the whole problem), and a map with this exact single key is unambiguous, so there is no correctness cost to always checking for it.
- I also checked the serializer direction and the sibling `Value` visitor in this file for the same gap: `Serialize for ConstValue`/`Serialize for Value` delegate `Number` straight to `Number::serialize`, which already round-trips correctly through `serde_json`'s own serializer regardless of `arbitrary_precision`, so no change was needed there.

## Testing

Added `test_arbitrary_precision_fractional_number` in `value/tests/test_serde.rs`, which parses real JSON (an object with fractional/negative/integer fields, and a bare top-level fractional number) via `serde_json::from_str` into both `ConstValue` and `Value`, and asserts the result is `Number`, not `Object`.

The bug only reproduces when `serde_json/arbitrary_precision` is active, so it's enabled via a `[dev-dependencies]` override in `value/Cargo.toml` (see the comment there). I considered isolating this into a separate, non-member crate to avoid Cargo unifying the feature workspace-wide during `cargo test --workspace`, but a plain dev-dependency is simpler and I verified empirically that it doesn't destabilize anything else in the suite:

- Confirmed the new test fails on `master` with the exact broken shape from the issue (`Object({"$serde_json::private::Number": "12.34"})`), and passes with this fix.
- `cargo test -p async-graphql-value` (default features and `--all-features`) — pass.
- `cargo clippy -p async-graphql-value --all-features --tests` — clean.
- `cargo build --workspace` and `cargo test --workspace --features <same set CI's ci.yml computes>` — all pass, including with `arbitrary_precision` unified in across the whole workspace for that run, so this change doesn't appear to affect anything outside `async-graphql-value`.
- `cargo +nightly-2025-04-09 fmt --all -- --check` (the toolchain pinned in `ci.yml`'s `rustfmt` job) — clean.

`cargo clippy --all` at the workspace root reports 2 pre-existing, unrelated errors in `src/request.rs` and `src/extensions/apollo_tracing.rs` on `master` (confirmed by stashing this change and re-running); this PR doesn't touch either file.