### PR TITLE
Add experimental @experimental_disableErrorPropagation directive

### DIFF
--- a/derive/src/subscription.rs
+++ b/derive/src/subscription.rs
@@ -391,15 +391,24 @@ pub fn generate(
                                             .map(::std::option::Option::Some)
                                     };
                                     #crate_name::futures_util::pin_mut!(resolve_fut);
-                                    let mut resp = query_env.extensions.resolve(ri, &mut resolve_fut).await.map(|value| {
-                                        let mut map = #crate_name::indexmap::IndexMap::new();
-                                        map.insert(::std::clone::Clone::clone(&field_name), value.unwrap_or_default());
-                                        #crate_name::Response::new(#crate_name::Value::Object(map))
-                                    })
-                                    .unwrap_or_else(|err| #crate_name::Response::from_errors(::std::vec![err]));
-
+                                    let res = query_env.extensions.resolve(ri, &mut resolve_fut).await;
+                                    let mut errors = ::std::mem::take(&mut *query_env.errors.lock().unwrap());
+                                    let mut resp = match res {
+                                        ::std::result::Result::Ok(value) => {
+                                            let mut map = #crate_name::indexmap::IndexMap::new();
+                                            map.insert(::std::clone::Clone::clone(&field_name), value.unwrap_or_default());
+                                            #crate_name::Response::new(#crate_name::Value::Object(map))
+                                        }
+                                        ::std::result::Result::Err(err) if query_env.disable_error_propagation => {
+                                            errors.push(err);
+                                            let mut map = #crate_name::indexmap::IndexMap::new();
+                                            map.insert(::std::clone::Clone::clone(&field_name), #crate_name::Value::Null);
+                                            #crate_name::Response::new(#crate_name::Value::Object(map))
+                                        }
+                                        ::std::result::Result::Err(err) => #crate_name::Response::from_errors(::std::vec![err]),
+                                    };
                                     use ::std::iter::Extend;
-                                    resp.errors.extend(::std::mem::take(&mut *query_env.errors.lock().unwrap()));
+                                    resp.errors.extend(errors);
                                     resp
                                 }
                             };

--- a/src/context.rs
+++ b/src/context.rs
@@ -259,6 +259,7 @@ pub struct QueryEnvInner {
     pub http_headers: Mutex<http::HeaderMap>,
     pub introspection_mode: IntrospectionMode,
     pub errors: Mutex<Vec<ServerError>>,
+    pub disable_error_propagation: bool,
 }
 
 #[doc(hidden)]

--- a/src/dynamic/resolve.rs
+++ b/src/dynamic/resolve.rs
@@ -200,14 +200,20 @@ fn collect_entities_field<'a>(
             });
 
             let field_value = match field_future {
-                FieldFuture::Future(fut) => {
-                    fut.await.map_err(|err| err.into_server_error(field.pos))?
-                }
+                FieldFuture::Future(fut) => fut
+                    .await
+                    .map_err(|err| ctx_field.set_error_path(err.into_server_error(field.pos)))?,
                 FieldFuture::Value(value) => value,
             };
-            let value = resolve(schema, &ctx_field, &entity_type, field_value.as_ref())
-                .await?
-                .unwrap_or_default();
+            let value = match resolve(schema, &ctx_field, &entity_type, field_value.as_ref()).await
+            {
+                Ok(value) => value.unwrap_or_default(),
+                Err(err) if ctx_field.query_env.disable_error_propagation => {
+                    ctx_field.add_error(err);
+                    Value::Null
+                }
+                Err(err) => return Err(err),
+            };
             Ok((field.node.response_key().node.clone(), value))
         }
         .boxed(),
@@ -271,9 +277,9 @@ fn collect_field<'a>(
 
                 let field_value = match field_future {
                     FieldFuture::Value(field_value) => field_value,
-                    FieldFuture::Future(future) => future
-                        .await
-                        .map_err(|err| err.into_server_error(field.pos))?,
+                    FieldFuture::Future(future) => future.await.map_err(|err| {
+                        ctx_field.set_error_path(err.into_server_error(field.pos))
+                    })?,
                 };
 
                 let value =
@@ -283,12 +289,19 @@ fn collect_field<'a>(
             };
             futures_util::pin_mut!(resolve_fut);
 
-            let res_value = ctx_field
+            let res_value = match ctx_field
                 .query_env
                 .extensions
                 .resolve(resolve_info, &mut resolve_fut)
-                .await?
-                .unwrap_or_default();
+                .await
+            {
+                Ok(value) => value.unwrap_or_default(),
+                Err(err) if ctx_field.query_env.disable_error_propagation => {
+                    ctx_field.add_error(err);
+                    Value::Null
+                }
+                Err(err) => return Err(err),
+            };
             Ok((field.node.response_key().node.clone(), res_value))
         }
         .boxed(),
@@ -484,12 +497,19 @@ async fn resolve_list<'a>(
             let resolve_fut = async { resolve(schema, &ctx_item, type_ref, Some(value)).await };
             futures_util::pin_mut!(resolve_fut);
 
-            let res_value = ctx_item
+            match ctx_item
                 .query_env
                 .extensions
                 .resolve(resolve_info, &mut resolve_fut)
-                .await?;
-            Ok::<_, ServerError>(res_value.unwrap_or_default())
+                .await
+            {
+                Ok(value) => Ok(value.unwrap_or_default()),
+                Err(err) if ctx_item.query_env.disable_error_propagation => {
+                    ctx_item.add_error(err);
+                    Ok(Value::Null)
+                }
+                Err(err) => Err(err),
+            }
         });
     }
     let values = futures_util::future::try_join_all(futures).await?;

--- a/src/dynamic/schema.rs
+++ b/src/dynamic/schema.rs
@@ -35,6 +35,7 @@ pub struct SchemaBuilder {
     introspection_mode: IntrospectionMode,
     enable_federation: bool,
     entity_resolver: Option<BoxResolverFn>,
+    experimental_disable_error_propagation: bool,
 }
 
 impl SchemaBuilder {
@@ -143,6 +144,22 @@ impl SchemaBuilder {
         self
     }
 
+    /// Enable support for the experimental
+    /// `@experimental_disableErrorPropagation` directive.
+    ///
+    /// When enabled, the directive is added to the schema and clients can
+    /// apply it to a `query`, `mutation` or `subscription` operation to opt
+    /// out of error propagation: an error raised by a non-null field is
+    /// reported in the `errors` list and the field itself is set to `null`,
+    /// instead of propagating the `null` up to the nearest nullable ancestor.
+    ///
+    /// See <https://www.graphql-js.org/docs/disabling-error-propagation/>.
+    #[must_use]
+    pub fn enable_experimental_disable_error_propagation(mut self) -> Self {
+        self.experimental_disable_error_propagation = true;
+        self
+    }
+
     /// Set the entity resolver for federation
     pub fn entity_resolver<F>(self, resolver_fn: F) -> Self
     where
@@ -170,6 +187,9 @@ impl SchemaBuilder {
             enable_suggestions: self.enable_suggestions,
         };
         registry.add_system_types();
+        if self.experimental_disable_error_propagation {
+            registry.add_disable_error_propagation_directive();
+        }
 
         for ty in self.types.values() {
             ty.register(&mut registry)?;
@@ -277,6 +297,7 @@ impl Schema {
             introspection_mode: IntrospectionMode::Enabled,
             entity_resolver: None,
             enable_federation: false,
+            experimental_disable_error_propagation: false,
         }
     }
 

--- a/src/dynamic/subscription.rs
+++ b/src/dynamic/subscription.rs
@@ -285,7 +285,10 @@ impl Subscription {
                                         .resolve(ri, &mut resolve_fut)
                                         .await;
 
-                                    match value {
+                                    let mut errors = std::mem::take(
+                                        &mut *ctx_field.query_env.errors.lock().unwrap(),
+                                    );
+                                    let mut resp = match value {
                                         Ok(value) => {
                                             let mut map = IndexMap::new();
                                             map.insert(
@@ -294,8 +297,18 @@ impl Subscription {
                                             );
                                             Response::new(Value::Object(map))
                                         }
+                                        Err(err)
+                                            if ctx_field.query_env.disable_error_propagation =>
+                                        {
+                                            errors.push(err);
+                                            let mut map = IndexMap::new();
+                                            map.insert(field_name.clone(), Value::Null);
+                                            Response::new(Value::Object(map))
+                                        }
                                         Err(err) => Response::from_errors(vec![err]),
-                                    }
+                                    };
+                                    resp.errors.extend(errors);
+                                    resp
                                 }
                             };
                             let resp = ctx_field
@@ -303,7 +316,7 @@ impl Subscription {
                                 .extensions
                                 .execute(ctx_field.query_env.operation_name.as_deref(), f)
                                 .await;
-                            let is_err = !resp.errors.is_empty();
+                            let is_err = matches!(resp.data, Value::Null);
                             yielder.yield_ok(resp).await;
                             if is_err {
                                 break;

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -21,6 +21,13 @@ use crate::{
     schema::IntrospectionMode,
 };
 
+/// The name of the experimental `@experimental_disableErrorPropagation`
+/// directive, registered on demand by
+/// `Registry::add_disable_error_propagation_directive`.
+///
+/// See <https://www.graphql-js.org/docs/disabling-error-propagation/>.
+pub(crate) const DISABLE_ERROR_PROPAGATION_DIRECTIVE: &str = "experimental_disableErrorPropagation";
+
 fn strip_brackets(type_name: &str) -> Option<&str> {
     type_name
         .strip_prefix('[')
@@ -1338,6 +1345,24 @@ impl Registry {
         <f32 as InputType>::create_type_info(self);
         <String as InputType>::create_type_info(self);
         <ID as InputType>::create_type_info(self);
+    }
+
+    /// Registers the experimental `@experimental_disableErrorPropagation`
+    /// directive.
+    pub(crate) fn add_disable_error_propagation_directive(&mut self) {
+        self.add_directive(MetaDirective {
+            name: DISABLE_ERROR_PROPAGATION_DIRECTIVE.into(),
+            description: Some("Disables error propagation.".to_string()),
+            locations: vec![
+                __DirectiveLocation::QUERY,
+                __DirectiveLocation::MUTATION,
+                __DirectiveLocation::SUBSCRIPTION,
+            ],
+            args: Default::default(),
+            is_repeatable: false,
+            visible: None,
+            composable: None,
+        });
     }
 
     pub fn create_input_type<T, F>(&mut self, type_id: MetaTypeId, mut f: F) -> String

--- a/src/resolver_utils/container.rs
+++ b/src/resolver_utils/container.rs
@@ -324,7 +324,20 @@ impl<'a> Fields<'a> {
                         }
                     });
 
-                    self.0.push(resolve_fut);
+                    if ctx.query_env.disable_error_propagation {
+                        let ctx = ctx.clone();
+                        self.0.push(Box::pin(async move {
+                            match resolve_fut.await {
+                                Ok(res) => Ok(res),
+                                Err(err) => {
+                                    ctx.add_error(err);
+                                    Ok((field.node.response_key().node.clone(), Value::Null))
+                                }
+                            }
+                        }));
+                    } else {
+                        self.0.push(resolve_fut);
+                    }
                 }
                 selection => {
                     let (type_condition, selection_set) = match selection {

--- a/src/resolver_utils/list.rs
+++ b/src/resolver_utils/list.rs
@@ -36,10 +36,14 @@ pub async fn resolve_list<'a, T: OutputType + 'a>(
                             .map_err(|err| ctx_idx.set_error_path(err))
                     };
                     futures_util::pin_mut!(resolve_fut);
-                    extensions
-                        .resolve(resolve_info, &mut resolve_fut)
-                        .await
-                        .map(|value| value.expect("You definitely encountered a bug!"))
+                    match extensions.resolve(resolve_info, &mut resolve_fut).await {
+                        Ok(value) => Ok(value.expect("You definitely encountered a bug!")),
+                        Err(err) if ctx_idx.query_env.disable_error_propagation => {
+                            ctx_idx.add_error(err);
+                            Ok(Value::Null)
+                        }
+                        Err(err) => Err(err),
+                    }
                 }
             });
         }
@@ -51,9 +55,14 @@ pub async fn resolve_list<'a, T: OutputType + 'a>(
         for (idx, item) in iter.into_iter().enumerate() {
             let ctx_idx = ctx.with_index(idx);
             futures.push(async move {
-                OutputType::resolve(&item, &ctx_idx, field)
-                    .await
-                    .map_err(|err| ctx_idx.set_error_path(err))
+                match OutputType::resolve(&item, &ctx_idx, field).await {
+                    Ok(value) => Ok(value),
+                    Err(err) if ctx_idx.query_env.disable_error_propagation => {
+                        ctx_idx.add_error(ctx_idx.set_error_path(err));
+                        Ok(Value::Null)
+                    }
+                    Err(err) => Err(ctx_idx.set_error_path(err)),
+                }
             });
         }
         Ok(Value::List(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -19,7 +19,7 @@ use crate::{
         Positioned, parse_query,
         types::{Directive, DocumentOperations, OperationType, Selection, SelectionSet},
     },
-    registry::{Registry, SDLExportOptions},
+    registry::{DISABLE_ERROR_PROPAGATION_DIRECTIVE, Registry, SDLExportOptions},
     resolver_utils::{resolve_container, resolve_container_serial},
     subscription::collect_subscription_streams,
     types::QueryRoot,
@@ -187,6 +187,22 @@ impl<Query, Mutation, Subscription> SchemaBuilder<Query, Mutation, Subscription>
     #[must_use]
     pub fn enable_subscription_in_federation(mut self) -> Self {
         self.registry.federation_subscription = true;
+        self
+    }
+
+    /// Enable support for the experimental
+    /// `@experimental_disableErrorPropagation` directive.
+    ///
+    /// When enabled, the directive is added to the schema and clients can
+    /// apply it to a `query`, `mutation` or `subscription` operation to opt
+    /// out of error propagation: an error raised by a non-null field is
+    /// reported in the `errors` list and the field itself is set to `null`,
+    /// instead of propagating the `null` up to the nearest nullable ancestor.
+    ///
+    /// See <https://www.graphql-js.org/docs/disabling-error-propagation/>.
+    #[must_use]
+    pub fn enable_experimental_disable_error_propagation(mut self) -> Self {
+        self.registry.add_disable_error_propagation_directive();
         self
     }
 
@@ -1025,6 +1041,15 @@ pub(crate) async fn prepare_request(
     }
     remove_skipped_selection(&mut operation.node.selection_set.node, &request.variables);
 
+    let disable_error_propagation = registry
+        .directives
+        .contains_key(DISABLE_ERROR_PROPAGATION_DIRECTIVE)
+        && operation
+            .node
+            .directives
+            .iter()
+            .any(|directive| directive.node.name.node == DISABLE_ERROR_PROPAGATION_DIRECTIVE);
+
     let env = QueryEnvInner {
         extensions,
         variables: request.variables,
@@ -1037,6 +1062,7 @@ pub(crate) async fn prepare_request(
         http_headers: Default::default(),
         introspection_mode: request.introspection_mode,
         errors: Default::default(),
+        disable_error_propagation,
     };
     Ok((QueryEnv::new(env), validation_result.cache_control))
 }

--- a/tests/disable_error_propagation.rs
+++ b/tests/disable_error_propagation.rs
@@ -1,0 +1,552 @@
+use async_graphql::*;
+use futures_util::stream::{Stream, StreamExt};
+
+#[derive(SimpleObject, Clone)]
+struct Profile {
+    bio: String,
+}
+
+struct Viewer;
+
+#[Object]
+impl Viewer {
+    async fn id(&self) -> ID {
+        ID::from("1")
+    }
+
+    async fn display_name(&self) -> Result<String> {
+        Err(Error::new("Could not fetch display name."))
+    }
+
+    async fn nickname(&self) -> String {
+        "Ada".to_string()
+    }
+
+    async fn profile(&self) -> Profile {
+        Profile {
+            bio: "hello".to_string(),
+        }
+    }
+
+    async fn broken_profile(&self) -> BrokenProfile {
+        BrokenProfile
+    }
+
+    async fn items(&self) -> Vec<Item> {
+        vec![Item(1), Item(2), Item(3)]
+    }
+}
+
+struct BrokenProfile;
+
+#[Object]
+impl BrokenProfile {
+    async fn bio(&self) -> Result<String> {
+        Err(Error::new("Could not fetch bio."))
+    }
+}
+
+struct Item(i32);
+
+#[Object]
+impl Item {
+    async fn value(&self) -> Result<i32> {
+        if self.0 == 2 {
+            Err(Error::new("Item 2 failed."))
+        } else {
+            Ok(self.0)
+        }
+    }
+}
+
+struct Query;
+
+#[Object]
+impl Query {
+    async fn viewer(&self) -> Viewer {
+        Viewer
+    }
+
+    async fn optional_viewer(&self) -> Option<Viewer> {
+        Some(Viewer)
+    }
+
+    async fn value(&self) -> i32 {
+        10
+    }
+}
+
+struct Mutation;
+
+#[Object]
+impl Mutation {
+    async fn update(&self) -> Result<i32> {
+        Err(Error::new("Update failed."))
+    }
+
+    async fn other(&self) -> i32 {
+        7
+    }
+}
+
+struct Subscription;
+
+#[Subscription]
+impl Subscription {
+    async fn events(&self) -> impl Stream<Item = Viewer> {
+        futures_util::stream::iter(vec![Viewer, Viewer])
+    }
+
+    async fn numbers(&self) -> impl Stream<Item = Result<i32>> {
+        futures_util::stream::iter(vec![Ok(1), Err(Error::new("boom")), Ok(3)])
+    }
+}
+
+fn schema() -> Schema<Query, Mutation, Subscription> {
+    Schema::build(Query, Mutation, Subscription)
+        .enable_experimental_disable_error_propagation()
+        .finish()
+}
+
+#[tokio::test]
+async fn test_error_propagation_default_behaviour() {
+    let schema = schema();
+    let resp = schema
+        .execute("{ viewer { id displayName nickname } }")
+        .await;
+    assert_eq!(resp.data, Value::Null);
+    assert_eq!(
+        resp.errors,
+        vec![ServerError {
+            message: "Could not fetch display name.".to_string(),
+            source: None,
+            locations: vec![Pos {
+                line: 1,
+                column: 15
+            }],
+            path: vec![
+                PathSegment::Field("viewer".to_owned()),
+                PathSegment::Field("displayName".to_owned())
+            ],
+            extensions: None,
+        }]
+    );
+
+    // A nullable parent absorbs the error.
+    let resp = schema
+        .execute("{ optionalViewer { id displayName nickname } }")
+        .await;
+    assert_eq!(resp.data, value!({ "optionalViewer": null }));
+    assert_eq!(resp.errors.len(), 1);
+}
+
+#[tokio::test]
+async fn test_disable_error_propagation_on_query() {
+    let schema = schema();
+    let resp = schema
+        .execute(
+            r#"query @experimental_disableErrorPropagation {
+                viewer { id displayName nickname }
+            }"#,
+        )
+        .await;
+    assert_eq!(
+        resp.data,
+        value!({
+            "viewer": {
+                "id": "1",
+                "displayName": null,
+                "nickname": "Ada",
+            }
+        })
+    );
+    assert_eq!(
+        resp.errors,
+        vec![ServerError {
+            message: "Could not fetch display name.".to_string(),
+            source: None,
+            locations: vec![Pos {
+                line: 2,
+                column: 29
+            }],
+            path: vec![
+                PathSegment::Field("viewer".to_owned()),
+                PathSegment::Field("displayName".to_owned())
+            ],
+            extensions: None,
+        }]
+    );
+}
+
+#[tokio::test]
+async fn test_disable_error_propagation_nested_non_null() {
+    let schema = schema();
+    let resp = schema
+        .execute(
+            r#"query @experimental_disableErrorPropagation {
+                viewer { nickname brokenProfile { bio } profile { bio } }
+            }"#,
+        )
+        .await;
+    assert_eq!(
+        resp.data,
+        value!({
+            "viewer": {
+                "nickname": "Ada",
+                "brokenProfile": { "bio": null },
+                "profile": { "bio": "hello" },
+            }
+        })
+    );
+    assert_eq!(resp.errors.len(), 1);
+    assert_eq!(resp.errors[0].message, "Could not fetch bio.");
+    assert_eq!(
+        resp.errors[0].path,
+        vec![
+            PathSegment::Field("viewer".to_owned()),
+            PathSegment::Field("brokenProfile".to_owned()),
+            PathSegment::Field("bio".to_owned()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_disable_error_propagation_list_items() {
+    let schema = schema();
+
+    // Default: an error in one item of `[Item!]!` nulls out the whole `viewer`.
+    let resp = schema.execute("{ viewer { items { value } } }").await;
+    assert_eq!(resp.data, Value::Null);
+    assert_eq!(resp.errors.len(), 1);
+
+    // Disabled: only the errored item becomes null.
+    let resp = schema
+        .execute(
+            r#"query @experimental_disableErrorPropagation {
+                viewer { items { value } }
+            }"#,
+        )
+        .await;
+    assert_eq!(
+        resp.data,
+        value!({
+            "viewer": {
+                "items": [{ "value": 1 }, { "value": null }, { "value": 3 }],
+            }
+        })
+    );
+    assert_eq!(resp.errors.len(), 1);
+    assert_eq!(
+        resp.errors[0].path,
+        vec![
+            PathSegment::Field("viewer".to_owned()),
+            PathSegment::Field("items".to_owned()),
+            PathSegment::Index(1),
+            PathSegment::Field("value".to_owned()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_disable_error_propagation_on_mutation() {
+    let schema = schema();
+
+    let resp = schema.execute("mutation { update other }").await;
+    assert_eq!(resp.data, Value::Null);
+    assert_eq!(resp.errors.len(), 1);
+
+    let resp = schema
+        .execute("mutation @experimental_disableErrorPropagation { update other }")
+        .await;
+    assert_eq!(resp.data, value!({ "update": null, "other": 7 }));
+    assert_eq!(resp.errors.len(), 1);
+    assert_eq!(resp.errors[0].message, "Update failed.");
+    assert_eq!(
+        resp.errors[0].path,
+        vec![PathSegment::Field("update".to_owned())]
+    );
+}
+
+#[tokio::test]
+async fn test_disable_error_propagation_on_subscription() {
+    let schema = schema();
+
+    // Nested non-null field errors inside an event.
+    let mut stream = schema.execute_stream(
+        r#"subscription @experimental_disableErrorPropagation {
+            events { nickname displayName }
+        }"#,
+    );
+    for _ in 0..2 {
+        let resp = stream.next().await.unwrap();
+        assert_eq!(
+            resp.data,
+            value!({ "events": { "nickname": "Ada", "displayName": null } })
+        );
+        assert_eq!(resp.errors.len(), 1);
+        assert_eq!(
+            resp.errors[0].path,
+            vec![
+                PathSegment::Field("events".to_owned()),
+                PathSegment::Field("displayName".to_owned()),
+            ]
+        );
+    }
+    assert!(stream.next().await.is_none());
+
+    // An error at the subscription root field nulls the root field itself.
+    let mut stream =
+        schema.execute_stream("subscription @experimental_disableErrorPropagation { numbers }");
+    let resp = stream.next().await.unwrap();
+    assert_eq!(resp.data, value!({ "numbers": 1 }));
+    assert!(resp.errors.is_empty());
+
+    let resp = stream.next().await.unwrap();
+    assert_eq!(resp.data, value!({ "numbers": null }));
+    assert_eq!(resp.errors.len(), 1);
+    assert_eq!(resp.errors[0].message, "boom");
+    assert_eq!(
+        resp.errors[0].path,
+        vec![PathSegment::Field("numbers".to_owned())]
+    );
+
+    let resp = stream.next().await.unwrap();
+    assert_eq!(resp.data, value!({ "numbers": 3 }));
+    assert!(stream.next().await.is_none());
+
+    // Without the directive, the root error yields a data-less response.
+    let mut stream = schema.execute_stream("subscription { numbers }");
+    stream.next().await.unwrap();
+    let resp = stream.next().await.unwrap();
+    assert_eq!(resp.data, Value::Null);
+    assert_eq!(resp.errors.len(), 1);
+}
+
+#[tokio::test]
+async fn test_disable_error_propagation_requires_opt_in() {
+    let schema = Schema::new(Query, Mutation, Subscription);
+
+    let resp = schema
+        .execute("query @experimental_disableErrorPropagation { value }")
+        .await;
+    assert_eq!(resp.data, Value::Null);
+    assert_eq!(resp.errors.len(), 1);
+    assert_eq!(
+        resp.errors[0].message,
+        r#"Unknown directive "experimental_disableErrorPropagation""#
+    );
+
+    // Not exposed in introspection or SDL either.
+    assert!(
+        !schema
+            .sdl()
+            .contains("experimental_disableErrorPropagation")
+    );
+}
+
+#[tokio::test]
+async fn test_disable_error_propagation_wrong_location() {
+    let schema = schema();
+    let resp = schema
+        .execute("{ value @experimental_disableErrorPropagation }")
+        .await;
+    assert_eq!(resp.data, Value::Null);
+    assert_eq!(resp.errors.len(), 1);
+    assert_eq!(
+        resp.errors[0].message,
+        r#"Directive "experimental_disableErrorPropagation" may not be used on "FIELD""#
+    );
+}
+
+#[tokio::test]
+async fn test_disable_error_propagation_introspection_and_sdl() {
+    let schema = schema();
+
+    assert!(schema.sdl().contains(
+        "directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION"
+    ));
+
+    let resp = schema
+        .execute(
+            r#"{
+                __schema {
+                    directives { name locations }
+                }
+            }"#,
+        )
+        .await
+        .into_result()
+        .unwrap();
+    let directives = match resp.data {
+        Value::Object(mut obj) => match obj.swap_remove("__schema") {
+            Some(Value::Object(mut schema)) => schema.swap_remove("directives").unwrap(),
+            _ => unreachable!(),
+        },
+        _ => unreachable!(),
+    };
+    let Value::List(directives) = directives else {
+        unreachable!()
+    };
+    assert!(directives.contains(&value!({
+        "name": "experimental_disableErrorPropagation",
+        "locations": ["QUERY", "MUTATION", "SUBSCRIPTION"],
+    })));
+}
+
+#[cfg(feature = "dynamic-schema")]
+mod dynamic {
+    use async_graphql::{
+        PathSegment, Value,
+        dynamic::{Field, FieldFuture, FieldValue, Object, Schema, TypeRef},
+        value,
+    };
+
+    fn schema(enable: bool) -> Schema {
+        let item = Object::new("Item").field(Field::new(
+            "value",
+            TypeRef::named_nn(TypeRef::INT),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let n = *ctx.parent_value.try_downcast_ref::<i32>()?;
+                    if n == 2 {
+                        Err(async_graphql::Error::new("Item 2 failed."))
+                    } else {
+                        Ok(Some(Value::from(n)))
+                    }
+                })
+            },
+        ));
+
+        let viewer = Object::new("Viewer")
+            .field(Field::new("id", TypeRef::named_nn(TypeRef::ID), |_| {
+                FieldFuture::new(async { Ok(Some(Value::from("1"))) })
+            }))
+            .field(Field::new(
+                "displayName",
+                TypeRef::named_nn(TypeRef::STRING),
+                |_| {
+                    FieldFuture::new(async {
+                        Err::<Option<Value>, _>(async_graphql::Error::new(
+                            "Could not fetch display name.",
+                        ))
+                    })
+                },
+            ))
+            .field(Field::new(
+                "missing",
+                TypeRef::named_nn(TypeRef::STRING),
+                |_| FieldFuture::new(async { Ok(None::<Value>) }),
+            ))
+            .field(Field::new(
+                "nickname",
+                TypeRef::named_nn(TypeRef::STRING),
+                |_| FieldFuture::new(async { Ok(Some(Value::from("Ada"))) }),
+            ))
+            .field(Field::new(
+                "items",
+                TypeRef::named_nn_list_nn("Item"),
+                |_| {
+                    FieldFuture::new(async {
+                        Ok(Some(FieldValue::list(
+                            [1, 2, 3].into_iter().map(FieldValue::owned_any),
+                        )))
+                    })
+                },
+            ));
+
+        let query =
+            Object::new("Query").field(Field::new("viewer", TypeRef::named_nn("Viewer"), |_| {
+                FieldFuture::new(async { Ok(Some(FieldValue::NULL)) })
+            }));
+
+        let builder = Schema::build(query.type_name(), None, None)
+            .register(item)
+            .register(viewer)
+            .register(query);
+        let builder = if enable {
+            builder.enable_experimental_disable_error_propagation()
+        } else {
+            builder
+        };
+        builder.finish().unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_disable_error_propagation() {
+        let schema = schema(true);
+
+        let resp = schema
+            .execute("{ viewer { id displayName nickname } }")
+            .await;
+        assert_eq!(resp.data, Value::Null);
+        assert_eq!(resp.errors.len(), 1);
+
+        let resp = schema
+            .execute(
+                r#"query @experimental_disableErrorPropagation {
+                    viewer { id displayName missing nickname items { value } }
+                }"#,
+            )
+            .await;
+        assert_eq!(
+            resp.data,
+            value!({
+                "viewer": {
+                    "id": "1",
+                    "displayName": null,
+                    "missing": null,
+                    "nickname": "Ada",
+                    "items": [{ "value": 1 }, { "value": null }, { "value": 3 }],
+                }
+            })
+        );
+        assert_eq!(resp.errors.len(), 3);
+        assert_eq!(resp.errors[0].message, "Could not fetch display name.");
+        assert_eq!(
+            resp.errors[0].path,
+            vec![
+                PathSegment::Field("viewer".to_owned()),
+                PathSegment::Field("displayName".to_owned()),
+            ]
+        );
+        assert_eq!(
+            resp.errors[1].path,
+            vec![
+                PathSegment::Field("viewer".to_owned()),
+                PathSegment::Field("missing".to_owned()),
+            ]
+        );
+        assert_eq!(resp.errors[2].message, "Item 2 failed.");
+        assert_eq!(
+            resp.errors[2].path,
+            vec![
+                PathSegment::Field("viewer".to_owned()),
+                PathSegment::Field("items".to_owned()),
+                PathSegment::Index(1),
+                PathSegment::Field("value".to_owned()),
+            ]
+        );
+
+        assert!(schema.sdl().contains(
+            "directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_disable_error_propagation_requires_opt_in() {
+        let schema = schema(false);
+        let resp = schema
+            .execute("query @experimental_disableErrorPropagation { viewer { id } }")
+            .await;
+        assert_eq!(resp.data, Value::Null);
+        assert_eq!(
+            resp.errors[0].message,
+            r#"Unknown directive "experimental_disableErrorPropagation""#
+        );
+        assert!(
+            !schema
+                .sdl()
+                .contains("experimental_disableErrorPropagation")
+        );
+    }
+}


### PR DESCRIPTION
An alternative to #1637 and #1638 in terms of Semantic Nullability support.

## Summary

Adds support for the experimental [`@experimental_disableErrorPropagation`](https://www.graphql-js.org/docs/disabling-error-propagation/) directive from graphql-js.

By default, an error raised by a non-null field propagates upwards: the parent becomes `null`, and so on until a nullable ancestor (or the whole `data` entry) is reached. With this directive applied to an operation, the error is still reported in `errors` with its full path, but the errored field itself becomes `null` and its ancestors are left intact.

```graphql
query @experimental_disableErrorPropagation {
  viewer {
    nickname
    displayName   # non-null, resolver fails
  }
}
```

```json
{
  "data": { "viewer": { "nickname": "Ada", "displayName": null } },
  "errors": [{ "message": "Could not fetch display name.", "path": ["viewer", "displayName"] }]
}
```

## Design

- **Opt-in, matching graphql-js.** The directive is only honoured when the server registers it. Both the static and dynamic `SchemaBuilder` gain `enable_experimental_disable_error_propagation()`, which adds the directive to the registry so it is validated, introspectable, and exported in SDL. Without opt-in, using it fails validation with `Unknown directive`.
- **Null placement follows graphql-js.** The errored position is nulled in place: a field, a single item inside a `[T!]!` list, or the root field of a subscription event (which then yields `{ "data": { "field": null }, "errors": [...] }` instead of a data-less response).
- **Cheap when unused.** The flag is computed once per request in `prepare_request` and stored on `QueryEnvInner`. Each error boundary checks one bool; a wrapper future is only allocated when the directive is present. Operations without the directive are unaffected.

## Changes

- `src/schema.rs`, `src/dynamic/schema.rs`: builder opt-in and per-request flag.
- `src/registry/mod.rs`: `Registry::add_disable_error_propagation_directive`.
- `src/resolver_utils/container.rs`, `src/resolver_utils/list.rs`: static executor error boundaries.
- `src/dynamic/resolve.rs`: dynamic executor error boundaries for fields, entities, and list items.
- `derive/src/subscription.rs`, `src/dynamic/subscription.rs`: subscription event responses.
- `tests/disable_error_propagation.rs`: 11 tests covering query, mutation, subscription, nested non-null objects, list items, opt-in required, wrong location, introspection/SDL, and the dynamic schema.

## Side effects worth noting

- Dynamic-schema resolver errors now carry the error `path`. They previously had none.
- The dynamic subscription loop previously dropped errors recorded via `add_error` and ended the stream on any error. It now drains those errors into the event response and only ends the stream when the event's `data` is `null`.

## Not included

No `CHANGELOG.md` entry or book documentation yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AXMEnsvqTE89bDMmWg9aZ
