### PR TITLE
fix: upgrade lru to 0.18.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ askama = { version = "0.15.1", default-features = false, features = [
 ], optional = true }
 blocking = { version = "1.6.1", optional = true }
 futures-channel = { version = "0.3.30", optional = true }
-lru = { version = "0.16.2", optional = true }
+lru = { version = "0.18.2", optional = true }
 sha2 = { version = "0.10.8", optional = true }
 scc = { version = "3.4.13", optional = true }
 


### PR DESCRIPTION
Updates the optional lru dependency from 0.16.2 to 0.18.2, addressing RUSTSEC-2026-0002 and RUSTSEC-2026-0253. The DataLoader cache implementation requires no source changes.

Testing:
- cargo test --features dataloader,tokio --lib dataloader (9 passed)